### PR TITLE
feat: add M5 RF433T/R module support as CC1101 alternative

### DIFF
--- a/firmware/src/core/PinConfigManager.h
+++ b/firmware/src/core/PinConfigManager.h
@@ -85,6 +85,30 @@
   #define PIN_CONFIG_NRF24_CSN_DEFAULT "-1"
 #endif
 
+// ─── RF module selection ─────────────────────────────────────────────────────
+// Values: "0" = M5 RF433T/R (single-pin OOK), "1" = CC1101 SPI (default)
+#define PIN_CONFIG_RF_MODULE        "rf_module"
+#ifdef CC1101_CS_PIN
+  #define PIN_CONFIG_RF_MODULE_DEFAULT "1"
+#else
+  #define PIN_CONFIG_RF_MODULE_DEFAULT "0"
+#endif
+
+#define PIN_CONFIG_RF_TX            "rf_tx"
+#define PIN_CONFIG_RF_RX            "rf_rx"
+
+#ifdef GROVE_SDA
+  #define PIN_CONFIG_RF_TX_DEFAULT  String(GROVE_SDA)
+#else
+  #define PIN_CONFIG_RF_TX_DEFAULT  "-1"
+#endif
+
+#ifdef GROVE_SCL
+  #define PIN_CONFIG_RF_RX_DEFAULT  String(GROVE_SCL)
+#else
+  #define PIN_CONFIG_RF_RX_DEFAULT  "-1"
+#endif
+
 // ─── GPS pin config ─────────────────────────────────────────────────────────
 #define PIN_CONFIG_GPS_TX           "gps_tx"
 #define PIN_CONFIG_GPS_RX           "gps_rx"

--- a/firmware/src/screens/module/SubGHzScreen.cpp
+++ b/firmware/src/screens/module/SubGHzScreen.cpp
@@ -11,23 +11,38 @@
 #include "ui/views/ProgressView.h"
 
 void SubGHzScreen::onInit() {
-  _csPin   = PinConfig.get(PIN_CONFIG_CC1101_CS,   PIN_CONFIG_CC1101_CS_DEFAULT).toInt();
-  _gdo0Pin = PinConfig.get(PIN_CONFIG_CC1101_GDO0, PIN_CONFIG_CC1101_GDO0_DEFAULT).toInt();
+  _rfModule = PinConfig.getInt(PIN_CONFIG_RF_MODULE, PIN_CONFIG_RF_MODULE_DEFAULT);
 
-  if (_csPin < 0 || _gdo0Pin < 0) {
-    ShowStatusAction::show("Set CC1101 pins first");
-    Screen.goBack();
-    return;
-  }
+  if (_rfModule == RF_MODULE_CC1101) {
+    _csPin   = PinConfig.get(PIN_CONFIG_CC1101_CS,   PIN_CONFIG_CC1101_CS_DEFAULT).toInt();
+    _gdo0Pin = PinConfig.get(PIN_CONFIG_CC1101_GDO0, PIN_CONFIG_CC1101_GDO0_DEFAULT).toInt();
 
-  ProgressView::init();
-  ProgressView::progress("Detecting CC1101...", 30);
-  if (!_rf.begin(Uni.Spi, _csPin, _gdo0Pin)) {
-    ShowStatusAction::show("CC1101 not found!");
-    Screen.goBack();
-    return;
+    if (_csPin < 0 || _gdo0Pin < 0) {
+      ShowStatusAction::show("Set CC1101 pins first");
+      Screen.goBack();
+      return;
+    }
+
+    ProgressView::init();
+    ProgressView::progress("Detecting CC1101...", 30);
+    if (!_rf.begin(Uni.Spi, _csPin, _gdo0Pin)) {
+      ShowStatusAction::show("CC1101 not found!");
+      Screen.goBack();
+      return;
+    }
+    _rf.end();
+  } else {
+    // M5 RF433T/R — no SPI chip, just single GPIO pins
+    _rfTxPin = PinConfig.getInt(PIN_CONFIG_RF_TX, PIN_CONFIG_RF_TX_DEFAULT);
+    _rfRxPin = PinConfig.getInt(PIN_CONFIG_RF_RX, PIN_CONFIG_RF_RX_DEFAULT);
+    if (_rfTxPin < 0 && _rfRxPin < 0) {
+      ShowStatusAction::show("Set RF TX/RX pins first");
+      Screen.goBack();
+      return;
+    }
+    // Default to 433.92 MHz label for M5 RF modules
+    _rf.setFrequency(433.92f);
   }
-  _rf.end();
 
   _showMenu();
 }
@@ -56,7 +71,25 @@ void SubGHzScreen::onUpdate() {
   if (_state == STATE_RECEIVING) {
     if (_capturedCount < kMaxCapture) {
       CC1101Util::Signal sig;
-      if (_rf.pollReceive(sig) && !_isDuplicate(sig)) {
+      bool gotSignal = false;
+
+      if (_rfModule == RF_MODULE_CC1101) {
+        gotSignal = _rf.pollReceive(sig);
+      } else {
+        // M5 RF433T/R — decode via RCSwitch interrupt
+        if (_sw.available()) {
+          sig.frequency = _rf.getFrequency();
+          sig.protocol  = "RcSwitch";
+          sig.preset    = String(_sw.getReceivedProtocol());
+          sig.key       = _sw.getReceivedValue();
+          sig.bit       = _sw.getReceivedBitlength();
+          sig.te        = _sw.getReceivedDelay();
+          _sw.resetAvailable();
+          gotSignal     = (sig.key != 0);
+        }
+      }
+
+      if (gotSignal && !_isDuplicate(sig)) {
         _capturedSignals[_capturedCount] = sig;
         _capturedTimes[_capturedCount]   = _generateTimestampName();
         _capturedSaved[_capturedCount]   = false;
@@ -67,7 +100,8 @@ void SubGHzScreen::onUpdate() {
           if (n == 1) Achievement.unlock("rf_receive_first");
         }
         if (_capturedCount >= kMaxCapture) {
-          _rf.endReceive();
+          if (_rfModule == RF_MODULE_CC1101) _rf.endReceive();
+          else                               _sw.disableReceive();
           snprintf(_titleBuf, sizeof(_titleBuf), "Sub-GHz Full");
         }
         _showReceiveList();
@@ -84,18 +118,24 @@ void SubGHzScreen::onUpdate() {
     if (Uni.Nav->wasPressed()) {
       auto dir = Uni.Nav->readDirection();
       if (dir == INavigation::DIR_BACK || dir == INavigation::DIR_PRESS) {
-        digitalWrite(_gdo0Pin, LOW);
-        _rf.end();
+        if (_rfModule == RF_MODULE_CC1101) {
+          digitalWrite(_gdo0Pin, LOW);
+          _rf.end();
+        } else {
+          digitalWrite(_rfTxPin, LOW);
+        }
         _showMenu();
         return;
       }
     }
 
+    // Drive the TX line (GDO0 for CC1101, rfTxPin for M5 RF)
+    int8_t jamPin = (_rfModule == RF_MODULE_CC1101) ? _gdo0Pin : _rfTxPin;
     for (int i = 0; i < 50; i++) {
       uint32_t pw  = 5 + (micros() % 46);
       uint32_t gap = 5 + (micros() % 96);
-      digitalWrite(_gdo0Pin, HIGH); delayMicroseconds(pw);
-      digitalWrite(_gdo0Pin, LOW);  delayMicroseconds(gap);
+      digitalWrite(jamPin, HIGH); delayMicroseconds(pw);
+      digitalWrite(jamPin, LOW);  delayMicroseconds(gap);
     }
     yield();
 
@@ -289,15 +329,20 @@ void SubGHzScreen::onBack() {
     _rf.end();
     Screen.goBack();
   } else if (_state == STATE_RECEIVING) {
-    _rf.end();
+    if (_rfModule == RF_MODULE_CC1101) _rf.end();
+    else                               _sw.disableReceive();
     _showMenu();
   } else if (_state == STATE_SCANNING) {
     _rf.endScan();
     _rf.end();
     _showMenu();
   } else if (_state == STATE_JAMMING) {
-    digitalWrite(_gdo0Pin, LOW);
-    _rf.end();
+    if (_rfModule == RF_MODULE_CC1101) {
+      digitalWrite(_gdo0Pin, LOW);
+      _rf.end();
+    } else {
+      digitalWrite(_rfTxPin, LOW);
+    }
     _showMenu();
   } else if (_state == STATE_SEND_BROWSE) {
     if (_browsePath == kRootPath) {
@@ -312,38 +357,57 @@ void SubGHzScreen::onBack() {
 
 void SubGHzScreen::onItemSelected(uint8_t index) {
   if (_state == STATE_MENU) {
-    switch (index) {
+    // Map M5 RF menu indices: 0=Freq, 1=Receive, 2=Send, 3=Jammer (no Detect Freq)
+    // Map CC1101 menu indices: 0=Freq, 1=DetectFreq, 2=Receive, 3=Send, 4=Jammer
+    uint8_t action = index;
+    if (_rfModule == RF_MODULE_M5RF && index >= 1) action = index + 1; // skip DetectFreq slot
+
+    switch (action) {
       case 0: { // Frequency
         _selectFrequency();
         return;
       }
-      case 1: { // Detect Freq
+      case 1: { // Detect Freq (CC1101 only)
         _startScan();
         return;
       }
       case 2: { // Receive
-        if (_csPin < 0 || _gdo0Pin < 0) {
-          ShowStatusAction::show("Set CS and GDO0 pins first");
-          render();
-          return;
-        }
-        if (!_rf.begin(Uni.Spi, _csPin, _gdo0Pin)) {
-          ShowStatusAction::show("CC1101 not found");
-          render();
-          return;
+        if (_rfModule == RF_MODULE_CC1101) {
+          if (_csPin < 0 || _gdo0Pin < 0) {
+            ShowStatusAction::show("Set CS and GDO0 pins first");
+            render();
+            return;
+          }
+          if (!_rf.begin(Uni.Spi, _csPin, _gdo0Pin)) {
+            ShowStatusAction::show("CC1101 not found");
+            render();
+            return;
+          }
+          _rf.beginReceive();
+        } else {
+          if (_rfRxPin < 0) {
+            ShowStatusAction::show("Set RF RX pin first");
+            render();
+            return;
+          }
+          _sw.enableReceive(_rfRxPin);
         }
         _capturedCount = 0;
         _lastRender = 0;
         _state = STATE_RECEIVING;
         _chromeDrawn = false;
         snprintf(_titleBuf, sizeof(_titleBuf), "Sub-GHz RX (0/%d)", kMaxCapture);
-        _rf.beginReceive();
         setItems(_capturedItems, 0);  // prime pointer once; _showReceiveList uses setCount after this
         break;
       }
       case 3: { // Send
-        if (_csPin < 0) {
+        if (_rfModule == RF_MODULE_CC1101 && _csPin < 0) {
           ShowStatusAction::show("Set CS pin first");
+          render();
+          return;
+        }
+        if (_rfModule == RF_MODULE_M5RF && _rfTxPin < 0) {
+          ShowStatusAction::show("Set RF TX pin first");
           render();
           return;
         }
@@ -351,17 +415,27 @@ void SubGHzScreen::onItemSelected(uint8_t index) {
         break;
       }
       case 4: { // Jammer
-        if (_csPin < 0 || _gdo0Pin < 0) {
-          ShowStatusAction::show("Set CS and GDO0 pins first");
-          render();
-          return;
+        if (_rfModule == RF_MODULE_CC1101) {
+          if (_csPin < 0 || _gdo0Pin < 0) {
+            ShowStatusAction::show("Set CS and GDO0 pins first");
+            render();
+            return;
+          }
+          if (!_rf.begin(Uni.Spi, _csPin, _gdo0Pin)) {
+            ShowStatusAction::show("CC1101 not found");
+            render();
+            return;
+          }
+          _rf.startTx();
+        } else {
+          if (_rfTxPin < 0) {
+            ShowStatusAction::show("Set RF TX pin first");
+            render();
+            return;
+          }
+          pinMode(_rfTxPin, OUTPUT);
+          digitalWrite(_rfTxPin, LOW);
         }
-        if (!_rf.begin(Uni.Spi, _csPin, _gdo0Pin)) {
-          ShowStatusAction::show("CC1101 not found");
-          render();
-          return;
-        }
-        _rf.startTx();
         _state = STATE_JAMMING;
         _chromeDrawn = false;
         _jamStart = millis();
@@ -383,7 +457,10 @@ void SubGHzScreen::onItemSelected(uint8_t index) {
     if (index < _capturedCount) {
       _handleCaptureSelection(index);
       // If a deletion freed a slot and receive was stopped, restart it
-      if (_capturedCount < kMaxCapture) _rf.beginReceive();
+      if (_capturedCount < kMaxCapture) {
+        if (_rfModule == RF_MODULE_CC1101) _rf.beginReceive();
+        else                               _sw.enableReceive(_rfRxPin);
+      }
     }
     return;
   }
@@ -415,15 +492,22 @@ void SubGHzScreen::_sendBrowseFile(uint8_t index) {
     render();
     return;
   }
-  if (!_rf.begin(Uni.Spi, _csPin, _gdo0Pin)) {
-    ShowStatusAction::show("CC1101 not found");
-    render();
-    return;
-  }
+
   ProgressView::init();
   ProgressView::progress(("Sending " + e.name).c_str(), 50);
-  _rf.sendSignal(sig);
-  _rf.end();
+
+  if (_rfModule == RF_MODULE_CC1101) {
+    if (!_rf.begin(Uni.Spi, _csPin, _gdo0Pin)) {
+      ShowStatusAction::show("CC1101 not found");
+      render();
+      return;
+    }
+    _rf.sendSignal(sig);
+    _rf.end();
+  } else {
+    _sendSignalM5RF(sig);
+  }
+
   {
     int n = Achievement.inc("rf_send_first");
     if (n == 1) Achievement.unlock("rf_send_first");
@@ -478,7 +562,12 @@ void SubGHzScreen::_showMenu() {
   _chromeDrawn = false;
   strcpy(_titleBuf, "Sub-GHz");
   _updateSublabels();
-  setItems(_menuItems, kMenuCount);
+  if (_rfModule == RF_MODULE_M5RF) {
+    _m5rfMenuItems[0].sublabel = _freqSub.c_str();
+    setItems(_m5rfMenuItems, kM5RFMenuCount);
+  } else {
+    setItems(_menuItems, kMenuCount);
+  }
 }
 
 void SubGHzScreen::_updateSublabels() {
@@ -613,20 +702,25 @@ void SubGHzScreen::_rebuildCapturedItems() {
 
 void SubGHzScreen::_sendCapturedSignal(uint8_t index) {
   if (index >= _capturedCount) return;
-  if (_csPin < 0) {
-    ShowStatusAction::show("Set CS pin first");
-    render();
-    return;
-  }
-  // Replay flow: stop receive → init/send/end transfer → start receive.
-  // Chip is already initialised by STATE_RECEIVING. We must detach the RX
-  // ISR before TX or every pulse on GDO0 we drive for transmission would
-  // re-fire the receive interrupt (corrupts RX buffer + adds pulse jitter).
-  // The caller (onItemSelected STATE_RECEIVING) re-arms RX via beginReceive().
-  _rf.endReceive();
+
   ProgressView::init();
   ProgressView::progress(("Replaying " + _capturedTimes[index]).c_str(), 50);
-  _rf.sendSignal(_capturedSignals[index]);
+
+  if (_rfModule == RF_MODULE_CC1101) {
+    if (_csPin < 0) {
+      ShowStatusAction::show("Set CS pin first");
+      render();
+      return;
+    }
+    // Stop RX ISR before TX to avoid corrupting the receive buffer
+    _rf.endReceive();
+    _rf.sendSignal(_capturedSignals[index]);
+  } else {
+    // Stop RX interrupt before TX to avoid ISR conflict on the same bus
+    _sw.disableReceive();
+    _sendSignalM5RF(_capturedSignals[index]);
+  }
+
   {
     int n = Achievement.inc("rf_send_first");
     if (n == 1) Achievement.unlock("rf_send_first");
@@ -692,6 +786,24 @@ String SubGHzScreen::_makeUniquePath(const String& name) {
     if (!Uni.Storage->exists(candidate.c_str())) return candidate;
   }
   return base;
+}
+
+// ── M5 RF433T/R send ──────────────────────────────────────────────────────
+
+void SubGHzScreen::_sendSignalM5RF(const CC1101Util::Signal& sig) {
+  if (_rfTxPin < 0) {
+    ShowStatusAction::show("Set RF TX pin first");
+    return;
+  }
+  if (sig.protocol != "RcSwitch") {
+    ShowStatusAction::show("RAW not supported on M5 RF");
+    return;
+  }
+  _sw.enableTransmit(_rfTxPin);
+  int proto = sig.preset.toInt();
+  if (proto > 0) _sw.setProtocol(proto, sig.te > 0 ? sig.te : 350);
+  _sw.send(sig.key, sig.bit > 0 ? sig.bit : 24);
+  _sw.disableTransmit();
 }
 
 void SubGHzScreen::_loadBrowseDir(const String& path) {

--- a/firmware/src/screens/module/SubGHzScreen.h
+++ b/firmware/src/screens/module/SubGHzScreen.h
@@ -7,8 +7,11 @@
 #include "ui/templates/ListScreen.h"
 #include "ui/views/BrowseFileView.h"
 #include "utils/rf/CC1101Util.h"
+#include "utils/rf/RCSwitchUtil.h"
 
 class SubGHzScreen : public ListScreen {
+  static constexpr int RF_MODULE_M5RF   = 0;
+  static constexpr int RF_MODULE_CC1101 = 1;
 public:
   const char* title() override { return _titleBuf; }
   bool inhibitPowerSave() override { return _state == STATE_RECEIVING || _state == STATE_SCANNING; }
@@ -29,17 +32,36 @@ private:
     STATE_SCANNING,
   } _state = STATE_MENU;
 
+  // RF module
+  int _rfModule  = RF_MODULE_CC1101;
+
+  // CC1101 SPI mode
   CC1101Util _rf;
   int8_t _csPin   = -1;
   int8_t _gdo0Pin = -1;
+
+  // M5 RF433T/R OOK mode
+  RCSwitchUtil _sw;
+  int8_t _rfTxPin = -1;
+  int8_t _rfRxPin = -1;
+
   char _titleBuf[32] = "Sub-GHz";
   bool _chromeDrawn = false;  // partial-redraw: static body painted once per state
 
-  // Menu (5 items)
+  // CC1101 menu (5 items)
   static constexpr uint8_t kMenuCount = 5;
   ListItem _menuItems[kMenuCount] = {
     {"Frequency"},
     {"Detect Freq"},
+    {"Receive"},
+    {"Send"},
+    {"Jammer"},
+  };
+
+  // M5 RF433T/R menu (4 items — no Detect Freq)
+  static constexpr uint8_t kM5RFMenuCount = 4;
+  ListItem _m5rfMenuItems[kM5RFMenuCount] = {
+    {"Frequency"},
     {"Receive"},
     {"Send"},
     {"Jammer"},
@@ -83,5 +105,6 @@ private:
   void _sendBrowseFile(uint8_t index);
   void _showBrowseOptions(uint8_t index);
   String _makeUniquePath(const String& name);
+  void _sendSignalM5RF(const CC1101Util::Signal& sig);
 };
 

--- a/firmware/src/screens/setting/PinSettingScreen.cpp
+++ b/firmware/src/screens/setting/PinSettingScreen.cpp
@@ -5,6 +5,7 @@
 #include "core/AchievementManager.h"
 #include "screens/setting/SettingScreen.h"
 #include "ui/actions/InputNumberAction.h"
+#include "ui/actions/InputSelectAction.h"
 
 
 void PinSettingScreen::onInit() {
@@ -33,6 +34,19 @@ void PinSettingScreen::onInit() {
     _map[_itemCount] = PIN_EXT_SCL;
     _itemCount++;
   }
+
+  // RF module selection
+  _items[_itemCount] = {"RF Module", ""};
+  _map[_itemCount] = PIN_RF_MODULE;
+  _itemCount++;
+
+  _items[_itemCount] = {"RF TX Pin", ""};
+  _map[_itemCount] = PIN_RF_TX;
+  _itemCount++;
+
+  _items[_itemCount] = {"RF RX Pin", ""};
+  _map[_itemCount] = PIN_RF_RX;
+  _itemCount++;
 
   // CC1101
   _items[_itemCount] = {"CC1101 CS Pin", ""};
@@ -80,6 +94,12 @@ void PinSettingScreen::_refresh() {
   _gpsBaudSub = PinConfig.get(PIN_CONFIG_GPS_BAUD, PIN_CONFIG_GPS_BAUD_DEFAULT);
   _sdaSub = PinConfig.get(PIN_CONFIG_EXT_SDA, PIN_CONFIG_EXT_SDA_DEFAULT);
   _sclSub = PinConfig.get(PIN_CONFIG_EXT_SCL, PIN_CONFIG_EXT_SCL_DEFAULT);
+  {
+    int mod = PinConfig.getInt(PIN_CONFIG_RF_MODULE, PIN_CONFIG_RF_MODULE_DEFAULT);
+    _rfModuleSub = (mod == 0) ? "M5 RF433T/R" : "CC1101 SPI";
+  }
+  _rfTxSub  = PinConfig.get(PIN_CONFIG_RF_TX, PIN_CONFIG_RF_TX_DEFAULT);
+  _rfRxSub  = PinConfig.get(PIN_CONFIG_RF_RX, PIN_CONFIG_RF_RX_DEFAULT);
   _cc1101CsSub = PinConfig.get(PIN_CONFIG_CC1101_CS, PIN_CONFIG_CC1101_CS_DEFAULT);
   _cc1101Gdo0Sub = PinConfig.get(PIN_CONFIG_CC1101_GDO0, PIN_CONFIG_CC1101_GDO0_DEFAULT);
   _nrf24CeSub = PinConfig.get(PIN_CONFIG_NRF24_CE, PIN_CONFIG_NRF24_CE_DEFAULT);
@@ -96,6 +116,9 @@ void PinSettingScreen::_refresh() {
       case PIN_GPS_BAUD:    _items[i].sublabel = _gpsBaudSub.c_str(); break;
       case PIN_EXT_SDA:     _items[i].sublabel = _sdaSub.c_str(); break;
       case PIN_EXT_SCL:     _items[i].sublabel = _sclSub.c_str(); break;
+      case PIN_RF_MODULE:   _items[i].sublabel = _rfModuleSub.c_str(); break;
+      case PIN_RF_TX:       _items[i].sublabel = _rfTxSub.c_str(); break;
+      case PIN_RF_RX:       _items[i].sublabel = _rfRxSub.c_str(); break;
       case PIN_CC1101_CS:   _items[i].sublabel = _cc1101CsSub.c_str(); break;
       case PIN_CC1101_GDO0: _items[i].sublabel = _cc1101Gdo0Sub.c_str(); break;
       case PIN_NRF24_CE:    _items[i].sublabel = _nrf24CeSub.c_str(); break;
@@ -155,6 +178,39 @@ void PinSettingScreen::onItemSelected(uint8_t index) {
       int val = InputNumberAction::popup("External SCL Pin", 0, 48, cur);
       if (!InputNumberAction::wasCancelled()) {
         PinConfig.set(PIN_CONFIG_EXT_SCL, String(val));
+        PinConfig.save(Uni.Storage);
+      }
+      break;
+    }
+    case PIN_RF_MODULE: {
+      static constexpr InputSelectAction::Option rfModOpts[] = {
+        {"M5 RF433T/R", "0"},
+        {"CC1101 SPI",  "1"},
+      };
+      int cur = PinConfig.getInt(PIN_CONFIG_RF_MODULE, PIN_CONFIG_RF_MODULE_DEFAULT);
+      char curBuf[4];
+      snprintf(curBuf, sizeof(curBuf), "%d", cur);
+      const char* choice = InputSelectAction::popup("RF Module", rfModOpts, 2, curBuf);
+      if (choice) {
+        PinConfig.set(PIN_CONFIG_RF_MODULE, String(choice));
+        PinConfig.save(Uni.Storage);
+      }
+      break;
+    }
+    case PIN_RF_TX: {
+      int cur = PinConfig.getInt(PIN_CONFIG_RF_TX, PIN_CONFIG_RF_TX_DEFAULT);
+      int val = InputNumberAction::popup("RF TX Pin", -1, 48, cur);
+      if (!InputNumberAction::wasCancelled()) {
+        PinConfig.set(PIN_CONFIG_RF_TX, String(val));
+        PinConfig.save(Uni.Storage);
+      }
+      break;
+    }
+    case PIN_RF_RX: {
+      int cur = PinConfig.getInt(PIN_CONFIG_RF_RX, PIN_CONFIG_RF_RX_DEFAULT);
+      int val = InputNumberAction::popup("RF RX Pin", -1, 48, cur);
+      if (!InputNumberAction::wasCancelled()) {
+        PinConfig.set(PIN_CONFIG_RF_RX, String(val));
         PinConfig.save(Uni.Storage);
       }
       break;

--- a/firmware/src/screens/setting/PinSettingScreen.h
+++ b/firmware/src/screens/setting/PinSettingScreen.h
@@ -22,12 +22,13 @@ private:
 
   BackFactory _backFn = nullptr;
 
-  static const uint8_t MAX_ITEMS = 14;
+  static const uint8_t MAX_ITEMS = 17;
   ListItem _items[MAX_ITEMS];
   uint8_t _itemCount = 0;
 
   // track which config each index maps to
   enum PinType { PIN_GPS_TX, PIN_GPS_RX, PIN_GPS_BAUD, PIN_EXT_SDA, PIN_EXT_SCL,
+                 PIN_RF_MODULE, PIN_RF_TX, PIN_RF_RX,
                  PIN_CC1101_CS, PIN_CC1101_GDO0,
                  PIN_NRF24_CE, PIN_NRF24_CSN,
                  PIN_PN532_TX, PIN_PN532_RX, PIN_PN532_BAUD,
@@ -39,6 +40,9 @@ private:
   String _gpsBaudSub;
   String _sdaSub;
   String _sclSub;
+  String _rfModuleSub;
+  String _rfTxSub;
+  String _rfRxSub;
   String _cc1101CsSub;
   String _cc1101Gdo0Sub;
   String _nrf24CeSub;


### PR DESCRIPTION
## Summary

- Adds runtime selection between **M5 RF433T/R** (single-pin OOK) and **CC1101 SPI** as the Sub-GHz module, mirroring the pattern already used in Bruce firmware (`M5_RF_MODULE` / `CC1101_SPI_MODULE`).
- New config keys: `rf_module`, `rf_tx`, `rf_rx` stored in `PinConfigManager` — defaults to CC1101 on boards that already define `CC1101_CS_PIN`, otherwise M5 RF.
- `SubGHzScreen` branches on the selected module at runtime: CC1101 path is **unchanged**; M5 RF path uses the existing `RCSwitchUtil` for receive/send/jammer via a single GPIO pin (no new library dependency).
- `PinSettingScreen` exposes a **RF Module** picker (`M5 RF433T/R` / `CC1101 SPI`) plus **RF TX Pin** and **RF RX Pin** fields.
- GPS was already compatible with M5 GPS module via UART pins — no changes needed there.

## Files changed

| File | Change |
|---|---|
| `PinConfigManager.h` | Add `rf_module`, `rf_tx`, `rf_rx` keys with board-aware defaults |
| `SubGHzScreen.h` | Add `RF_MODULE_*` constants, `_rfModule`/`_rfTxPin`/`_rfRxPin` members, M5 RF menu |
| `SubGHzScreen.cpp` | Branch all RF operations (init, receive, send, jammer, back) on module type |
| `PinSettingScreen.h` | Add `PIN_RF_MODULE`, `PIN_RF_TX`, `PIN_RF_RX` to enum + string members |
| `PinSettingScreen.cpp` | Add RF Module selector and RF TX/RX pin inputs |

## Test plan

- [x] Build `m5_cardputer_adv` — compiles clean
- [x] Set RF Module = CC1101 SPI → Sub-GHz screen behaves as before
- [x] Set RF Module = M5 RF433T/R → Sub-GHz shows 4-item menu (no Detect Freq)
- [x] M5 RF receive captures RcSwitch-decoded signals
- [x] M5 RF send replays a captured RcSwitch signal
- [ ] M5 RF jammer toggles TX pin
- [ ] Saved `.sub` files are compatible between both module modes