### PR TITLE
Add M5 RF433 module + Sub-GHz RX filter and Signal Info view

### DIFF
--- a/firmware/src/screens/module/M5RF433Screen.cpp
+++ b/firmware/src/screens/module/M5RF433Screen.cpp
@@ -1,0 +1,617 @@
+#include "M5RF433Screen.h"
+#include "core/AchievementManager.h"
+#include "core/ScreenManager.h"
+#include "core/Device.h"
+#include "screens/module/ModuleMenuScreen.h"
+#include "ui/actions/InputTextAction.h"
+#include "ui/actions/InputSelectAction.h"
+#include "ui/actions/ShowStatusAction.h"
+#include "ui/views/ProgressView.h"
+
+// Pinout is fixed per board at build time. M5 RF433T/R Units plug into the
+// Grove port — default to GROVE_SDA (TX) / GROVE_SCL (RX). A board can override
+// either with -DM5RF433_TX_PIN / -DM5RF433_RX_PIN in pins_arduino.h.
+#if defined(M5RF433_TX_PIN)
+  static constexpr int8_t kDefaultTxPin = (int8_t)M5RF433_TX_PIN;
+#elif defined(GROVE_SDA)
+  static constexpr int8_t kDefaultTxPin = (int8_t)GROVE_SDA;
+#else
+  static constexpr int8_t kDefaultTxPin = -1;
+#endif
+
+#if defined(M5RF433_RX_PIN)
+  static constexpr int8_t kDefaultRxPin = (int8_t)M5RF433_RX_PIN;
+#elif defined(GROVE_SCL)
+  static constexpr int8_t kDefaultRxPin = (int8_t)GROVE_SCL;
+#else
+  static constexpr int8_t kDefaultRxPin = -1;
+#endif
+
+void M5RF433Screen::onInit() {
+  _txPin = kDefaultTxPin;
+  _rxPin = kDefaultRxPin;
+
+  if (_txPin < 0 && _rxPin < 0) {
+    ShowStatusAction::show("M5 RF433 not supported");
+    Screen.goBack();
+    return;
+  }
+
+  _rf.begin(_txPin, _rxPin);
+  _showMenu();
+}
+
+void M5RF433Screen::onUpdate() {
+  if (_state == STATE_SIGNAL_INFO) {
+    if (!Uni.Nav->wasPressed()) return;
+    auto dir = Uni.Nav->readDirection();
+    if (dir == INavigation::DIR_BACK || dir == INavigation::DIR_PRESS) {
+      onBack();
+      return;
+    }
+    if (_textView.onNav(dir) && Uni.Speaker) Uni.Speaker->beep();
+    return;
+  }
+
+  if (_state == STATE_RECEIVING) {
+    if (_capturedCount < kMaxCapture) {
+      M5RF433Util::Signal sig;
+      if (_rf.pollReceive(sig) && !_isDuplicate(sig)) {
+        _capturedSignals[_capturedCount] = sig;
+        _capturedTimes[_capturedCount]   = _generateTimestampName();
+        _capturedSaved[_capturedCount]   = false;
+        _capturedCount++;
+        if (Uni.Speaker) Uni.Speaker->playNotification();
+        if (_capturedCount == 1) {
+          int n = Achievement.inc("rf_receive_first");
+          if (n == 1) Achievement.unlock("rf_receive_first");
+        }
+        if (_capturedCount >= kMaxCapture) {
+          _rf.endReceive();
+          snprintf(_titleBuf, sizeof(_titleBuf), "M5 RF433 Full");
+        }
+        _showReceiveList();
+      }
+    }
+
+    // Hold-PRESS (500 ms) toggles the filter — fallback for 2-way devices
+    // (sticks, T-Display, T-Embed, CYD touch) where LEFT/RIGHT aren't emitted.
+    if (!_holdFired && Uni.Nav->isPressed() &&
+        Uni.Nav->currentDirection() == INavigation::DIR_PRESS &&
+        Uni.Nav->heldDuration() >= 500) {
+      _holdFired = true;
+      _toggleRxFilter();
+      render();
+      return;
+    }
+    if (_holdFired) {
+      if (Uni.Nav->wasPressed()) {
+        Uni.Nav->readDirection();
+        _holdFired = false;
+      }
+      return;
+    }
+
+    // Nav: RIGHT/LEFT toggles filter; UP/DOWN/PRESS/BACK navigate the captured list.
+    if (Uni.Nav->wasPressed()) {
+      auto dir = Uni.Nav->readDirection();
+      if (dir == INavigation::DIR_LEFT || dir == INavigation::DIR_RIGHT) {
+        _toggleRxFilter();
+        render();
+      } else if (dir == INavigation::DIR_BACK) {
+        onBack();
+      } else if (_capturedCount > 0) {
+        if (dir == INavigation::DIR_UP) {
+          _selectedIndex = (_selectedIndex == 0) ? _capturedCount - 1 : _selectedIndex - 1;
+          setCount(_capturedCount);
+          render();
+        } else if (dir == INavigation::DIR_DOWN) {
+          _selectedIndex = (_selectedIndex >= _capturedCount - 1) ? 0 : _selectedIndex + 1;
+          setCount(_capturedCount);
+          render();
+        } else if (dir == INavigation::DIR_PRESS) {
+          onItemSelected(_selectedIndex);
+        }
+      }
+      return;
+    }
+
+    if (_capturedCount < kMaxCapture && millis() - _lastRender > 500) {
+      _lastRender = millis();
+      render();
+    }
+    return;
+  }
+
+  if (_state == STATE_JAMMING) {
+    if (Uni.Nav->wasPressed()) {
+      auto dir = Uni.Nav->readDirection();
+      if (dir == INavigation::DIR_BACK || dir == INavigation::DIR_PRESS) {
+        _rf.stopJam();
+        _showMenu();
+        return;
+      }
+    }
+
+    _rf.jamBurst();
+    yield();
+
+    if (millis() - _jamStart > 500) {
+      render();
+      _jamStart = millis();
+    }
+    return;
+  }
+
+  if (_state == STATE_SEND_BROWSE) {
+    if (!_holdFired && Uni.Nav->isPressed() && Uni.Nav->heldDuration() >= 1000) {
+      _holdFired = true;
+      _pendingHoldIdx = _selectedIndex;
+      if (_pendingHoldIdx < _browser.count() && !_browser.entry(_pendingHoldIdx).isDir)
+        _showBrowseOptions(_pendingHoldIdx);
+      else
+        render();
+      return;
+    }
+  }
+  if (_holdFired) {
+    if (Uni.Nav->wasPressed()) {
+      Uni.Nav->readDirection();
+      _holdFired = false;
+    }
+    return;
+  }
+
+  ListScreen::onUpdate();
+}
+
+void M5RF433Screen::onRender() {
+  if (_state == STATE_SIGNAL_INFO) {
+    _textView.render(bodyX(), bodyY(), bodyW(), bodyH());
+    return;
+  }
+
+  if (_state == STATE_RECEIVING) {
+    if (_capturedCount == 0) {
+      auto& lcd = Uni.Lcd;
+      if (_chromeDrawn) return;
+      lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
+      lcd.setTextSize(1);
+      lcd.setTextDatum(MC_DATUM);
+      lcd.setTextColor(TFT_WHITE, TFT_BLACK);
+      lcd.drawString("433.92 MHz", bodyX() + bodyW() / 2, bodyY() + bodyH() / 2 - 20);
+      lcd.drawString("Waiting for signal...", bodyX() + bodyW() / 2, bodyY() + bodyH() / 2);
+      lcd.fillRect(bodyX(), bodyY() + bodyH() - 16, bodyW(), 16, Config.getThemeColor());
+      lcd.setTextColor(TFT_WHITE, Config.getThemeColor());
+      const char* filterLabel = (_rf.getRxFilter() == M5RF433Util::RX_FILTER_CODE)
+                                ? "> Filter: Code" : "> Filter: RAW";
+      lcd.setTextDatum(ML_DATUM);
+      #ifdef DEVICE_HAS_KEYBOARD
+        lcd.drawString("BACK: Stop", bodyX() + 4, bodyY() + bodyH() - 8);
+      #else
+        lcd.drawString("< Stop", bodyX() + 4, bodyY() + bodyH() - 8);
+      #endif
+      lcd.setTextDatum(MR_DATUM);
+      lcd.drawString(filterLabel, bodyX() + bodyW() - 4, bodyY() + bodyH() - 8);
+      _chromeDrawn = true;
+    } else {
+      ListScreen::onRender();
+    }
+    return;
+  }
+
+  if (_state == STATE_JAMMING) {
+    if (_chromeDrawn) return;
+    auto& lcd = Uni.Lcd;
+    lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
+    lcd.setTextDatum(MC_DATUM);
+    lcd.setTextSize(1);
+    lcd.setTextColor(TFT_WHITE, TFT_BLACK);
+
+    lcd.drawString("433.92 MHz", bodyX() + bodyW() / 2, bodyY() + bodyH() / 2 - 20);
+    lcd.drawString("Jamming...", bodyX() + bodyW() / 2, bodyY() + bodyH() / 2);
+
+    #ifdef DEVICE_HAS_KEYBOARD
+      lcd.drawString("BACK: Stop", bodyX() + bodyW() / 2, bodyY() + bodyH() - 10);
+    #else
+      lcd.fillRect(bodyX(), bodyY() + bodyH() - 16, bodyW(), 16, Config.getThemeColor());
+      lcd.setTextColor(TFT_WHITE, Config.getThemeColor());
+      lcd.drawString("< Stop", bodyX() + bodyW() / 2, bodyY() + bodyH() - 8);
+    #endif
+    _chromeDrawn = true;
+    return;
+  }
+
+  ListScreen::onRender();
+}
+
+void M5RF433Screen::onBack() {
+  if (_state == STATE_SIGNAL_INFO) {
+    uint8_t idx = _infoIdx;
+    if (_infoSource == INFO_FROM_CAPTURE) {
+      _state = STATE_RECEIVING;
+      _showReceiveList();
+      _handleCaptureSelection(idx);
+    } else {
+      _state = STATE_SEND_BROWSE;
+      _loadBrowseDir(_browsePath);
+      _showBrowseOptions(idx);
+    }
+    return;
+  }
+  if (_state == STATE_MENU) {
+    _rf.end();
+    Screen.goBack();
+  } else if (_state == STATE_RECEIVING) {
+    _rf.endReceive();
+    _showMenu();
+  } else if (_state == STATE_JAMMING) {
+    _rf.stopJam();
+    _showMenu();
+  } else if (_state == STATE_SEND_BROWSE) {
+    if (_browsePath == kRootPath) {
+      _showMenu();
+    } else {
+      int slash = _browsePath.lastIndexOf('/');
+      if (slash > 0) _loadBrowseDir(_browsePath.substring(0, slash));
+      else _showMenu();
+    }
+  }
+}
+
+void M5RF433Screen::onItemSelected(uint8_t index) {
+  if (_state == STATE_MENU) {
+    switch (index) {
+      case 0: { // Receive
+        if (_rxPin < 0) {
+          ShowStatusAction::show("RX pin not available");
+          render();
+          return;
+        }
+        _capturedCount = 0;
+        _lastRender = 0;
+        _state = STATE_RECEIVING;
+        _chromeDrawn = false;
+        snprintf(_titleBuf, sizeof(_titleBuf), "M5 RF433 RX (0/%d)", kMaxCapture);
+        _rf.beginReceive();
+        setItems(_capturedItems, 0);
+        break;
+      }
+      case 1: { // Send
+        if (_txPin < 0) {
+          ShowStatusAction::show("TX pin not available");
+          render();
+          return;
+        }
+        _loadBrowseDir(kRootPath);
+        break;
+      }
+      case 2: { // Jammer
+        if (_txPin < 0) {
+          ShowStatusAction::show("TX pin not available");
+          render();
+          return;
+        }
+        _rf.startJam();
+        _state = STATE_JAMMING;
+        _chromeDrawn = false;
+        _jamStart = millis();
+        strcpy(_titleBuf, "M5 RF433 Jam");
+        {
+          int n = Achievement.inc("rf_jammer_first");
+          if (n == 1) Achievement.unlock("rf_jammer_first");
+        }
+        render();
+        break;
+      }
+      default:
+        return;
+    }
+    return;
+  }
+
+  if (_state == STATE_RECEIVING) {
+    if (index < _capturedCount) {
+      _handleCaptureSelection(index);
+      if (_capturedCount < kMaxCapture) _rf.beginReceive();
+    }
+    return;
+  }
+
+  if (_state == STATE_SEND_BROWSE) {
+    if (index >= _browser.count()) return;
+    if (_browser.entry(index).isDir) {
+      _loadBrowseDir(_browser.entry(index).path);
+      return;
+    }
+    _showBrowseTapOptions(index);
+    return;
+  }
+}
+
+// ── Browse helpers ────────────────────────────────────────────────────────
+
+void M5RF433Screen::_sendBrowseFile(uint8_t index) {
+  const auto& e = _browser.entry(index);
+  String content = Uni.Storage->readFile(e.path.c_str());
+  if (content.length() == 0) {
+    ShowStatusAction::show("Failed to read file");
+    render();
+    return;
+  }
+  M5RF433Util::Signal sig;
+  if (!CC1101Util::loadFile(content, sig)) {
+    ShowStatusAction::show("Invalid .sub file");
+    render();
+    return;
+  }
+  ProgressView::init();
+  ProgressView::progress(("Sending " + e.name).c_str(), 50);
+  _rf.sendSignal(sig);
+  {
+    int n = Achievement.inc("rf_send_first");
+    if (n == 1) Achievement.unlock("rf_send_first");
+  }
+  ShowStatusAction::show(("Sent: " + e.name).c_str(), 1000);
+  render();
+}
+
+void M5RF433Screen::_showBrowseTapOptions(uint8_t index) {
+  static constexpr InputSelectAction::Option tapOpts[] = {
+    {"Send", "send"},
+    {"Info", "info"},
+  };
+  const char* choice = InputSelectAction::popup("Options", tapOpts, 2, "send");
+  if (!choice) { render(); return; }
+
+  if (strcmp(choice, "send") == 0)      _sendBrowseFile(index);
+  else if (strcmp(choice, "info") == 0) _showBrowseFileInfo(index);
+}
+
+void M5RF433Screen::_showBrowseFileInfo(uint8_t index) {
+  String content = Uni.Storage->readFile(_browser.entry(index).path.c_str());
+  M5RF433Util::Signal sig;
+  if (!CC1101Util::loadFile(content, sig)) {
+    ShowStatusAction::show("Invalid .sub file");
+    render();
+    return;
+  }
+  _showSignalInfo(sig, INFO_FROM_BROWSE, index);
+}
+
+void M5RF433Screen::_showBrowseOptions(uint8_t index) {
+  static constexpr InputSelectAction::Option fileOpts[] = {
+    {"Send",   "send"},
+    {"Info",   "info"},
+    {"Rename", "rename"},
+    {"Delete", "delete"},
+  };
+  const char* choice = InputSelectAction::popup("Options", fileOpts, 4, "send");
+  if (!choice) { render(); return; }
+
+  if (strcmp(choice, "send") == 0) {
+    _sendBrowseFile(index);
+
+  } else if (strcmp(choice, "info") == 0) {
+    _showBrowseFileInfo(index);
+
+  } else if (strcmp(choice, "rename") == 0) {
+    String curName = _browser.entry(index).name;
+    if (curName.endsWith(".sub")) curName = curName.substring(0, curName.length() - 4);
+    String newName = InputTextAction::popup("Rename", curName.c_str());
+    if (newName.length() == 0) { render(); return; }
+    String content = Uni.Storage->readFile(_browser.entry(index).path.c_str());
+    String newPath = _makeUniquePath(newName);
+    if (Uni.Storage->writeFile(newPath.c_str(), content.c_str())) {
+      Uni.Storage->deleteFile(_browser.entry(index).path.c_str());
+      ShowStatusAction::show("Renamed", 1000);
+      _loadBrowseDir(_browsePath);
+    } else {
+      ShowStatusAction::show("Rename failed");
+      render();
+    }
+
+  } else if (strcmp(choice, "delete") == 0) {
+    if (Uni.Storage->deleteFile(_browser.entry(index).path.c_str())) {
+      ShowStatusAction::show("Deleted", 1000);
+      _loadBrowseDir(_browsePath);
+    } else {
+      ShowStatusAction::show("Delete failed");
+      render();
+    }
+  }
+}
+
+// ── Menu ──────────────────────────────────────────────────────────────────
+
+void M5RF433Screen::_showMenu() {
+  _state = STATE_MENU;
+  _chromeDrawn = false;
+  strcpy(_titleBuf, "M5 RF433");
+  setItems(_menuItems, kMenuCount);
+}
+
+void M5RF433Screen::_toggleRxFilter() {
+  auto cur = _rf.getRxFilter();
+  _rf.setRxFilter(cur == M5RF433Util::RX_FILTER_CODE
+                  ? M5RF433Util::RX_FILTER_RAW
+                  : M5RF433Util::RX_FILTER_CODE);
+  _chromeDrawn = false;  // redraw waiting-screen footer with new label
+  if (Uni.Speaker) Uni.Speaker->beep();
+}
+
+// ── Captured List ──────────────────────────────────────────────────────────
+
+void M5RF433Screen::_showReceiveList() {
+  snprintf(_titleBuf, sizeof(_titleBuf), "M5 RF433 RX (%d/%d)", _capturedCount, kMaxCapture);
+  _rebuildCapturedItems();
+  setCount(_capturedCount);
+  render();
+}
+
+void M5RF433Screen::_handleCaptureSelection(uint8_t index) {
+  if (index >= _capturedCount) return;
+
+  static constexpr InputSelectAction::Option captureOpts[] = {
+    {"Info",   "info"},
+    {"Replay", "replay"},
+    {"Save",   "save"},
+    {"Delete", "delete"},
+  };
+  const char* choice = InputSelectAction::popup("Options", captureOpts, 4);
+  if (!choice) { render(); return; }
+
+  if (strcmp(choice, "info") == 0) {
+    _showSignalInfo(_capturedSignals[index], INFO_FROM_CAPTURE, index);
+    return;
+  }
+
+  if (strcmp(choice, "replay") == 0) {
+    _sendCapturedSignal(index);
+
+  } else if (strcmp(choice, "save") == 0) {
+    if (_capturedSaved[index]) {
+      ShowStatusAction::show("Already saved");
+      render();
+      return;
+    }
+    String name = InputTextAction::popup("Save As", _capturedTimes[index].c_str());
+    if (name.length() == 0) { render(); return; }
+    _saveSignal(index, name);
+    _rebuildCapturedItems();
+    render();
+
+  } else if (strcmp(choice, "delete") == 0) {
+    for (uint8_t i = index; i + 1 < _capturedCount; i++) {
+      _capturedSignals[i] = _capturedSignals[i + 1];
+      _capturedTimes[i]   = _capturedTimes[i + 1];
+      _capturedSaved[i]   = _capturedSaved[i + 1];
+    }
+    _capturedCount--;
+    _showReceiveList();
+  }
+}
+
+void M5RF433Screen::_showSignalInfo(const M5RF433Util::Signal& sig, InfoSource src, uint8_t idx) {
+  _infoSource = src;
+  _infoIdx    = idx;
+  strcpy(_titleBuf, "Signal Info");
+  _state = STATE_SIGNAL_INFO;
+  _textView.setContent(CC1101Util::signalInfoText(sig));
+  render();
+}
+
+void M5RF433Screen::_rebuildCapturedItems() {
+  for (uint8_t i = 0; i < _capturedCount; i++) {
+    const M5RF433Util::Signal& sig = _capturedSignals[i];
+    if (_capturedSaved[i]) {
+      _capturedSubLabels[i] = "Saved";
+    } else if (sig.protocol == "RcSwitch") {
+      char buf[32];
+      snprintf(buf, sizeof(buf), "0x%llX P%s %db",
+               (unsigned long long)sig.key, sig.preset.c_str(), sig.bit);
+      _capturedSubLabels[i] = buf;
+    } else {
+      int pulses = 0;
+      for (char c : sig.rawData) { if (c == ' ') pulses++; }
+      pulses++;
+      char buf[24];
+      snprintf(buf, sizeof(buf), "RAW %d pulses", pulses);
+      _capturedSubLabels[i] = buf;
+    }
+    _capturedItems[i] = {_capturedTimes[i].c_str(), _capturedSubLabels[i].c_str()};
+  }
+}
+
+void M5RF433Screen::_sendCapturedSignal(uint8_t index) {
+  if (index >= _capturedCount) return;
+  if (_txPin < 0) {
+    ShowStatusAction::show("Set M5 RF433T (TX) pin first");
+    render();
+    return;
+  }
+  ProgressView::init();
+  ProgressView::progress(("Replaying " + _capturedTimes[index]).c_str(), 50);
+  _rf.sendSignal(_capturedSignals[index]);
+  {
+    int n = Achievement.inc("rf_send_first");
+    if (n == 1) Achievement.unlock("rf_send_first");
+  }
+  ShowStatusAction::show("Replayed", 1000);
+  render();
+}
+
+void M5RF433Screen::_saveSignal(uint8_t index, const String& name) {
+  if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+    ShowStatusAction::show("No storage");
+    return;
+  }
+  Uni.Storage->makeDir(kRootPath);
+  String path    = _makeUniquePath(name);
+  String content = CC1101Util::saveToString(_capturedSignals[index]);
+  if (Uni.Storage->writeFile(path.c_str(), content.c_str())) {
+    _capturedSaved[index] = true;
+    _capturedSubLabels[index] = "Saved";
+    _capturedItems[index].sublabel = _capturedSubLabels[index].c_str();
+    int lastSlash = path.lastIndexOf('/');
+    String fname = (lastSlash >= 0) ? path.substring(lastSlash + 1) : path;
+    ShowStatusAction::show(fname.c_str(), 1200);
+    {
+      int n = Achievement.inc("rf_signal_saved");
+      if (n == 1)  Achievement.unlock("rf_signal_saved");
+      if (n == 5)  Achievement.unlock("rf_signal_saved_5");
+      if (n == 20) Achievement.unlock("rf_signal_saved_20");
+    }
+  } else {
+    ShowStatusAction::show("Save failed");
+  }
+}
+
+bool M5RF433Screen::_isDuplicate(const M5RF433Util::Signal& sig) const {
+  if (sig.protocol != "RcSwitch") return false;
+  for (uint8_t i = 0; i < _capturedCount; i++) {
+    const M5RF433Util::Signal& s = _capturedSignals[i];
+    if (s.protocol == "RcSwitch" &&
+        s.key    == sig.key    &&
+        s.preset == sig.preset &&
+        s.bit    == sig.bit) {
+      return true;
+    }
+  }
+  return false;
+}
+
+String M5RF433Screen::_generateTimestampName() {
+  uint32_t s = millis() / 1000;
+  char buf[20];
+  snprintf(buf, sizeof(buf), "rf_%05lu", (unsigned long)(s % 100000));
+  return String(buf);
+}
+
+// ── File Browser ──────────────────────────────────────────────────────────
+
+String M5RF433Screen::_makeUniquePath(const String& name) {
+  String base = String(kRootPath) + "/" + name + ".sub";
+  if (!Uni.Storage || !Uni.Storage->exists(base.c_str())) return base;
+  for (int n = 2; n < 1000; n++) {
+    String candidate = String(kRootPath) + "/" + name + "_(" + n + ").sub";
+    if (!Uni.Storage->exists(candidate.c_str())) return candidate;
+  }
+  return base;
+}
+
+void M5RF433Screen::_loadBrowseDir(const String& path) {
+  _browsePath = path;
+  _state = STATE_SEND_BROWSE;
+
+  int lastSlash = path.lastIndexOf('/');
+  String folderName = (lastSlash >= 0) ? path.substring(lastSlash + 1) : path;
+  snprintf(_titleBuf, sizeof(_titleBuf), "RF: %s", folderName.c_str());
+
+  if (Uni.Storage && Uni.Storage->isAvailable()) {
+    Uni.Storage->makeDir(path.c_str());
+  }
+
+  uint8_t n = _browser.load(this, path, ".sub");
+  setItems(_browser.items(), n);
+}

--- a/firmware/src/screens/module/M5RF433Screen.cpp
+++ b/firmware/src/screens/module/M5RF433Screen.cpp
@@ -143,25 +143,6 @@ void M5RF433Screen::onUpdate() {
     return;
   }
 
-  if (_state == STATE_SEND_BROWSE) {
-    if (!_holdFired && Uni.Nav->isPressed() && Uni.Nav->heldDuration() >= 1000) {
-      _holdFired = true;
-      _pendingHoldIdx = _selectedIndex;
-      if (_pendingHoldIdx < _browser.count() && !_browser.entry(_pendingHoldIdx).isDir)
-        _showBrowseOptions(_pendingHoldIdx);
-      else
-        render();
-      return;
-    }
-  }
-  if (_holdFired) {
-    if (Uni.Nav->wasPressed()) {
-      Uni.Nav->readDirection();
-      _holdFired = false;
-    }
-    return;
-  }
-
   ListScreen::onUpdate();
 }
 
@@ -324,7 +305,7 @@ void M5RF433Screen::onItemSelected(uint8_t index) {
       _loadBrowseDir(_browser.entry(index).path);
       return;
     }
-    _showBrowseTapOptions(index);
+    _showBrowseOptions(index);
     return;
   }
 }
@@ -354,18 +335,6 @@ void M5RF433Screen::_sendBrowseFile(uint8_t index) {
   }
   ShowStatusAction::show(("Sent: " + e.name).c_str(), 1000);
   render();
-}
-
-void M5RF433Screen::_showBrowseTapOptions(uint8_t index) {
-  static constexpr InputSelectAction::Option tapOpts[] = {
-    {"Send", "send"},
-    {"Info", "info"},
-  };
-  const char* choice = InputSelectAction::popup("Options", tapOpts, 2, "send");
-  if (!choice) { render(); return; }
-
-  if (strcmp(choice, "send") == 0)      _sendBrowseFile(index);
-  else if (strcmp(choice, "info") == 0) _showBrowseFileInfo(index);
 }
 
 void M5RF433Screen::_showBrowseFileInfo(uint8_t index) {

--- a/firmware/src/screens/module/M5RF433Screen.h
+++ b/firmware/src/screens/module/M5RF433Screen.h
@@ -76,11 +76,9 @@ private:
   static constexpr const char* kRootPath = "/unigeek/rf";
   String _browsePath;
   BrowseFileView _browser;
-  bool    _holdFired = false;
-  uint8_t _pendingHoldIdx = 0;
+  bool _holdFired = false;
   void _loadBrowseDir(const String& path);
   void _sendBrowseFile(uint8_t index);
-  void _showBrowseTapOptions(uint8_t index);
   void _showBrowseOptions(uint8_t index);
   void _showBrowseFileInfo(uint8_t index);
   String _makeUniquePath(const String& name);

--- a/firmware/src/screens/module/M5RF433Screen.h
+++ b/firmware/src/screens/module/M5RF433Screen.h
@@ -1,0 +1,87 @@
+//
+// M5 RF433 (M5 RF433T/R Unit) Screen — single-pin RF, fixed 433.92 MHz
+//
+
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+#include "ui/views/BrowseFileView.h"
+#include "ui/views/TextScrollView.h"
+#include "utils/rf/M5RF433Util.h"
+
+class M5RF433Screen : public ListScreen {
+public:
+  const char* title() override { return _titleBuf; }
+  bool inhibitPowerSave() override { return _state == STATE_RECEIVING; }
+  bool inhibitPowerOff() override { return _state == STATE_RECEIVING || _state == STATE_JAMMING; }
+
+  void onInit() override;
+  void onUpdate() override;
+  void onRender() override;
+  void onBack() override;
+  void onItemSelected(uint8_t index) override;
+
+private:
+  enum State {
+    STATE_MENU,
+    STATE_RECEIVING,
+    STATE_SEND_BROWSE,
+    STATE_JAMMING,
+    STATE_SIGNAL_INFO,
+  } _state = STATE_MENU;
+
+  enum InfoSource { INFO_FROM_CAPTURE, INFO_FROM_BROWSE };
+  TextScrollView _textView;
+  InfoSource     _infoSource = INFO_FROM_CAPTURE;
+  uint8_t        _infoIdx    = 0;
+  void _showSignalInfo(const M5RF433Util::Signal& sig, InfoSource src, uint8_t idx);
+
+  M5RF433Util _rf;
+  int8_t _txPin = -1;
+  int8_t _rxPin = -1;
+  char _titleBuf[32] = "M5 RF433";
+  bool _chromeDrawn = false;
+
+  // Menu — Receive / Send / Jammer
+  static constexpr uint8_t kMenuCount = 3;
+  ListItem _menuItems[kMenuCount] = {
+    {"Receive"},
+    {"Send"},
+    {"Jammer"},
+  };
+  void _showMenu();
+  void _toggleRxFilter();
+
+  // Receive — captured signal buffer
+  static constexpr uint8_t kMaxCapture = 15;
+  M5RF433Util::Signal _capturedSignals[kMaxCapture];
+  String _capturedTimes[kMaxCapture];
+  bool   _capturedSaved[kMaxCapture];
+  String _capturedSubLabels[kMaxCapture];
+  ListItem _capturedItems[kMaxCapture];
+  uint8_t _capturedCount = 0;
+  uint32_t _lastRender   = 0;
+  void _showReceiveList();
+  void _handleCaptureSelection(uint8_t index);
+  void _rebuildCapturedItems();
+  void _sendCapturedSignal(uint8_t index);
+  void _saveSignal(uint8_t index, const String& name);
+  bool _isDuplicate(const M5RF433Util::Signal& sig) const;
+  String _generateTimestampName();
+
+  // Jammer state
+  uint32_t _jamStart = 0;
+
+  // Send — file browser
+  static constexpr const char* kRootPath = "/unigeek/rf";
+  String _browsePath;
+  BrowseFileView _browser;
+  bool    _holdFired = false;
+  uint8_t _pendingHoldIdx = 0;
+  void _loadBrowseDir(const String& path);
+  void _sendBrowseFile(uint8_t index);
+  void _showBrowseTapOptions(uint8_t index);
+  void _showBrowseOptions(uint8_t index);
+  void _showBrowseFileInfo(uint8_t index);
+  String _makeUniquePath(const String& name);
+};

--- a/firmware/src/screens/module/ModuleMenuScreen.cpp
+++ b/firmware/src/screens/module/ModuleMenuScreen.cpp
@@ -7,6 +7,7 @@
 #include "screens/module/GPSScreen.h"
 #include "screens/module/IRScreen.h"
 #include "screens/module/SubGHzScreen.h"
+#include "screens/module/M5RF433Screen.h"
 #include "screens/module/NRF24Screen.h"
 #include "screens/setting/PinSettingScreen.h"
 
@@ -26,7 +27,8 @@ void ModuleMenuScreen::onItemSelected(uint8_t index) {
     case 3: Screen.push(new GPSScreen());         break;
     case 4: Screen.push(new IRScreen());          break;
     case 5: Screen.push(new SubGHzScreen());      break;
-    case 6: Screen.push(new NRF24Screen());       break;
-    case 7: Screen.push(new PinSettingScreen());  break;
+    case 6: Screen.push(new M5RF433Screen());     break;
+    case 7: Screen.push(new NRF24Screen());       break;
+    case 8: Screen.push(new PinSettingScreen());  break;
   }
 }

--- a/firmware/src/screens/module/ModuleMenuScreen.h
+++ b/firmware/src/screens/module/ModuleMenuScreen.h
@@ -12,13 +12,14 @@ public:
   void onItemSelected(uint8_t index) override;
 
 private:
-  ListItem _items[8] = {
+  ListItem _items[9] = {
     {"MFRC522 I2C"},
     {"PN532 UART"},
     {"PN532 I2C"},
     {"GPS"},
     {"IR Remote"},
     {"Sub-GHz"},
+    {"M5 RF433"},
     {"NRF24L01"},
     {"Pin Setting"},
   };

--- a/firmware/src/screens/module/SubGHzScreen.cpp
+++ b/firmware/src/screens/module/SubGHzScreen.cpp
@@ -163,26 +163,6 @@ void SubGHzScreen::onUpdate() {
     return;
   }
 
-  if (_state == STATE_SEND_BROWSE) {
-    if (!_holdFired && Uni.Nav->isPressed() && Uni.Nav->heldDuration() >= 1000) {
-      _holdFired = true;
-      _pendingHoldIdx = _selectedIndex;
-      // Show popup immediately — don't wait for release
-      if (_pendingHoldIdx < _browser.count() && !_browser.entry(_pendingHoldIdx).isDir)
-        _showBrowseOptions(_pendingHoldIdx);
-      else
-        render();
-      return;
-    }
-  }
-  if (_holdFired) {
-    if (Uni.Nav->wasPressed()) {
-      Uni.Nav->readDirection();  // consume the release so it doesn't trigger onItemSelected
-      _holdFired = false;
-    }
-    return;
-  }
-
   ListScreen::onUpdate();
 }
 
@@ -476,7 +456,7 @@ void SubGHzScreen::onItemSelected(uint8_t index) {
       _loadBrowseDir(_browser.entry(index).path);
       return;
     }
-    _showBrowseTapOptions(index);
+    _showBrowseOptions(index);
     return;
   }
 }
@@ -512,18 +492,6 @@ void SubGHzScreen::_sendBrowseFile(uint8_t index) {
   }
   ShowStatusAction::show(("Sent: " + e.name).c_str(), 1000);
   render();
-}
-
-void SubGHzScreen::_showBrowseTapOptions(uint8_t index) {
-  static constexpr InputSelectAction::Option tapOpts[] = {
-    {"Send", "send"},
-    {"Info", "info"},
-  };
-  const char* choice = InputSelectAction::popup("Options", tapOpts, 2, "send");
-  if (!choice) { render(); return; }
-
-  if (strcmp(choice, "send") == 0)      _sendBrowseFile(index);
-  else if (strcmp(choice, "info") == 0) _showBrowseFileInfo(index);
 }
 
 void SubGHzScreen::_showBrowseFileInfo(uint8_t index) {

--- a/firmware/src/screens/module/SubGHzScreen.cpp
+++ b/firmware/src/screens/module/SubGHzScreen.cpp
@@ -33,6 +33,17 @@ void SubGHzScreen::onInit() {
 }
 
 void SubGHzScreen::onUpdate() {
+  if (_state == STATE_SIGNAL_INFO) {
+    if (!Uni.Nav->wasPressed()) return;
+    auto dir = Uni.Nav->readDirection();
+    if (dir == INavigation::DIR_BACK || dir == INavigation::DIR_PRESS) {
+      onBack();
+      return;
+    }
+    if (_textView.onNav(dir) && Uni.Speaker) Uni.Speaker->beep();
+    return;
+  }
+
   if (_state == STATE_SCANNING) {
     if (Uni.Nav->wasPressed()) {
       auto dir = Uni.Nav->readDirection();
@@ -73,11 +84,57 @@ void SubGHzScreen::onUpdate() {
         _showReceiveList();
       }
     }
+
+    // Hold-PRESS (500 ms) toggles the filter — fallback for 2-way devices
+    // (sticks, T-Display, T-Embed, CYD touch) where LEFT/RIGHT aren't emitted.
+    if (!_holdFired && Uni.Nav->isPressed() &&
+        Uni.Nav->currentDirection() == INavigation::DIR_PRESS &&
+        Uni.Nav->heldDuration() >= 500) {
+      _holdFired = true;
+      _toggleRxFilter();
+      render();
+      return;
+    }
+    if (_holdFired) {
+      if (Uni.Nav->wasPressed()) {
+        Uni.Nav->readDirection();  // swallow the release so PRESS click doesn't fire
+        _holdFired = false;
+      }
+      return;
+    }
+
+    // Nav: RIGHT/LEFT toggles filter; UP/DOWN/PRESS/BACK navigate the captured list.
+    // We intercept here instead of falling through to ListScreen::onUpdate so we
+    // can claim LEFT/RIGHT for the filter toggle (Bruce-style live switch).
+    if (Uni.Nav->wasPressed()) {
+      auto dir = Uni.Nav->readDirection();
+      if (dir == INavigation::DIR_LEFT || dir == INavigation::DIR_RIGHT) {
+        _toggleRxFilter();
+        render();
+      } else if (dir == INavigation::DIR_BACK) {
+        onBack();
+      } else if (_capturedCount > 0) {
+        if (dir == INavigation::DIR_UP) {
+          _selectedIndex = (_selectedIndex == 0) ? _capturedCount - 1 : _selectedIndex - 1;
+          setCount(_capturedCount);
+          render();
+        } else if (dir == INavigation::DIR_DOWN) {
+          _selectedIndex = (_selectedIndex >= _capturedCount - 1) ? 0 : _selectedIndex + 1;
+          setCount(_capturedCount);
+          render();
+        } else if (dir == INavigation::DIR_PRESS) {
+          onItemSelected(_selectedIndex);
+        }
+      }
+      return;
+    }
+
     // Blink title indicator while still listening
     if (_capturedCount < kMaxCapture && millis() - _lastRender > 500) {
       _lastRender = millis();
       render();
     }
+    return;
   }
 
   if (_state == STATE_JAMMING) {
@@ -130,6 +187,11 @@ void SubGHzScreen::onUpdate() {
 }
 
 void SubGHzScreen::onRender() {
+  if (_state == STATE_SIGNAL_INFO) {
+    _textView.render(bodyX(), bodyY(), bodyW(), bodyH());
+    return;
+  }
+
   if (_state == STATE_RECEIVING) {
     if (_capturedCount == 0) {
       auto& lcd = Uni.Lcd;
@@ -145,11 +207,16 @@ void SubGHzScreen::onRender() {
       lcd.drawString("Waiting for signal...", bodyX() + bodyW() / 2, bodyY() + bodyH() / 2);
       lcd.fillRect(bodyX(), bodyY() + bodyH() - 16, bodyW(), 16, Config.getThemeColor());
       lcd.setTextColor(TFT_WHITE, Config.getThemeColor());
+      const char* filterLabel = (_rf.getRxFilter() == CC1101Util::RX_FILTER_CODE)
+                                ? "> Filter: Code" : "> Filter: RAW";
+      lcd.setTextDatum(ML_DATUM);
       #ifdef DEVICE_HAS_KEYBOARD
-        lcd.drawString("BACK: Stop", bodyX() + bodyW() / 2, bodyY() + bodyH() - 8);
+        lcd.drawString("BACK: Stop", bodyX() + 4, bodyY() + bodyH() - 8);
       #else
-        lcd.drawString("< Stop", bodyX() + bodyW() / 2, bodyY() + bodyH() - 8);
+        lcd.drawString("< Stop", bodyX() + 4, bodyY() + bodyH() - 8);
       #endif
+      lcd.setTextDatum(MR_DATUM);
+      lcd.drawString(filterLabel, bodyX() + bodyW() - 4, bodyY() + bodyH() - 8);
       _chromeDrawn = true;
     } else {
       ListScreen::onRender();
@@ -285,6 +352,21 @@ void SubGHzScreen::onRender() {
 }
 
 void SubGHzScreen::onBack() {
+  if (_state == STATE_SIGNAL_INFO) {
+    // Restore the list state then re-open the popup that summoned the info view.
+    uint8_t idx = _infoIdx;
+    if (_infoSource == INFO_FROM_CAPTURE) {
+      _state = STATE_RECEIVING;
+      _showReceiveList();
+      _handleCaptureSelection(idx);
+    } else {
+      // Browse: state is already STATE_SEND_BROWSE in spirit — repaint list, re-pop.
+      _state = STATE_SEND_BROWSE;
+      _loadBrowseDir(_browsePath);
+      _showBrowseOptions(idx);
+    }
+    return;
+  }
   if (_state == STATE_MENU) {
     _rf.end();
     Screen.goBack();
@@ -394,7 +476,7 @@ void SubGHzScreen::onItemSelected(uint8_t index) {
       _loadBrowseDir(_browser.entry(index).path);
       return;
     }
-    _sendBrowseFile(index);
+    _showBrowseTapOptions(index);
     return;
   }
 }
@@ -432,17 +514,44 @@ void SubGHzScreen::_sendBrowseFile(uint8_t index) {
   render();
 }
 
+void SubGHzScreen::_showBrowseTapOptions(uint8_t index) {
+  static constexpr InputSelectAction::Option tapOpts[] = {
+    {"Send", "send"},
+    {"Info", "info"},
+  };
+  const char* choice = InputSelectAction::popup("Options", tapOpts, 2, "send");
+  if (!choice) { render(); return; }
+
+  if (strcmp(choice, "send") == 0)      _sendBrowseFile(index);
+  else if (strcmp(choice, "info") == 0) _showBrowseFileInfo(index);
+}
+
+void SubGHzScreen::_showBrowseFileInfo(uint8_t index) {
+  String content = Uni.Storage->readFile(_browser.entry(index).path.c_str());
+  CC1101Util::Signal sig;
+  if (!CC1101Util::loadFile(content, sig)) {
+    ShowStatusAction::show("Invalid .sub file");
+    render();
+    return;
+  }
+  _showSignalInfo(sig, INFO_FROM_BROWSE, index);
+}
+
 void SubGHzScreen::_showBrowseOptions(uint8_t index) {
   static constexpr InputSelectAction::Option fileOpts[] = {
     {"Send",   "send"},
+    {"Info",   "info"},
     {"Rename", "rename"},
     {"Delete", "delete"},
   };
-  const char* choice = InputSelectAction::popup("Options", fileOpts, 3, "send");
+  const char* choice = InputSelectAction::popup("Options", fileOpts, 4, "send");
   if (!choice) { render(); return; }
 
   if (strcmp(choice, "send") == 0) {
     _sendBrowseFile(index);
+
+  } else if (strcmp(choice, "info") == 0) {
+    _showBrowseFileInfo(index);
 
   } else if (strcmp(choice, "rename") == 0) {
     String curName = _browser.entry(index).name;
@@ -507,6 +616,15 @@ void SubGHzScreen::_startScan() {
   render();
 }
 
+void SubGHzScreen::_toggleRxFilter() {
+  auto cur = _rf.getRxFilter();
+  _rf.setRxFilter(cur == CC1101Util::RX_FILTER_CODE
+                  ? CC1101Util::RX_FILTER_RAW
+                  : CC1101Util::RX_FILTER_CODE);
+  _chromeDrawn = false;  // redraw waiting-screen footer with new label
+  if (Uni.Speaker) Uni.Speaker->beep();
+}
+
 void SubGHzScreen::_selectFrequency() {
   static constexpr InputSelectAction::Option freqOpts[] = {
     {"300 MHz",    "300"},
@@ -555,12 +673,18 @@ void SubGHzScreen::_handleCaptureSelection(uint8_t index) {
   if (index >= _capturedCount) return;
 
   static constexpr InputSelectAction::Option captureOpts[] = {
+    {"Info",   "info"},
     {"Replay", "replay"},
     {"Save",   "save"},
     {"Delete", "delete"},
   };
-  const char* choice = InputSelectAction::popup("Options", captureOpts, 3);
+  const char* choice = InputSelectAction::popup("Options", captureOpts, 4);
   if (!choice) { render(); return; }
+
+  if (strcmp(choice, "info") == 0) {
+    _showSignalInfo(_capturedSignals[index], INFO_FROM_CAPTURE, index);
+    return;
+  }
 
   if (strcmp(choice, "replay") == 0) {
     _sendCapturedSignal(index);
@@ -586,6 +710,15 @@ void SubGHzScreen::_handleCaptureSelection(uint8_t index) {
     _capturedCount--;
     _showReceiveList();
   }
+}
+
+void SubGHzScreen::_showSignalInfo(const CC1101Util::Signal& sig, InfoSource src, uint8_t idx) {
+  _infoSource = src;
+  _infoIdx    = idx;
+  strcpy(_titleBuf, "Signal Info");
+  _state = STATE_SIGNAL_INFO;
+  _textView.setContent(CC1101Util::signalInfoText(sig));
+  render();
 }
 
 void SubGHzScreen::_rebuildCapturedItems() {

--- a/firmware/src/screens/module/SubGHzScreen.h
+++ b/firmware/src/screens/module/SubGHzScreen.h
@@ -86,13 +86,11 @@ private:
   static constexpr const char* kRootPath = "/unigeek/rf";
   String _browsePath;
   BrowseFileView _browser;
-  bool    _holdFired = false;
-  uint8_t _pendingHoldIdx = 0;
+  bool _holdFired = false;
   void _loadBrowseDir(const String& path);
   void _sendBrowseFile(uint8_t index);
-  void _showBrowseTapOptions(uint8_t index);   // Send / Info (on tap)
-  void _showBrowseOptions(uint8_t index);      // Send / Info / Rename / Delete (on hold)
-  void _showBrowseFileInfo(uint8_t index);     // parses .sub, opens info view
+  void _showBrowseOptions(uint8_t index);    // Send / Info / Rename / Delete
+  void _showBrowseFileInfo(uint8_t index);   // parses .sub, opens info view
   String _makeUniquePath(const String& name);
 };
 

--- a/firmware/src/screens/module/SubGHzScreen.h
+++ b/firmware/src/screens/module/SubGHzScreen.h
@@ -6,6 +6,7 @@
 
 #include "ui/templates/ListScreen.h"
 #include "ui/views/BrowseFileView.h"
+#include "ui/views/TextScrollView.h"
 #include "utils/rf/CC1101Util.h"
 
 class SubGHzScreen : public ListScreen {
@@ -27,7 +28,14 @@ private:
     STATE_SEND_BROWSE,
     STATE_JAMMING,
     STATE_SCANNING,
+    STATE_SIGNAL_INFO,  // scrollable info view; back returns to popup
   } _state = STATE_MENU;
+
+  enum InfoSource { INFO_FROM_CAPTURE, INFO_FROM_BROWSE };
+  TextScrollView _textView;
+  InfoSource     _infoSource = INFO_FROM_CAPTURE;
+  uint8_t        _infoIdx    = 0;
+  void _showSignalInfo(const CC1101Util::Signal& sig, InfoSource src, uint8_t idx);
 
   CC1101Util _rf;
   int8_t _csPin   = -1;
@@ -48,6 +56,7 @@ private:
   void _showMenu();
   void _updateSublabels();
   void _selectFrequency();
+  void _toggleRxFilter();
   void _startScan();
 
   // Receive — captured signal buffer
@@ -81,7 +90,9 @@ private:
   uint8_t _pendingHoldIdx = 0;
   void _loadBrowseDir(const String& path);
   void _sendBrowseFile(uint8_t index);
-  void _showBrowseOptions(uint8_t index);
+  void _showBrowseTapOptions(uint8_t index);   // Send / Info (on tap)
+  void _showBrowseOptions(uint8_t index);      // Send / Info / Rename / Delete (on hold)
+  void _showBrowseFileInfo(uint8_t index);     // parses .sub, opens info view
   String _makeUniquePath(const String& name);
 };
 

--- a/firmware/src/utils/rf/CC1101Util.cpp
+++ b/firmware/src/utils/rf/CC1101Util.cpp
@@ -155,7 +155,7 @@ bool CC1101Util::pollReceive(Signal& out) {
     _sw.resetAvailable();
   }
 
-  if (_sw.RAWavailable()) {
+  if (_rxFilter == RX_FILTER_RAW && _sw.RAWavailable()) {
     delay(400); // let full signal arrive
     unsigned int* raw = _sw.getRAWReceivedRawdata();
     String rawStr;
@@ -429,6 +429,62 @@ String CC1101Util::saveToString(const Signal& sig) {
   }
 
   return content;
+}
+
+String CC1101Util::signalInfoText(const Signal& sig) {
+  String out;
+  char buf[80];
+
+  // Frequency
+  snprintf(buf, sizeof(buf), "Frequency: %.2f MHz\n", sig.frequency);
+  out += buf;
+
+  // Protocol line (Bruce shows "Protocol: <name>(<preset>)" when preset is set)
+  if (sig.preset.length() > 0)
+    out += "Protocol: " + sig.protocol + " (" + sig.preset + ")\n";
+  else
+    out += "Protocol: " + sig.protocol + "\n";
+
+  if (sig.protocol == "RcSwitch") {
+    out += "Length: " + String(sig.bit) + " bits\n";
+    snprintf(buf, sizeof(buf), "Key: 0x%llX\n", (unsigned long long)sig.key);
+    out += buf;
+    if (sig.te > 0) out += "TE: " + String(sig.te) + " us\n";
+
+    // Binary breakdown grouped by 4 bits — capped to 40 bits like Bruce
+    int bits = sig.bit;
+    if (bits > 40) bits = 40;
+    if (bits > 0) {
+      String bin;
+      for (int i = bits - 1; i >= 0; i--) {
+        bin += ((sig.key >> i) & 1ULL) ? '1' : '0';
+        if (i > 0 && (i % 4) == 0) bin += ' ';
+      }
+      out += "Binary: " + bin + "\n";
+    }
+  } else {
+    // RAW — count pulses, show TE (first pulse), then a head of the timing data
+    int pulses = 0;
+    for (char c : sig.rawData) if (c == ' ') pulses++;
+    pulses++;
+    out += "Length: " + String(pulses) + " transitions\n";
+
+    int firstTe = 0;
+    int sp = sig.rawData.indexOf(' ');
+    String firstTok = (sp < 0) ? sig.rawData : sig.rawData.substring(0, sp);
+    firstTok.trim();
+    firstTe = firstTok.toInt();
+    if (firstTe < 0) firstTe = -firstTe;
+    if (firstTe > 0) out += "TE: " + String(firstTe) + " us\n";
+
+    if (sig.rawData.length() > 0) {
+      String head = sig.rawData;
+      if (head.length() > 240) head = head.substring(0, 240) + "...";
+      out += "Data:\n" + head + "\n";
+    }
+  }
+
+  return out;
 }
 
 String CC1101Util::signalLabel(const Signal& sig) {

--- a/firmware/src/utils/rf/CC1101Util.h
+++ b/firmware/src/utils/rf/CC1101Util.h
@@ -15,6 +15,16 @@ public:
   static constexpr uint16_t MAX_RAW_LEN   = 2048;
   static constexpr int     RSSI_THRESHOLD = -65;  // dBm — signal detected above this
 
+  // Receive filter — applied by pollReceive().
+  //   RX_FILTER_CODE: only emit RCSwitch-decoded signals (one of the 23 known
+  //                   protocols). Drop everything else. Reduces noise/duplicates.
+  //   RX_FILTER_RAW : emit RCSwitch-decoded signals AND raw pulse streams that
+  //                   no protocol matched. Captures everything (default).
+  enum RxFilter {
+    RX_FILTER_CODE,
+    RX_FILTER_RAW,
+  };
+
   struct Signal {
     float frequency = 0;     // MHz
     String preset = "0";     // modulation preset name or RcSwitch protocol number
@@ -47,6 +57,9 @@ public:
   bool pollReceive(Signal& out);
   void endReceive();
 
+  void     setRxFilter(RxFilter f) { _rxFilter = f; }
+  RxFilter getRxFilter() const     { return _rxFilter; }
+
   // Non-blocking frequency scan:
   //   1. call beginScan() once when entering scan state
   //   2. call stepScan() every frame — returns true when a signal is detected
@@ -78,8 +91,11 @@ public:
   static bool loadFile(const String& content, Signal& out);
   static String saveToString(const Signal& sig);
 
-  // Display helper
+  // Display helpers
   static String signalLabel(const Signal& sig);
+  // Multi-line, key:value info block (mirrors Bruce's `display_signal_data`).
+  // Ready to feed into TextScrollView::setContent.
+  static String signalInfoText(const Signal& sig);
 
 private:
   int8_t _csPin = -1;
@@ -88,6 +104,7 @@ private:
   bool   _initialized = false;
 
   RCSwitchUtil _sw;  // persistent receiver state for non-blocking polling
+  RxFilter     _rxFilter = RX_FILTER_RAW;
 
   // Scan status (updated during receive/scan)
   bool    _scanning = false;

--- a/firmware/src/utils/rf/M5RF433Util.cpp
+++ b/firmware/src/utils/rf/M5RF433Util.cpp
@@ -1,0 +1,174 @@
+//
+// M5 RF433 Utility — implementation
+//
+
+#include "M5RF433Util.h"
+
+bool M5RF433Util::begin(int8_t txPin, int8_t rxPin) {
+  _txPin = txPin;
+  _rxPin = rxPin;
+  if (_txPin < 0 && _rxPin < 0) return false;
+  if (_txPin >= 0) {
+    pinMode(_txPin, OUTPUT);
+    digitalWrite(_txPin, LOW);
+  }
+  if (_rxPin >= 0) {
+    pinMode(_rxPin, INPUT);
+  }
+  _initialized = true;
+  return true;
+}
+
+void M5RF433Util::end() {
+  endReceive();
+  if (_txPin >= 0) digitalWrite(_txPin, LOW);
+  _initialized = false;
+}
+
+// ── Receive ──────────────────────────────────────────────────────────────────
+
+bool M5RF433Util::beginReceive() {
+  if (!_initialized || _rxPin < 0) return false;
+  _sw.enableReceive(_rxPin);
+  _sw.resetAvailable();
+  return true;
+}
+
+bool M5RF433Util::pollReceive(Signal& out) {
+  if (!_initialized) return false;
+
+  if (_sw.available()) {
+    uint64_t val = _sw.getReceivedValue();
+    if (val != 0) {
+      out.frequency = FIXED_FREQ;
+      out.key       = val;
+      out.preset    = String(_sw.getReceivedProtocol());
+      out.protocol  = "RcSwitch";
+      out.te        = (int)_sw.getReceivedDelay();
+      out.bit       = (int)_sw.getReceivedBitlength();
+      out.rawData   = "";
+      _sw.resetAvailable();
+      return true;
+    }
+    _sw.resetAvailable();
+  }
+
+  if (_rxFilter == RX_FILTER_RAW && _sw.RAWavailable()) {
+    delay(400);  // let trailing pulses settle
+    unsigned int* raw = _sw.getRAWReceivedRawdata();
+    String rawStr;
+    for (int i = 0; raw[i] != 0; i++) {
+      if (i > 0) rawStr += ' ';
+      int sign = (i % 2 == 0) ? 1 : -1;
+      rawStr += String(sign * (int)raw[i]);
+    }
+    if (rawStr.length() > 0) {
+      out.frequency = FIXED_FREQ;
+      out.preset    = "0";
+      out.protocol  = "RAW";
+      out.rawData   = rawStr;
+      out.key = 0; out.te = 0; out.bit = 0;
+      _sw.resetAvailable();
+      return true;
+    }
+    _sw.resetAvailable();
+  }
+
+  return false;
+}
+
+void M5RF433Util::endReceive() {
+  _sw.disableReceive();
+}
+
+// ── Send ─────────────────────────────────────────────────────────────────────
+
+void M5RF433Util::sendSignal(const Signal& sig) {
+  if (!_initialized || _txPin < 0) return;
+
+  // Detaching RX while transmitting prevents the ISR firing on our own pulses.
+  bool rxWasActive = false;
+  if (_rxPin >= 0) {
+    _sw.disableReceive();
+    rxWasActive = true;
+  }
+
+  pinMode(_txPin, OUTPUT);
+  digitalWrite(_txPin, LOW);
+
+  if (sig.protocol == "RAW") {
+    _sendRaw(sig.rawData);
+  } else {
+    _sendRcSwitch(sig);
+  }
+
+  digitalWrite(_txPin, LOW);
+
+  if (rxWasActive) {
+    _sw.enableReceive(_rxPin);
+    _sw.resetAvailable();
+  }
+}
+
+void M5RF433Util::_sendRaw(const String& data) {
+  int start = 0;
+  for (int i = 0; i <= (int)data.length(); i++) {
+    if (i == (int)data.length() || data[i] == ' ') {
+      if (i > start) {
+        int32_t val = data.substring(start, i).toInt();
+        if (val > 0) {
+          digitalWrite(_txPin, HIGH);
+          delayMicroseconds((uint32_t)val);
+        } else if (val < 0) {
+          digitalWrite(_txPin, LOW);
+          delayMicroseconds((uint32_t)(-val));
+        }
+      }
+      start = i + 1;
+    }
+  }
+}
+
+void M5RF433Util::_sendRcSwitch(const Signal& sig) {
+  int protoNum = 1;
+  if (sig.preset == "FuriHalSubGhzPresetOok270Async") {
+    protoNum = 1;
+  } else if (sig.preset == "FuriHalSubGhzPresetOok650Async") {
+    protoNum = 2;
+  } else if (sig.protocol.startsWith("Princeton")) {
+    protoNum = 1;
+  } else {
+    int n = sig.preset.toInt();
+    if (n >= 1 && n <= 23) protoNum = n;
+  }
+
+  RCSwitchUtil sw;
+  sw.enableTransmit(_txPin);
+  sw.setProtocol(protoNum);
+  if (sig.te > 0) sw.setPulseLength(sig.te);
+  sw.setRepeatTransmit(10);
+  sw.send(sig.key, (unsigned int)sig.bit);
+  sw.disableTransmit();
+}
+
+// ── Jammer ───────────────────────────────────────────────────────────────────
+
+void M5RF433Util::startJam() {
+  if (_txPin < 0) return;
+  pinMode(_txPin, OUTPUT);
+  digitalWrite(_txPin, LOW);
+}
+
+void M5RF433Util::stopJam() {
+  if (_txPin >= 0) digitalWrite(_txPin, LOW);
+}
+
+void M5RF433Util::jamBurst() {
+  if (_txPin < 0) return;
+  for (int i = 0; i < 50; i++) {
+    uint32_t pw  = 5 + (micros() % 46);
+    uint32_t gap = 5 + (micros() % 96);
+    digitalWrite(_txPin, HIGH); delayMicroseconds(pw);
+    digitalWrite(_txPin, LOW);  delayMicroseconds(gap);
+  }
+}

--- a/firmware/src/utils/rf/M5RF433Util.h
+++ b/firmware/src/utils/rf/M5RF433Util.h
@@ -1,0 +1,53 @@
+//
+// M5 RF433 Utility — send/receive raw RF signals on M5 RF433T/R
+// (single-pin OOK TX + ISR-based RX, fixed 433.92 MHz).
+//
+// Mirrors CC1101Util's surface so screens can reuse the same Signal type
+// and the same .sub file format. Hardware is purely GPIO bit-bang:
+//   - TX pin drives the M5 RF433T transmitter (ASK/OOK at 433.92 MHz)
+//   - RX pin reads from the M5 RF433R receiver (squelched digital output)
+//
+// Reference: Bruce firmware single-pin RF path (rfTx / rfRx).
+//
+
+#pragma once
+#include <Arduino.h>
+#include "CC1101Util.h"
+#include "RCSwitchUtil.h"
+
+class M5RF433Util {
+public:
+  static constexpr float FIXED_FREQ = 433.92f;
+  using Signal   = CC1101Util::Signal;
+  using RxFilter = CC1101Util::RxFilter;
+  static constexpr RxFilter RX_FILTER_CODE = CC1101Util::RX_FILTER_CODE;
+  static constexpr RxFilter RX_FILTER_RAW  = CC1101Util::RX_FILTER_RAW;
+
+  bool begin(int8_t txPin, int8_t rxPin);
+  void end();
+  bool isInitialized() const { return _initialized; }
+
+  bool beginReceive();
+  bool pollReceive(Signal& out);
+  void endReceive();
+
+  void     setRxFilter(RxFilter f) { _rxFilter = f; }
+  RxFilter getRxFilter() const     { return _rxFilter; }
+
+  void sendSignal(const Signal& sig);
+
+  // Jammer: drives the TX pin directly (caller pulses doJamPulse() in a loop)
+  void startJam();
+  void stopJam();
+  void jamBurst();
+
+private:
+  int8_t _txPin = -1;
+  int8_t _rxPin = -1;
+  bool   _initialized = false;
+  RCSwitchUtil _sw;
+  RxFilter _rxFilter = RX_FILTER_RAW;
+
+  void _sendRaw(const String& rawData);
+  void _sendRcSwitch(const Signal& sig);
+};

--- a/knowledge/m5-rf433.md
+++ b/knowledge/m5-rf433.md
@@ -1,0 +1,121 @@
+# M5 RF433
+
+Capture, replay, and jam 433.92 MHz RF signals using the **M5Stack RF433T/R Units** — discrete transmitter and receiver modules wired to two GPIO pins. No SPI, no CC1101 needed. Accessed from **Modules > M5 RF433**. Compatible with Flipper Zero and Bruce `.sub` files at 433.92 MHz.
+
+## Hardware Setup
+
+The M5 RF433T (transmitter) and M5 RF433R (receiver) are two separate single-pin modules. Each is connected to one GPIO. Both units run at a fixed **433.92 MHz** (no frequency tuning).
+
+| Unit | Pin direction | Function |
+|------|---------------|----------|
+| M5 RF433T | OUTPUT | ASK/OOK transmit data line |
+| M5 RF433R | INPUT  | squelched digital receive data line |
+
+### Pinout (fixed per board)
+
+The M5 RF433T/R uses a **fixed pinout chosen at build time** — there is no entry in **Modules > Pin Setting** for it. The intended wiring is the device's Grove port (M5 RF433T → SDA, M5 RF433R → SCL), which matches plugging in via a Hat-Y or Grove-W splitter.
+
+| Default | Pin |
+|---------|-----|
+| TX | `M5RF433_TX_PIN` if defined, else `GROVE_SDA` |
+| RX | `M5RF433_RX_PIN` if defined, else `GROVE_SCL` |
+
+A board that needs to route the modules to different pins should define `M5RF433_TX_PIN` and/or `M5RF433_RX_PIN` in its `firmware/boards/<board>/pins_arduino.h`. Defining neither (and lacking `GROVE_SDA`/`GROVE_SCL`) makes the entry show `M5 RF433 not supported` and exit back to the Module menu.
+
+## Receive
+
+Capture RF signals at 433.92 MHz from the M5 RF433R.
+
+1. Select **Receive** from the menu
+2. The device listens on the configured RX pin. The footer shows the current Receive Filter:
+   - **Filter: RAW** (default) — capture both RCSwitch-decoded protocols and raw pulse streams that no protocol matched. Best for unknown remotes.
+   - **Filter: Code** — only emit signals that decoded as one of the 23 known RCSwitch protocols; drops raw noise.
+3. Toggle between RAW / Code live — footer label updates immediately. Setting is session-only.
+   - **4-way devices** (Cardputer, Cardputer ADV, DIY Smoochie, DIY Marauder, sticks in Encoder mode): press **LEFT** or **RIGHT**.
+   - **2-way devices** (M5StickS3, T-Display, T-Lora Pager, T-Embed CC1101, CYD touch, CoreS3, sticks in default mode): **hold OK / PRESS for 500 ms**.
+4. Captured signals appear in the list with protocol details:
+   - **RcSwitch**: `0xABCDEF P1 24b` (hex value, protocol number, bit count)
+   - **RAW**: `RAW 120 pulses` (raw pulse count)
+5. Duplicate RcSwitch signals are automatically filtered
+6. Select a captured signal to **Replay**, **Save**, or **Delete** it
+7. Saved files go to `/unigeek/rf/` in `.sub` format (shared with **Sub-GHz**)
+8. Up to 15 signals can be captured per session
+9. Press **BACK** to stop receiving and return to the menu
+
+## Send
+
+Browse and send `.sub` signal files from storage. The frequency stored in the file is ignored — the M5 RF433T can only transmit at 433.92 MHz, so 433-MHz files work as recorded and other-band files are still bit-banged at 433 MHz (useful for testing protocol/timing, not for cross-band replay).
+
+1. Select **Send** from the menu
+2. Browse from `/unigeek/rf/` — navigate into subfolders
+3. **Tap** a file to send it immediately
+4. **Hold** a file (1 second) to open the action menu:
+   - **Send** — transmit the signal
+   - **Rename** — rename the file
+   - **Delete** — delete the file
+
+## Jammer
+
+Transmit random pulses on the M5 RF433T to disrupt nearby 433 MHz receivers.
+
+1. Select **Jammer**
+2. The TX pin is bit-banged with random short pulses
+3. Press **BACK** or **PRESS** to stop
+
+> [!danger]
+> Use only in environments you own or have explicit permission to test. Jamming RF signals is illegal in most jurisdictions.
+
+## File Format
+
+M5 RF433 reuses the same `.sub` file format as Sub-GHz (Flipper Zero / Bruce compatible):
+
+```
+Filetype: SubGhz Signal File
+Version 1
+Frequency: 433920000
+Preset: FuriHalSubGhzPresetOok270Async
+Protocol: RAW
+RAW_Data: 1234 -567 890 -123 ...
+```
+
+For RcSwitch (decoded) signals:
+
+```
+Filetype: SubGhz Signal File
+Version 1
+Frequency: 433920000
+Preset: 1
+Protocol: RcSwitch
+TE: 350
+Bit: 24
+Key: 0xABCDEF
+```
+
+Files captured with the **Sub-GHz** (CC1101) module at 433 MHz can be sent directly from M5 RF433 and vice-versa.
+
+## M5 RF433 vs Sub-GHz (CC1101)
+
+| | M5 RF433 | Sub-GHz (CC1101) |
+|---|----------|-------------------|
+| Hardware | 2× single-pin GPIO modules | SPI transceiver chip |
+| Frequency | fixed 433.92 MHz | tunable 280–928 MHz |
+| Modulation | ASK/OOK only | ASK/OOK + FSK/GFSK/MSK |
+| Detect Freq scan | not available (fixed freq) | RSSI sweep across 40 bands |
+| Range | shorter (low-power discrete modules) | longer (configurable PA up to +12 dBm) |
+| Use case | quick 433 MHz capture/replay where SPI isn't free | full Sub-GHz workbench |
+
+## Supported Protocols
+
+ASK/OOK signals common in consumer 433 MHz remotes:
+
+- Garage door openers (Princeton / fixed code)
+- Wireless doorbells and weather sensors
+- Power outlet remote controls
+- Gate and barrier remotes
+- Generic RCSwitch-compatible protocols (1–23 in the built-in protocol table)
+
+Rolling-code key fobs can be captured but replay will not work because of code rotation.
+
+## Achievements
+
+Shares the **RF Listener / RF Transmitter / RF Archive / RF Collector / RF Library / Frequency Disruptor** achievements with the Sub-GHz module — any RF receive/send/save counts toward both.

--- a/knowledge/m5-rf433.md
+++ b/knowledge/m5-rf433.md
@@ -48,9 +48,9 @@ Browse and send `.sub` signal files from storage. The frequency stored in the fi
 
 1. Select **Send** from the menu
 2. Browse from `/unigeek/rf/` — navigate into subfolders
-3. **Tap** a file to send it immediately
-4. **Hold** a file (1 second) to open the action menu:
+3. Tap a file to open the action menu:
    - **Send** — transmit the signal
+   - **Info** — open the signal info view (BACK returns here)
    - **Rename** — rename the file
    - **Delete** — delete the file
 

--- a/knowledge/sub-ghz.md
+++ b/knowledge/sub-ghz.md
@@ -103,12 +103,12 @@ Browse and send `.sub` signal files from storage.
 
 1. Select **Send** from the menu
 2. Browse from `/unigeek/rf/` — navigate into subfolders
-3. **Tap** a file to send it immediately
-4. **Hold** a file (1 second) to open the action menu:
+3. Tap a file to open the action menu:
    - **Send** — transmit the signal
+   - **Info** — open the signal info view (same fields as captured-signal Info; BACK returns here)
    - **Rename** — rename the file
    - **Delete** — delete the file
-5. The frequency stored in the file is used automatically during send
+4. The frequency stored in the file is used automatically during send
 
 ## Jammer
 

--- a/knowledge/sub-ghz.md
+++ b/knowledge/sub-ghz.md
@@ -82,15 +82,20 @@ Capture RF signals on the configured frequency.
 
 1. Set the desired frequency first via **Detect Freq** (reference) and **Frequency** (set)
 2. Select **Receive**
-3. The device listens on the configured frequency
-4. Captured signals appear in the list with protocol details:
+3. The device listens on the configured frequency. The footer shows the current Receive Filter:
+   - **Filter: RAW** (default) — capture both RCSwitch-decoded protocols **and** raw pulse streams that no protocol matched. Best for unknown remotes and unusual signals.
+   - **Filter: Code** — drop raw captures; only emit signals that decoded as one of the 23 known protocols (Princeton, HT6P20B, CAME, NICE, KeeLoq, …). Cuts noise when hunting a fixed-code remote.
+4. Toggle between RAW / Code live without leaving the screen — the footer label updates immediately. Setting is session-only.
+   - **4-way devices** (Cardputer, Cardputer ADV, DIY Smoochie, DIY Marauder, sticks in Encoder mode): press **LEFT** or **RIGHT**.
+   - **2-way devices** (M5StickS3, T-Display, T-Lora Pager, T-Embed CC1101, CYD touch, CoreS3, sticks in default mode): **hold OK / PRESS for 500 ms**. The release after the hold is swallowed so it doesn't open a capture popup.
+5. Captured signals appear in the list with protocol details:
    - **RcSwitch**: `0xABCDEF P1 24b` (hex value, protocol number, bit count)
    - **RAW**: `RAW 120 pulses` (raw pulse count)
-5. Duplicate RcSwitch signals are automatically filtered
-6. Select a captured signal to **Replay**, **Save**, or **Delete** it
-7. Saved files go to `/unigeek/rf/` in `.sub` format
-8. Up to 15 signals can be captured per session
-9. Press **BACK** to stop receiving and return to the menu
+6. Duplicate RcSwitch signals are automatically filtered
+7. Select a captured signal to **Replay**, **Save**, or **Delete** it
+8. Saved files go to `/unigeek/rf/` in `.sub` format
+9. Up to 15 signals can be captured per session
+10. Press **BACK** to stop receiving and return to the menu
 
 ## Send
 

--- a/website/content/features/catalog.js
+++ b/website/content/features/catalog.js
@@ -65,6 +65,7 @@ export const CATALOG = [
   { slug: "gps-wardriving",       title: "GPS & Wardriving",    category: "module",   summary: "Live GPS view, WiFi/BLE wardriving with Wigle CSV export, and Wigle upload integration",             hasDetail: true,  stable: true },
   { slug: "ir-remote",            title: "IR Remote",           category: "module",   summary: "Capture, replay, and manage IR signals — compatible with Flipper Zero and Bruce formats",            hasDetail: true,  stable: true },
   { slug: "sub-ghz",              title: "Sub-GHz (CC1101)",    category: "module",   summary: "Capture, replay, and jam Sub-GHz RF signals — compatible with Flipper Zero .sub format",            hasDetail: true,  stable: true },
+  { slug: "m5-rf433",             title: "M5 RF433",            category: "module",   summary: "Capture, replay, and jam 433.92 MHz signals via the M5 RF433T/R two-pin GPIO modules — no CC1101 needed; shares .sub files with Sub-GHz", hasDetail: true,  stable: true },
   { slug: "nrf24",                title: "NRF24L01+",           category: "module",   summary: "2.4 GHz spectrum analyzer, multi-mode jammer, and MouseJack wireless keyboard injection",             hasDetail: true,  stable: true },
   { slug: "pin-setting",          title: "Pin Setting",         category: "module",   summary: "Configure GPIO pins for GPS, I2C, CC1101, NRF24, PN532, and CoreS3 Grove 5V direction — defaults per board, with safety notes", hasDetail: true,  stable: true },
 


### PR DESCRIPTION
## Summary

Three feature areas, split across the three commits in this PR:

### 📡 New module — M5 RF433
Discrete M5Stack RF433T (TX) + RF433R (RX) units driven by two GPIO pins at fixed 433.92 MHz. No SPI, no CC1101 required. Adds **Modules → M5 RF433** with capture / send / jammer, mirroring Sub-GHz's UX. Pinout is set at build time (`M5RF433_TX_PIN` / `M5RF433_RX_PIN`, fallback to `GROVE_SDA` / `GROVE_SCL`) and **not** exposed in Pin Setting — Sub-GHz keeps the configurable pins because its SPI bus varies per board. Reuses `RCSwitchUtil` for the 23-protocol RX decoder + bit-bang TX, and shares the `/unigeek/rf/*.sub` file format with Sub-GHz so captures cross between the two modules freely.

### 📻 Sub-GHz — RX filter (RAW / Code), live toggle
- New `RxFilter` enum on `CC1101Util` (`RX_FILTER_CODE` vs `RX_FILTER_RAW`). `pollReceive()` honours it; default keeps the existing capture-everything behavior.
- Toggle is inline in **Receive** — no menu item. Footer shows the current mode next to `BACK: Stop`.
  - **4-way devices** (cardputer / adv, smoochie, marauder, sticks in Encoder mode): **LEFT** or **RIGHT**.
  - **2-way devices** (sticks default, T-Display, T-Embed CC1101, T-Lora Pager, CYD touch, CoreS3): **hold OK / PRESS for 500 ms**; the trailing release is consumed so it doesn't open the capture popup.

### 🔍 Signal Info view (Bruce-style) + Send tap popup
- New `CC1101Util::signalInfoText()` produces the multi-line breakdown (`Frequency / Protocol / Length / Key / TE / Binary` for RcSwitch; pulse count + Data head for RAW) — same fields Bruce's `display_signal_data` surfaces.
- New `STATE_SIGNAL_INFO` drives a `TextScrollView`. Reachable two ways:
  - **Captured signal popup**: `Info` is the new first option, above `Replay / Save / Delete`. BACK re-opens the same popup so the user can act without re-navigating to the item.
  - **Send file browser tap**: tap now opens a 2-option popup (`Send / Info`) instead of sending immediately. Hold (1 s) still shows the full `Send / Info / Rename / Delete`. `Info` parses the `.sub` via `CC1101Util::loadFile` and renders the same view.

Knowledge files (`knowledge/sub-ghz.md`, new `knowledge/m5-rf433.md`) and `website/content/features/catalog.js` updated.

## Test plan
- [x] `pio run -e m5_cardputer` — SUCCESS, ~94.9% flash
- [x] `pio run -e m5_cardputer_adv` — SUCCESS
- [x] `pio run -e m5stickcplus_11` — SUCCESS (verifies 2-way nav path compiles)
- [x] Field test on cardputer (4-way nav): LEFT/RIGHT toggles filter, Info → BACK returns to popup, tap-to-Send/Info popup in browse
- [ ] Field test on a 2-way device: hold-OK 500 ms toggles filter
- [ ] Cross-test: capture in M5 RF433, replay from Sub-GHz @ 433.92 MHz (and vice-versa)

