### PR TITLE
EAPOL Capture: Target mode + 10s WiFi scan

### DIFF
--- a/firmware/src/screens/wifi/WifiEapolCaptureScreen.cpp
+++ b/firmware/src/screens/wifi/WifiEapolCaptureScreen.cpp
@@ -700,6 +700,16 @@ void WifiEapolCaptureScreen::_flush() {
     const RawCapture& cap = _ring[_ringTail];
     _ringTail = (_ringTail + 1) % RING_SIZE;
 
+    // Target mode: drop everything that isn't the chosen AP. The promiscuous
+    // callback can't filter (it has no instance state), so collateral beacons
+    // / EAPOL on the same channel still arrive here — we discard them now so
+    // _apTargets stays at exactly one entry (the picked target) and the
+    // deauth burst only ever hits that BSSID.
+    if (_mode == MODE_TARGET &&
+        memcmp(cap.bssid.data(), _target.bssid, 6) != 0) {
+      continue;
+    }
+
     if (cap.isBeacon) {
       // Parse SSID from beacon IEs (802.11 header=24B + fixed params=12B = offset 36)
       bool newSsid = false;

--- a/firmware/src/screens/wifi/WifiEapolCaptureScreen.cpp
+++ b/firmware/src/screens/wifi/WifiEapolCaptureScreen.cpp
@@ -8,6 +8,7 @@
 #include "utils/StorageUtil.h"
 
 #include "utils/network/WifiAttackUtil.h"
+#include <WiFi.h>
 #include <cstring>
 
 // ── Static definitions ────────────────────────────────────────────────────
@@ -115,33 +116,85 @@ void WifiEapolCaptureScreen::onInit() {
 }
 
 void WifiEapolCaptureScreen::_showMenu() {
+  // Action ids used to keep onItemSelected mode-agnostic.
+  enum { ACT_MODE = 0, ACT_TARGET_WIFI, ACT_DISCOVERY_DWELL, ACT_ATTACK_DWELL,
+         ACT_MAX_DEAUTH, ACT_START };
+
+  _modeSub      = (_mode == MODE_TARGET) ? "Target" : "All";
+  _targetSub    = _target.ssid;
   _discoverySub = String(_discoveryDwellMs) + " ms";
   _attackSub    = String(_attackDwellMs) + " ms";
   _deauthSub    = String(_maxDeauthAttempts);
-  _menuItems[0] = {"Discovery Dwell", _discoverySub.c_str()};
-  _menuItems[1] = {"Attack Dwell", _attackSub.c_str()};
-  _menuItems[2] = {"Max Deauth", _deauthSub.c_str()};
-  _menuItems[3] = {"Start"};
-  setItems(_menuItems, 4);
+
+  _menuCount = 0;
+  auto add = [&](const char* label, const char* sub, uint8_t act) {
+    _menuItems[_menuCount] = {label, sub};
+    _menuMap[_menuCount]   = act;
+    _menuCount++;
+  };
+
+  add("Mode", _modeSub.c_str(), ACT_MODE);
+  if (_mode == MODE_TARGET) {
+    add("Target WiFi", _targetSub.c_str(), ACT_TARGET_WIFI);
+  } else {
+    add("Discovery Dwell", _discoverySub.c_str(), ACT_DISCOVERY_DWELL);
+    add("Attack Dwell",    _attackSub.c_str(),    ACT_ATTACK_DWELL);
+  }
+  add("Max Deauth", _deauthSub.c_str(), ACT_MAX_DEAUTH);
+  add("Start",      nullptr,            ACT_START);
+
+  setItems(_menuItems, _menuCount);
 }
 
 void WifiEapolCaptureScreen::onItemSelected(uint8_t index) {
+  if (_phase == PHASE_SELECT_WIFI) {
+    if (index >= _scanCount) return;
+    // _scanLabels[index] is "[ch] ssid"
+    _target.channel = atoi(_scanLabels[index] + 1);
+    const char* sp = strchr(_scanLabels[index], ']');
+    _target.ssid = (sp && sp[1]) ? String(sp + 2) : String("(hidden)");
+    sscanf(_scanValues[index], "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
+           &_target.bssid[0], &_target.bssid[1], &_target.bssid[2],
+           &_target.bssid[3], &_target.bssid[4], &_target.bssid[5]);
+    _phase = PHASE_MENU;
+    _showMenu();
+    return;
+  }
   if (_phase != PHASE_MENU) return;
 
-  switch (index) {
-    case 0:
+  if (index >= _menuCount) return;
+  enum { ACT_MODE = 0, ACT_TARGET_WIFI, ACT_DISCOVERY_DWELL, ACT_ATTACK_DWELL,
+         ACT_MAX_DEAUTH, ACT_START };
+  switch (_menuMap[index]) {
+    case ACT_MODE:
+      _mode = (_mode == MODE_TARGET) ? MODE_ALL : MODE_TARGET;
+      _showMenu();
+      break;
+    case ACT_TARGET_WIFI:
+      _selectWifi();
+      break;
+    case ACT_DISCOVERY_DWELL:
       _discoveryDwellMs = InputNumberAction::popup("Discovery Dwell (ms)", 250, 10000, _discoveryDwellMs);
       _showMenu();
       break;
-    case 1:
+    case ACT_ATTACK_DWELL:
       _attackDwellMs = InputNumberAction::popup("Attack Dwell (ms)", 250, 10000, _attackDwellMs);
       _showMenu();
       break;
-    case 2:
+    case ACT_MAX_DEAUTH:
       _maxDeauthAttempts = InputNumberAction::popup("Max Deauth Attempts", 5, 30, _maxDeauthAttempts);
       _showMenu();
       break;
-    case 3: {
+    case ACT_START: {
+      if (_mode == MODE_TARGET) {
+        bool unset = (_target.ssid == "-" || _target.channel == 0);
+        uint8_t blank[6] = {0};
+        if (unset && memcmp(_target.bssid, blank, 6) == 0) {
+          ShowStatusAction::show("Select a Target WiFi first!");
+          return;
+        }
+      }
+
       // Start capture
       _channel          = 0;
       _needRefresh      = false;
@@ -186,11 +239,37 @@ void WifiEapolCaptureScreen::onItemSelected(uint8_t index) {
       int ne = Achievement.inc("wifi_eapol_capture_started");
       if (ne == 1) Achievement.unlock("wifi_eapol_capture_started");
 
-      _logView.addLine("Discovery scan...", TFT_DARKGREY);
-
       _attacker = new WifiAttackUtil();
       esp_wifi_set_promiscuous(true);
       esp_wifi_set_promiscuous_rx_cb(&WifiEapolCaptureScreen::_promiscuousCb);
+
+      if (_mode == MODE_TARGET) {
+        // Seed the chosen AP and jump straight to PHASE_ATTACK on its channel.
+        // No discovery scan, no channel hopping, no rescan on failure.
+        MacAddr mac;
+        memcpy(mac.data(), _target.bssid, 6);
+        memcpy(_apTargets[0].bssid, _target.bssid, 6);
+        _apTargets[0].channel     = (uint8_t)_target.channel;
+        _apTargets[0].deauthCount = 0;
+        _apCount = 1;
+        _ssidMap[mac] = std::string(_target.ssid.c_str());
+
+        _phase           = PHASE_ATTACK;
+        _attackChans[0]  = (uint8_t)_target.channel;
+        _attackChanCount = 1;
+        _attackChanIdx   = 0;
+        _channel         = _target.channel;
+        _attacker->setChannel(_channel);
+        _deauthFired     = false;
+        // Beacons stay enabled briefly so we can capture one for the PCAP header.
+        // _flush() handles the beacon → PCAP write path normally.
+
+        char buf[44];
+        snprintf(buf, sizeof(buf), "Target: %s CH%d", _target.ssid.c_str(), _target.channel);
+        _logView.addLine(buf, TFT_CYAN);
+      } else {
+        _logView.addLine("Discovery scan...", TFT_DARKGREY);
+      }
 
       render();
       break;
@@ -198,8 +277,40 @@ void WifiEapolCaptureScreen::onItemSelected(uint8_t index) {
   }
 }
 
+void WifiEapolCaptureScreen::_selectWifi() {
+  _phase = PHASE_SELECT_WIFI;
+  ShowStatusAction::show("Scanning (10s)...", 0);
+
+  WiFi.mode(WIFI_STA);
+  WiFi.disconnect();
+  // 770 ms per channel × 13 channels ≈ 10 s — long sweep so weaker / less
+  // chatty APs have time to broadcast at least one beacon per channel.
+  const int total = WiFi.scanNetworks(false, false, false, 770, 0);
+
+  if (total <= 0) {
+    ShowStatusAction::show("No networks found");
+    _phase = PHASE_MENU;
+    _showMenu();
+    return;
+  }
+
+  _scanCount = total > MAX_SCAN ? MAX_SCAN : total;
+  for (int i = 0; i < _scanCount; i++) {
+    snprintf(_scanLabels[i], sizeof(_scanLabels[i]), "[%2d] %s",
+             WiFi.channel(i), WiFi.SSID(i).c_str());
+    snprintf(_scanValues[i], sizeof(_scanValues[i]), "%s",
+             WiFi.BSSIDstr(i).c_str());
+    _scanItems[i] = {_scanLabels[i], _scanValues[i]};
+  }
+
+  setItems(_scanItems, _scanCount);
+}
+
 void WifiEapolCaptureScreen::onUpdate() {
-  if (_phase == PHASE_MENU) { ListScreen::onUpdate(); return; }
+  if (_phase == PHASE_MENU || _phase == PHASE_SELECT_WIFI) {
+    ListScreen::onUpdate();
+    return;
+  }
 
   const unsigned long now = millis();
 
@@ -260,7 +371,26 @@ void WifiEapolCaptureScreen::onUpdate() {
       } else {
         _attackChanIdx++;
         if (_attackChanIdx >= _attackChanCount) {
-          // All attack channels exhausted — reset incomplete APs and rescan
+          if (_mode == MODE_TARGET) {
+            // Single target — either captured or out of attempts. Stop here.
+            MacAddr mac;
+            memcpy(mac.data(), _target.bssid, 6);
+            auto it = _eapolMap.find(mac);
+            const bool got = (it != _eapolMap.end() && it->second.validated);
+            _logView.addLine(got ? "Done. Handshake captured." : "Done. No handshake (timeout).",
+                             got ? TFT_GREEN : TFT_YELLOW);
+            _logView.addLine("BACK to exit.", TFT_DARKGREY);
+            render();
+            // Stop firing deauths; let user press BACK.
+            _phase = PHASE_ATTACK;  // keep state, but no more channels to attack
+            _attackChanIdx   = 0;
+            _attackChanCount = 0;
+            _chanDwellUntil  = ULONG_MAX;  // never re-fire
+            _deauthFired     = true;
+            return;
+          }
+
+          // All mode — reset incomplete APs and rescan
           for (int i = 0; i < _apCount; i++) {
             MacAddr mac;
             memcpy(mac.data(), _apTargets[i].bssid, 6);
@@ -307,11 +437,19 @@ void WifiEapolCaptureScreen::onUpdate() {
 }
 
 void WifiEapolCaptureScreen::onRender() {
-  if (_phase == PHASE_MENU) { ListScreen::onRender(); return; }
+  if (_phase == PHASE_MENU || _phase == PHASE_SELECT_WIFI) {
+    ListScreen::onRender();
+    return;
+  }
   _logView.draw(Uni.Lcd, bodyX(), bodyY(), bodyW(), bodyH(), _statusBarCb, this);
 }
 
 void WifiEapolCaptureScreen::onBack() {
+  if (_phase == PHASE_SELECT_WIFI) {
+    _phase = PHASE_MENU;
+    _showMenu();
+    return;
+  }
   Screen.goBack();
 }
 

--- a/firmware/src/screens/wifi/WifiEapolCaptureScreen.h
+++ b/firmware/src/screens/wifi/WifiEapolCaptureScreen.h
@@ -106,16 +106,40 @@ private:
   unsigned long _discoveryDwellMs = 1000;    // ms per channel during discovery scan
   unsigned long _attackDwellMs    = 8000;  // ms to stay on channel after deauth
 
+  // ── Mode (single AP vs every visible AP) ─────────────────────────────────
+  enum Mode { MODE_TARGET, MODE_ALL };
+  Mode  _mode = MODE_TARGET;
+
+  struct Target {
+    String  ssid    = "-";
+    uint8_t bssid[6] = {};
+    int     channel = 0;
+  };
+  Target _target;
+
   // ── Scan phase ────────────────────────────────────────────────────────────
-  enum Phase { PHASE_MENU, PHASE_DISCOVERY, PHASE_ATTACK };
+  enum Phase { PHASE_MENU, PHASE_SELECT_WIFI, PHASE_DISCOVERY, PHASE_ATTACK };
   Phase         _phase            = PHASE_MENU;
 
   // ── Menu items ────────────────────────────────────────────────────────────
-  ListItem      _menuItems[4]     = {};
+  static constexpr int MAX_MENU = 5;
+  ListItem      _menuItems[MAX_MENU] = {};
+  uint8_t       _menuCount       = 0;
+  uint8_t       _menuMap[MAX_MENU] = {};   // each entry → action id (see _showMenu)
+  String        _modeSub;
+  String        _targetSub;
   String        _discoverySub;
   String        _attackSub;
   String        _deauthSub;
   void          _showMenu();
+  void          _selectWifi();
+
+  // ── Network scan list ────────────────────────────────────────────────────
+  static constexpr int MAX_SCAN = 20;
+  ListItem _scanItems[MAX_SCAN];
+  char     _scanLabels[MAX_SCAN][52];
+  char     _scanValues[MAX_SCAN][18];
+  int      _scanCount = 0;
   int           _discoveryCount   = 0;    // channels scanned in current discovery pass
   uint8_t       _attackChans[13]  = {};   // unique channels with APs needing EAPOL
   int           _attackChanCount  = 0;

--- a/knowledge/eapol.md
+++ b/knowledge/eapol.md
@@ -7,19 +7,30 @@ Captures WPA2 4-way handshakes from nearby networks and saves them as PCAP files
 ### Setup
 
 1. Go to **WiFi > EAPOL Capture**
-2. Configure settings before starting:
-   - **Discovery Dwell** — Time spent per channel during scanning to discover SSID and BSSID (250–10000 ms, default 500)
-   - **Attack Dwell** — Time spent on a channel after sending deauth to get EAPOL (250–10000 ms, default 6000)
-   - **Max Deauth** — Maximum deauth attempts per AP before rescanning (5–30, default 20)
-3. **Start** — Begins the capture
+2. Pick a **Mode** at the top of the menu:
+   - **Target** (default) — attack a single AP that you choose from a live scan. The menu collapses to `Mode / Target WiFi / Max Deauth / Start` — Discovery/Attack Dwell are hidden because there is only one channel to attack.
+   - **All** — sweep every visible AP across all 13 channels. The menu becomes `Mode / Discovery Dwell / Attack Dwell / Max Deauth / Start`.
+3. Configure as needed:
+   - **Target WiFi** *(Target mode only)* — runs a ~10 s active scan across all 13 channels and lists each network as `[channel] SSID` with its BSSID; tap one to lock it in.
+   - **Discovery Dwell** *(All mode only)* — time per channel during scanning (250–10000 ms, default 1000).
+   - **Attack Dwell** *(All mode only)* — time on a channel after deauth (250–10000 ms, default 8000).
+   - **Max Deauth** — max deauth bursts per AP before giving up (5–30, default 10).
+4. **Start** — begins capture.
 
 ### How It Works
 
-1. **Discovery phase** — Scans all 13 channels to discover APs and collect beacon frames
-2. **Attack phase** — Sends deauth bursts to discovered APs to force clients to reconnect, capturing the EAPOL handshake during reconnection
-3. The deauth log shows progress as `[current/max]` (e.g., `Deauth CH6 (2 AP) [3/20]`)
+#### Target mode
+1. The selected AP is seeded directly into the attack list — no discovery scan, no channel hopping.
+2. The screen jumps straight to **Attack phase** on the target's channel and sends deauth bursts until either a valid handshake lands or `Max Deauth` is reached.
+3. On finish, the log shows `Done. Handshake captured.` (green) or `Done. No handshake (timeout).` (yellow) and waits. Press **BACK** to leave. No automatic rescan.
+
+#### All mode
+1. **Discovery phase** — scans all 13 channels to discover APs and collect beacon frames
+2. **Attack phase** — sends deauth bursts to discovered APs to force clients to reconnect, capturing the EAPOL handshake during reconnection
+3. The deauth log shows progress as `[current/max]` (e.g., `Deauth CH6 (2 AP) [3/10]`)
 4. When all APs are either captured or reach the max deauth limit, incomplete APs are reset and discovery restarts
-5. Validated handshakes (beacon + M1 + M2) are saved as PCAP files to `/unigeek/wifi/eapol/`
+
+Validated handshakes (beacon + M1 + M2) are saved as PCAP files to `/unigeek/wifi/eapol/` in both modes.
 
 ### Status Bar
 

--- a/knowledge/eapol.md
+++ b/knowledge/eapol.md
@@ -22,7 +22,8 @@ Captures WPA2 4-way handshakes from nearby networks and saves them as PCAP files
 #### Target mode
 1. The selected AP is seeded directly into the attack list — no discovery scan, no channel hopping.
 2. The screen jumps straight to **Attack phase** on the target's channel and sends deauth bursts until either a valid handshake lands or `Max Deauth` is reached.
-3. On finish, the log shows `Done. Handshake captured.` (green) or `Done. No handshake (timeout).` (yellow) and waits. Press **BACK** to leave. No automatic rescan.
+3. **Only the selected BSSID is deauthed.** Other APs that happen to broadcast on the same channel during the attack are filtered out — their beacons and EAPOL frames are dropped before `_apTargets` gets polluted. The deauth burst only ever hits the chosen network.
+4. On finish, the log shows `Done. Handshake captured.` (green) or `Done. No handshake (timeout).` (yellow) and waits. Press **BACK** to leave. No automatic rescan.
 
 #### All mode
 1. **Discovery phase** — scans all 13 channels to discover APs and collect beacon frames


### PR DESCRIPTION
## Summary

Adds a **Mode** option at the top of the EAPOL Capture menu so the user can attack a single AP from a live scan, instead of always sweeping every visible network.

### Target mode (default)
Menu collapses to:

```
Mode          Target
Target WiFi   <ssid you picked>
Max Deauth    10
Start
```

- **Target WiFi** runs `WiFi.scanNetworks(false, false, false, 770, 0)` — 770 ms × 13 channels ≈ **10 s active sweep** so weaker / less chatty APs still show up. Picking a network locks it in (SSID + BSSID + channel).
- **Start** seeds `_apTargets[0]` + `_ssidMap` directly from the picked network and jumps straight to `PHASE_ATTACK` on the target's channel — no discovery, no channel hop. Discovery / Attack Dwell are hidden because there's only one channel to attack.
- When the channel is exhausted (handshake validated or `Max Deauth` reached), the log prints either `Done. Handshake captured.` (green) or `Done. No handshake (timeout).` (yellow) and stops. **BACK** to leave. No automatic rescan.

### All mode
Menu becomes the original flow:

```
Mode             All
Discovery Dwell  1000 ms
Attack Dwell     8000 ms
Max Deauth       10
Start
```

Identical behavior to the previous default: sweep 13 channels, discover APs, attack everything in range.

### Wiring
- `WifiEapolCaptureScreen` gains `enum Mode { MODE_TARGET, MODE_ALL }`, a `Target` struct (ssid / bssid / channel), and a new `PHASE_SELECT_WIFI` state for the scan list.
- Menu items are now built dynamically via a `_menuMap[]` indirection so onItemSelected stays mode-agnostic.
- `PHASE_ATTACK` ends in Target mode when `_attackChanIdx >= _attackChanCount` instead of rescanning.

`knowledge/eapol.md` describes both flows.

## Test plan
- [x] `pio run -e m5_cardputer` — SUCCESS
- [x] Target mode: scan returns network list, pick one, attack runs only on that channel
- [x] Target mode: captures and stops cleanly
- [x] Target mode: out-of-attempts shows timeout message
- [x] All mode: original behavior preserved

