### PR TITLE
File navigation: speed up listDir + ".." parent entry across modules

### DIFF
--- a/firmware/src/core/StorageLFS.h
+++ b/firmware/src/core/StorageLFS.h
@@ -86,11 +86,15 @@ public:
     if (!dir) return 0;
     uint8_t count = 0;
     while (count < max) {
-      fs::File f = dir.openNextFile();
-      if (!f) break;
-      out[count].name  = f.name();
-      out[count].isDir = f.isDirectory();
-      f.close();
+      // Lightweight iteration — no File handle allocated per entry. Matches
+      // Bruce's readFs and dramatically reduces open/close overhead on
+      // directories with many entries.
+      bool   isDir;
+      String full = dir.getNextFileName(&isDir);
+      if (full.length() == 0) break;
+      int slash = full.lastIndexOf('/');
+      out[count].name  = (slash >= 0) ? full.substring(slash + 1) : full;
+      out[count].isDir = isDir;
       count++;
     }
     dir.close();

--- a/firmware/src/core/StorageSD.h
+++ b/firmware/src/core/StorageSD.h
@@ -127,11 +127,15 @@ public:
     if (!dir) return 0;
     uint8_t count = 0;
     while (count < max) {
-      File f = dir.openNextFile();
-      if (!f) break;
-      out[count].name  = f.name();
-      out[count].isDir = f.isDirectory();
-      f.close();
+      // Lightweight iteration — no File handle allocated per entry. Same
+      // approach Bruce uses; orders of magnitude faster on large directories
+      // (e.g. Flipper IRDB folders with 100+ entries) than openNextFile().
+      bool   isDir;
+      String full = dir.getNextFileName(&isDir);
+      if (full.length() == 0) break;
+      int slash = full.lastIndexOf('/');
+      out[count].name  = (slash >= 0) ? full.substring(slash + 1) : full;
+      out[count].isDir = isDir;
       count++;
     }
     dir.close();

--- a/firmware/src/screens/LuaScreen.cpp
+++ b/firmware/src/screens/LuaScreen.cpp
@@ -8,7 +8,7 @@
 
 void LuaScreen::_loadDir(const String& path) {
   _currentDir = path;
-  _browser.load(this, path, ".lua");
+  _browser.load(this, path, ".lua", nullptr, /*prependParent=*/true);
   setItems(_browser.items(), _browser.count());
 }
 
@@ -61,13 +61,12 @@ void LuaScreen::onRender() {
 
 void LuaScreen::onBack() {
   if (_state != STATE_BROWSE) return;
-  if (_currentDir == ROOT_DIR) {
+  if (_currentDir == "/" || _currentDir.length() == 0) {
     Screen.goBack();
     return;
   }
   int slash = _currentDir.lastIndexOf('/');
-  String parent = (slash > 0) ? _currentDir.substring(0, slash) : ROOT_DIR;
-  if (parent.length() == 0) parent = ROOT_DIR;
+  String parent = (slash > 0) ? _currentDir.substring(0, slash) : "/";
   _loadDir(parent);
 }
 

--- a/firmware/src/screens/LuaScreen.cpp
+++ b/firmware/src/screens/LuaScreen.cpp
@@ -8,7 +8,10 @@
 
 void LuaScreen::_loadDir(const String& path) {
   _currentDir = path;
-  _browser.load(this, path, ".lua", nullptr, /*prependParent=*/true);
+  // _browser.root confines the picker to ROOT_DIR — ".." appears below but
+  // never resolves above /unigeek/lua.
+  _browser.root = ROOT_DIR;
+  _browser.load(this, path, ".lua");
   setItems(_browser.items(), _browser.count());
 }
 
@@ -61,12 +64,13 @@ void LuaScreen::onRender() {
 
 void LuaScreen::onBack() {
   if (_state != STATE_BROWSE) return;
-  if (_currentDir == "/" || _currentDir.length() == 0) {
+  // Clamp at ROOT_DIR — never climb above /unigeek/lua.
+  if (_currentDir == ROOT_DIR || _currentDir.length() == 0) {
     Screen.goBack();
     return;
   }
   int slash = _currentDir.lastIndexOf('/');
-  String parent = (slash > 0) ? _currentDir.substring(0, slash) : "/";
+  String parent = (slash > 0) ? _currentDir.substring(0, slash) : ROOT_DIR;
   _loadDir(parent);
 }
 

--- a/firmware/src/screens/ble/chameleon/ChameleonMfcDictScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonMfcDictScreen.cpp
@@ -37,11 +37,18 @@ uint8_t ChameleonMfcDictScreen::_trailerBlock(uint8_t sector) {
 }
 
 void ChameleonMfcDictScreen::_loadFilePicker() {
-  _items[0] = {"Built-in keys"};
-  uint8_t n = _browser.load(this, kDictDir, ".txt");
-  for (uint8_t i = 0; i < n; i++) _items[1 + i] = _browser.items()[i];
+  if (_pickDir.length() == 0) _pickDir = kDictDir;
+  uint8_t n = _browser.load(this, _pickDir, ".txt", nullptr, /*prependParent=*/true);
+
+  // "Built-in keys" only at the default kDictDir — pinned at index 0.
+  uint8_t baseOffset = 0;
+  if (_pickDir == kDictDir) {
+    _items[0]   = {"Built-in keys"};
+    baseOffset  = 1;
+  }
+  for (uint8_t i = 0; i < n; i++) _items[i + baseOffset] = _browser.items()[i];
   _fileCount = n;
-  setItems(_items, 1 + n);
+  setItems(_items, (uint8_t)(n + baseOffset));
 }
 
 void ChameleonMfcDictScreen::onInit() {
@@ -50,6 +57,19 @@ void ChameleonMfcDictScreen::onInit() {
 }
 
 void ChameleonMfcDictScreen::onBack() {
+  if (_state == STATE_SELECT) {
+    // Climb the picker. At "/" or empty, exit the screen.
+    if (_pickDir == "/" || _pickDir.length() == 0) {
+      _pickDir = "";
+      Screen.goBack();
+      return;
+    }
+    int slash = _pickDir.lastIndexOf('/');
+    _pickDir = (slash > 0) ? _pickDir.substring(0, slash) : "/";
+    _loadFilePicker();
+    render();
+    return;
+  }
   Screen.goBack();
 }
 
@@ -116,19 +136,29 @@ void ChameleonMfcDictScreen::onRender() {
 void ChameleonMfcDictScreen::onItemSelected(uint8_t index) {
   if (_state != STATE_SELECT) return;
 
+  // Index 0 is "Built-in keys" only when in the default kDictDir.
+  uint8_t baseOffset = (_pickDir == kDictDir) ? 1 : 0;
+
   char srcLabel[40];
-  if (index == 0) {
+  if (baseOffset && index == 0) {
     _loadBuiltinKeys();
     snprintf(srcLabel, sizeof(srcLabel), "Built-in");
   } else {
-    uint8_t fi = index - 1;
+    uint8_t fi = index - baseOffset;
     if (fi >= _browser.count()) return;
-    if (!_loadFileKeys(_browser.entry(fi).path.c_str())) {
+    const auto& e = _browser.entry(fi);
+    if (e.isDir) {                       // ".." or any subdir
+      _pickDir = e.path;
+      _loadFilePicker();
+      render();
+      return;
+    }
+    if (!_loadFileKeys(e.path.c_str())) {
       ShowStatusAction::show("Load keys failed", 1200);
       render();
       return;
     }
-    snprintf(srcLabel, sizeof(srcLabel), "%s", _browser.entry(fi).name.c_str());
+    snprintf(srcLabel, sizeof(srcLabel), "%s", e.name.c_str());
   }
 
   if (_keyCount == 0) {

--- a/firmware/src/screens/ble/chameleon/ChameleonMfcDictScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonMfcDictScreen.cpp
@@ -38,7 +38,8 @@ uint8_t ChameleonMfcDictScreen::_trailerBlock(uint8_t sector) {
 
 void ChameleonMfcDictScreen::_loadFilePicker() {
   if (_pickDir.length() == 0) _pickDir = kDictDir;
-  uint8_t n = _browser.load(this, _pickDir, ".txt", nullptr, /*prependParent=*/true);
+  _browser.root = kDictDir;
+  uint8_t n = _browser.load(this, _pickDir, ".txt");
 
   // "Built-in keys" only at the default kDictDir — pinned at index 0.
   uint8_t baseOffset = 0;
@@ -58,14 +59,14 @@ void ChameleonMfcDictScreen::onInit() {
 
 void ChameleonMfcDictScreen::onBack() {
   if (_state == STATE_SELECT) {
-    // Climb the picker. At "/" or empty, exit the screen.
-    if (_pickDir == "/" || _pickDir.length() == 0) {
+    // Clamp at kDictDir — never climb above /unigeek/nfc/dictionaries.
+    if (_pickDir == kDictDir || _pickDir.length() == 0) {
       _pickDir = "";
       Screen.goBack();
       return;
     }
     int slash = _pickDir.lastIndexOf('/');
-    _pickDir = (slash > 0) ? _pickDir.substring(0, slash) : "/";
+    _pickDir = (slash > 0) ? _pickDir.substring(0, slash) : kDictDir;
     _loadFilePicker();
     render();
     return;

--- a/firmware/src/screens/ble/chameleon/ChameleonMfcDictScreen.h
+++ b/firmware/src/screens/ble/chameleon/ChameleonMfcDictScreen.h
@@ -25,6 +25,7 @@ private:
   BrowseFileView _browser;
   ListItem _items[1 + BrowseFileView::kCap];    // "Built-in" + file list
   uint8_t  _fileCount = 0;
+  String   _pickDir;            // current directory in the picker
 
   // ── Attack state ──
   uint8_t  _uid[7]    = {};

--- a/firmware/src/screens/ble/chameleon/ChameleonMfcScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonMfcScreen.cpp
@@ -404,12 +404,18 @@ void ChameleonMfcScreen::_callDump() {
 // ── Dictionary Attack ──
 
 void ChameleonMfcScreen::_loadDictPicker() {
-  _dictItems[0] = {"Built-in keys"};
-  uint8_t n = _browser.load(this, _kDictDir, ".txt");
-  for (uint8_t i = 0; i < n; i++) _dictItems[1 + i] = _browser.items()[i];
+  if (_dictPickDir.length() == 0) _dictPickDir = _kDictDir;
+  uint8_t n = _browser.load(this, _dictPickDir, ".txt", nullptr, /*prependParent=*/true);
+
+  uint8_t baseOffset = 0;
+  if (_dictPickDir == _kDictDir) {
+    _dictItems[0] = {"Built-in keys"};
+    baseOffset    = 1;
+  }
+  for (uint8_t i = 0; i < n; i++) _dictItems[i + baseOffset] = _browser.items()[i];
   _dictFileCount = n;
   _state = STATE_DICT_SEL;
-  setItems(_dictItems, 1 + n);
+  setItems(_dictItems, (uint8_t)(n + baseOffset));
   render();
 }
 
@@ -1034,13 +1040,20 @@ void ChameleonMfcScreen::onItemSelected(uint8_t index) {
       case 4: _callNestedAttack();    break;
     }
   } else if (_state == STATE_DICT_SEL) {
-    if (index == 0) {
+    uint8_t baseOffset = (_dictPickDir == _kDictDir) ? 1 : 0;
+    if (baseOffset && index == 0) {
       _dictKeyCount = kMfcBuiltinCount;
       memcpy(_dictKeys, kMfcBuiltinKeys, kMfcBuiltinCount * 6);
     } else {
-      uint8_t fi = index - 1;
+      uint8_t fi = index - baseOffset;
       if (fi >= _browser.count()) return;
-      if (!_loadDictFile(_browser.entry(fi).path.c_str())) {
+      const auto& e = _browser.entry(fi);
+      if (e.isDir) {
+        _dictPickDir = e.path;
+        _loadDictPicker();
+        return;
+      }
+      if (!_loadDictFile(e.path.c_str())) {
         ShowStatusAction::show("Load keys failed", 1200);
         render();
         return;
@@ -1059,8 +1072,19 @@ void ChameleonMfcScreen::onBack() {
   switch (_state) {
     case STATE_MF_MENU:
       Screen.goBack(); break;
+    case STATE_DICT_SEL: {
+      // Climb the picker; exit to MF menu only when already at "/".
+      if (_dictPickDir == "/" || _dictPickDir.length() == 0) {
+        _dictPickDir = "";
+        _goMfMenu();
+        return;
+      }
+      int slash = _dictPickDir.lastIndexOf('/');
+      _dictPickDir = (slash > 0) ? _dictPickDir.substring(0, slash) : "/";
+      _loadDictPicker();
+      return;
+    }
     case STATE_SHOW_KEYS:
-    case STATE_DICT_SEL:
     case STATE_STATIC_NESTED_LOG:
     case STATE_NESTED_LOG:
       _goMfMenu(); break;

--- a/firmware/src/screens/ble/chameleon/ChameleonMfcScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonMfcScreen.cpp
@@ -405,7 +405,8 @@ void ChameleonMfcScreen::_callDump() {
 
 void ChameleonMfcScreen::_loadDictPicker() {
   if (_dictPickDir.length() == 0) _dictPickDir = _kDictDir;
-  uint8_t n = _browser.load(this, _dictPickDir, ".txt", nullptr, /*prependParent=*/true);
+  _browser.root = _kDictDir;
+  uint8_t n = _browser.load(this, _dictPickDir, ".txt");
 
   uint8_t baseOffset = 0;
   if (_dictPickDir == _kDictDir) {
@@ -1073,14 +1074,14 @@ void ChameleonMfcScreen::onBack() {
     case STATE_MF_MENU:
       Screen.goBack(); break;
     case STATE_DICT_SEL: {
-      // Climb the picker; exit to MF menu only when already at "/".
-      if (_dictPickDir == "/" || _dictPickDir.length() == 0) {
+      // Clamp at _kDictDir — never climb above /unigeek/nfc/dictionaries.
+      if (_dictPickDir == _kDictDir || _dictPickDir.length() == 0) {
         _dictPickDir = "";
         _goMfMenu();
         return;
       }
       int slash = _dictPickDir.lastIndexOf('/');
-      _dictPickDir = (slash > 0) ? _dictPickDir.substring(0, slash) : "/";
+      _dictPickDir = (slash > 0) ? _dictPickDir.substring(0, slash) : _kDictDir;
       _loadDictPicker();
       return;
     }

--- a/firmware/src/screens/ble/chameleon/ChameleonMfcScreen.h
+++ b/firmware/src/screens/ble/chameleon/ChameleonMfcScreen.h
@@ -80,6 +80,7 @@ private:
   BrowseFileView _browser;
   ListItem _dictItems[1 + BrowseFileView::kCap];
   uint8_t  _dictFileCount = 0;
+  String   _dictPickDir;        // current directory in the dict picker
   static constexpr uint16_t MAX_DICT_KEYS = 256;
   uint8_t  _dictKeys[MAX_DICT_KEYS][6] = {};
   uint16_t _dictKeyCount = 0;

--- a/firmware/src/screens/ble/chameleon/ChameleonSlotEditScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonSlotEditScreen.cpp
@@ -307,34 +307,26 @@ void ChameleonSlotEditScreen::_writeContent() {
   if (!f) { render(); return; }
 
   if (strcmp(f, "hf") == 0) {
-    // Pick a .bin file from the dumps dir.
+    // Pick a .bin file from the dumps dir via BrowseFileView (sorted + filtered).
     static constexpr uint8_t kMax = 10;
-    IStorage::DirEntry entries[kMax];
-    String names[kMax];
-    uint8_t count = 0;
-    if (Uni.Storage && Uni.Storage->isAvailable()) {
-      uint8_t total = Uni.Storage->listDir("/unigeek/nfc/dumps", entries, kMax);
-      for (uint8_t i = 0; i < total && count < kMax; i++) {
-        if (!entries[i].isDir && entries[i].name.endsWith(".bin")) {
-          names[count++] = entries[i].name;
-        }
-      }
-    }
-    if (count == 0) {
+    uint8_t n = _browser.load(this, "/unigeek/nfc/dumps", ".bin");
+    if (n == 0) {
       ShowStatusAction::show("No .bin in nfc/dumps", 1500);
       render();
       return;
     }
+    uint8_t count = (n < kMax) ? n : kMax;
     InputSelectAction::Option opts[kMax];
     String vals[kMax];
     for (uint8_t i = 0; i < count; i++) {
       vals[i] = String(i);
-      opts[i] = { names[i].c_str(), vals[i].c_str() };
+      opts[i] = { _browser.entry(i).name.c_str(), vals[i].c_str() };
     }
     const char* r = InputSelectAction::popup("HF dump", opts, count, nullptr);
     if (!r) { render(); return; }
     uint8_t idx = (uint8_t)atoi(r);
-    String path = String("/unigeek/nfc/dumps/") + names[idx];
+    if (idx >= count) { render(); return; }
+    String path = _browser.entry(idx).path;
     bool ok = _writeHfFromBin(path.c_str());
     ShowStatusAction::show(ok ? "HF loaded to slot" : "HF load failed", 1500);
     if (ok) {

--- a/firmware/src/screens/ble/chameleon/ChameleonSlotEditScreen.h
+++ b/firmware/src/screens/ble/chameleon/ChameleonSlotEditScreen.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "ui/templates/ListScreen.h"
+#include "ui/views/BrowseFileView.h"
 
 class ChameleonSlotEditScreen : public ListScreen {
 public:
@@ -20,6 +21,8 @@ private:
   ListItem _items[kCount];
   char     _labels[kCount][22];
   char     _subs[kCount][22];
+
+  BrowseFileView _browser;  // shared file picker (HF dump browse)
 
   uint16_t _hfType    = 0;
   uint16_t _lfType    = 0;

--- a/firmware/src/screens/game/GameMusicComposerScreen.cpp
+++ b/firmware/src/screens/game/GameMusicComposerScreen.cpp
@@ -150,8 +150,15 @@ void GameMusicComposerScreen::onRender() {
 }
 
 void GameMusicComposerScreen::onBack() {
-  if (_state == STATE_FILES || _state == STATE_BUILTIN) { _enterMenu(); return; }
-  if (_state == STATE_EDIT || _state == STATE_PLAY)     { _enterMenu(); return; }
+  if (_state == STATE_FILES) {
+    if (_filesDir == "/" || _filesDir.length() == 0) { _enterMenu(); return; }
+    int slash = _filesDir.lastIndexOf('/');
+    _filesDir = (slash > 0) ? _filesDir.substring(0, slash) : "/";
+    _enterFiles();
+    return;
+  }
+  if (_state == STATE_BUILTIN)                       { _enterMenu(); return; }
+  if (_state == STATE_EDIT || _state == STATE_PLAY)  { _enterMenu(); return; }
   Screen.goBack();
 }
 
@@ -166,13 +173,17 @@ void GameMusicComposerScreen::onItemSelected(uint8_t index) {
   }
   if (_state == STATE_FILES) {
     const auto& e = _browser.entry(index);
-    if (e.isDir) return;  // music dir is flat — ignore
+    if (e.isDir) {                       // ".." or any subdir
+      _filesDir = e.path;
+      _enterFiles();
+      return;
+    }
     if (_loadFile(e.path)) {
       _filename = e.path;
       _enterEdit();
     } else {
       ShowStatusAction::show("Load failed");
-      render();  // ShowStatusAction left a black hole in the file list
+      render();
     }
     return;
   }
@@ -203,8 +214,10 @@ void GameMusicComposerScreen::_enterMenu() {
 
 void GameMusicComposerScreen::_enterFiles() {
   _state = STATE_FILES;
-  uint8_t n = _browser.load(this, kMusicDir, BrowseFileView::Mode(".rtttl"), "song");
-  if (n == 0) {
+  if (_filesDir.length() == 0) _filesDir = kMusicDir;
+  uint8_t n = _browser.load(this, _filesDir, BrowseFileView::Mode(".rtttl"),
+                            "song", /*prependParent=*/true);
+  if (n == 0 && _filesDir == kMusicDir) {
     ShowStatusAction::show("No saved songs");
     _enterMenu();
     return;

--- a/firmware/src/screens/game/GameMusicComposerScreen.cpp
+++ b/firmware/src/screens/game/GameMusicComposerScreen.cpp
@@ -151,9 +151,9 @@ void GameMusicComposerScreen::onRender() {
 
 void GameMusicComposerScreen::onBack() {
   if (_state == STATE_FILES) {
-    if (_filesDir == "/" || _filesDir.length() == 0) { _enterMenu(); return; }
+    if (_filesDir == kMusicDir || _filesDir.length() == 0) { _enterMenu(); return; }
     int slash = _filesDir.lastIndexOf('/');
-    _filesDir = (slash > 0) ? _filesDir.substring(0, slash) : "/";
+    _filesDir = (slash > 0) ? _filesDir.substring(0, slash) : kMusicDir;
     _enterFiles();
     return;
   }
@@ -215,8 +215,8 @@ void GameMusicComposerScreen::_enterMenu() {
 void GameMusicComposerScreen::_enterFiles() {
   _state = STATE_FILES;
   if (_filesDir.length() == 0) _filesDir = kMusicDir;
-  uint8_t n = _browser.load(this, _filesDir, BrowseFileView::Mode(".rtttl"),
-                            "song", /*prependParent=*/true);
+  _browser.root = kMusicDir;
+  uint8_t n = _browser.load(this, _filesDir, BrowseFileView::Mode(".rtttl"), "song");
   if (n == 0 && _filesDir == kMusicDir) {
     ShowStatusAction::show("No saved songs");
     _enterMenu();

--- a/firmware/src/screens/game/GameMusicComposerScreen.h
+++ b/firmware/src/screens/game/GameMusicComposerScreen.h
@@ -46,6 +46,7 @@ private:
 
   // ── File listing ─────────────────────────────────────────────────────────────
   BrowseFileView _browser;
+  String         _filesDir;   // current directory in the Open Saved... browser
 
   // ── Menu items (one buffer reused per state) ─────────────────────────────────
   ListItem  _menuItems[3];

--- a/firmware/src/screens/hid/KeyboardScreen.cpp
+++ b/firmware/src/screens/hid/KeyboardScreen.cpp
@@ -187,12 +187,13 @@ void KeyboardScreen::onItemSelected(uint8_t index)
 void KeyboardScreen::onBack()
 {
   if (_state == STATE_SELECT_FILE) {
-    int slash = _curPath.lastIndexOf('/');
-    if (slash > 0 && _curPath != kDuckyBase) {
-      _showFiles(_curPath.substring(0, slash));
-    } else {
+    if (_curPath == "/" || _curPath.length() == 0) {
       _goMenu();
+      return;
     }
+    int slash = _curPath.lastIndexOf('/');
+    String parent = (slash > 0) ? _curPath.substring(0, slash) : "/";
+    _showFiles(parent);
   } else if (_state == STATE_MEDIA_MENU) {
     _goMenu();
   } else {
@@ -253,7 +254,7 @@ void KeyboardScreen::_showFiles(const String& path)
 
   _curPath = path;
   _state   = STATE_SELECT_FILE;
-  uint8_t n = _browser.load(this, path);
+  uint8_t n = _browser.load(this, path, BrowseFileView::Mode{}, nullptr, /*prependParent=*/true);
 
   if (n == 0) {
     ShowStatusAction::show("No files found", 1500);

--- a/firmware/src/screens/hid/KeyboardScreen.cpp
+++ b/firmware/src/screens/hid/KeyboardScreen.cpp
@@ -187,12 +187,14 @@ void KeyboardScreen::onItemSelected(uint8_t index)
 void KeyboardScreen::onBack()
 {
   if (_state == STATE_SELECT_FILE) {
-    if (_curPath == "/" || _curPath.length() == 0) {
+    // Clamp at kDuckyBase — don't let the picker climb above /unigeek/hid/duckyscript
+    // into the rest of the SD card.
+    if (_curPath == kDuckyBase || _curPath.length() == 0) {
       _goMenu();
       return;
     }
     int slash = _curPath.lastIndexOf('/');
-    String parent = (slash > 0) ? _curPath.substring(0, slash) : "/";
+    String parent = (slash > 0) ? _curPath.substring(0, slash) : kDuckyBase;
     _showFiles(parent);
   } else if (_state == STATE_MEDIA_MENU) {
     _goMenu();
@@ -254,7 +256,10 @@ void KeyboardScreen::_showFiles(const String& path)
 
   _curPath = path;
   _state   = STATE_SELECT_FILE;
-  uint8_t n = _browser.load(this, path, BrowseFileView::Mode{}, nullptr, /*prependParent=*/true);
+  // ".." only below the screen's root — _browser.root clamps the parent
+  // entry so the picker can never escape /unigeek/hid/duckyscript.
+  _browser.root = kDuckyBase;
+  uint8_t n = _browser.load(this, path);
 
   if (n == 0) {
     ShowStatusAction::show("No files found", 1500);

--- a/firmware/src/screens/module/IRScreen.cpp
+++ b/firmware/src/screens/module/IRScreen.cpp
@@ -120,14 +120,13 @@ void IRScreen::onBack() {
     _ir.end();
     _showMenu();
   } else if (_state == STATE_SEND_BROWSE) {
-    // Navigate up or back to menu
-    if (_browsePath == kRootPath) {
+    // Climb to parent if possible; exit to menu only when already at "/".
+    // Lets users browse out of /unigeek/ir into any directory on storage.
+    if (_browsePath == "/" || _browsePath.length() == 0) {
       _showMenu();
     } else {
       int slash = _browsePath.lastIndexOf('/');
-      String parent = (slash > 0) ? _browsePath.substring(0, slash) : String(kRootPath);
-      // Don't go above root
-      if (parent.length() < String(kRootPath).length()) parent = kRootPath;
+      String parent = (slash > 0) ? _browsePath.substring(0, slash) : "/";
       _loadBrowseDir(parent);
     }
   } else if (_state == STATE_SEND_LIST) {
@@ -418,7 +417,7 @@ void IRScreen::_loadBrowseDir(const String& path) {
   if (path == kRootPath) folderName = "IR Files";
   snprintf(_titleBuf, sizeof(_titleBuf), "%s", folderName.c_str());
 
-  uint8_t n = _browser.load(this, path, ".ir");
+  uint8_t n = _browser.load(this, path, ".ir", nullptr, /*prependParent=*/true);
 
   if (n == 0 && path == kRootPath) {
     ShowStatusAction::show("No IR files found in /unigeek/ir/");

--- a/firmware/src/screens/module/IRScreen.cpp
+++ b/firmware/src/screens/module/IRScreen.cpp
@@ -120,13 +120,13 @@ void IRScreen::onBack() {
     _ir.end();
     _showMenu();
   } else if (_state == STATE_SEND_BROWSE) {
-    // Climb to parent if possible; exit to menu only when already at "/".
-    // Lets users browse out of /unigeek/ir into any directory on storage.
-    if (_browsePath == "/" || _browsePath.length() == 0) {
+    // Climb to parent if below kRootPath; at the screen's root, exit to menu.
+    // Keeps the picker confined to /unigeek/ir — no whole-SD-card browse.
+    if (_browsePath == kRootPath || _browsePath.length() == 0) {
       _showMenu();
     } else {
       int slash = _browsePath.lastIndexOf('/');
-      String parent = (slash > 0) ? _browsePath.substring(0, slash) : "/";
+      String parent = (slash > 0) ? _browsePath.substring(0, slash) : kRootPath;
       _loadBrowseDir(parent);
     }
   } else if (_state == STATE_SEND_LIST) {
@@ -417,7 +417,8 @@ void IRScreen::_loadBrowseDir(const String& path) {
   if (path == kRootPath) folderName = "IR Files";
   snprintf(_titleBuf, sizeof(_titleBuf), "%s", folderName.c_str());
 
-  uint8_t n = _browser.load(this, path, ".ir", nullptr, /*prependParent=*/true);
+  _browser.root = kRootPath;
+  uint8_t n = _browser.load(this, path, ".ir");
 
   if (n == 0 && path == kRootPath) {
     ShowStatusAction::show("No IR files found in /unigeek/ir/");

--- a/firmware/src/screens/module/MFRC522Screen.cpp
+++ b/firmware/src/screens/module/MFRC522Screen.cpp
@@ -137,7 +137,16 @@ void MFRC522Screen::onBack() {
     _currentCard = {};
     _mf1AuthKeys.fill({});
     _goMainMenu();
-  } else if (_state == STATE_SHOW_KEY || _state == STATE_MEMORY_READER || _state == STATE_DICT_SELECT || _state == STATE_NESTED || _state == STATE_STATIC_NESTED) {
+  } else if (_state == STATE_DICT_SELECT) {
+    if (_dictPickDir == "/" || _dictPickDir.length() == 0) {
+      _dictPickDir = "";
+      _goMifareClassic();
+    } else {
+      int slash = _dictPickDir.lastIndexOf('/');
+      _dictPickDir = (slash > 0) ? _dictPickDir.substring(0, slash) : "/";
+      _callDictionaryAttack();
+    }
+  } else if (_state == STATE_SHOW_KEY || _state == STATE_MEMORY_READER || _state == STATE_NESTED || _state == STATE_STATIC_NESTED) {
     _goMifareClassic();
   }
 }
@@ -623,8 +632,9 @@ void MFRC522Screen::_callMemoryReader() {
 
 void MFRC522Screen::_callDictionaryAttack() {
   _state = STATE_DICT_SELECT;
-  uint8_t n = _browser.load(this, _dictPath, ".txt");
-  if (n == 0) {
+  if (_dictPickDir.length() == 0) _dictPickDir = _dictPath;
+  uint8_t n = _browser.load(this, _dictPickDir, ".txt", nullptr, /*prependParent=*/true);
+  if (n == 0 && _dictPickDir == _dictPath) {
     ShowStatusAction::show("No dictionary files in nfc/dictionaries/");
     _goMifareClassic();
     return;
@@ -654,8 +664,13 @@ static bool _parseHexKey(const String& line, uint8_t* out) {
 
 void MFRC522Screen::_callDictAttackWithFile(uint8_t fileIndex) {
   if (fileIndex >= _browser.count()) return;
-
-  String filePath = _browser.entry(fileIndex).path;
+  const auto& e = _browser.entry(fileIndex);
+  if (e.isDir) {
+    _dictPickDir = e.path;
+    _callDictionaryAttack();
+    return;
+  }
+  String filePath = e.path;
   String content = Uni.Storage->readFile(filePath.c_str());
   if (content.length() == 0) {
     ShowStatusAction::show("Empty dictionary file");

--- a/firmware/src/screens/module/MFRC522Screen.cpp
+++ b/firmware/src/screens/module/MFRC522Screen.cpp
@@ -138,12 +138,12 @@ void MFRC522Screen::onBack() {
     _mf1AuthKeys.fill({});
     _goMainMenu();
   } else if (_state == STATE_DICT_SELECT) {
-    if (_dictPickDir == "/" || _dictPickDir.length() == 0) {
+    if (_dictPickDir == _dictPath || _dictPickDir.length() == 0) {
       _dictPickDir = "";
       _goMifareClassic();
     } else {
       int slash = _dictPickDir.lastIndexOf('/');
-      _dictPickDir = (slash > 0) ? _dictPickDir.substring(0, slash) : "/";
+      _dictPickDir = (slash > 0) ? _dictPickDir.substring(0, slash) : _dictPath;
       _callDictionaryAttack();
     }
   } else if (_state == STATE_SHOW_KEY || _state == STATE_MEMORY_READER || _state == STATE_NESTED || _state == STATE_STATIC_NESTED) {
@@ -633,7 +633,8 @@ void MFRC522Screen::_callMemoryReader() {
 void MFRC522Screen::_callDictionaryAttack() {
   _state = STATE_DICT_SELECT;
   if (_dictPickDir.length() == 0) _dictPickDir = _dictPath;
-  uint8_t n = _browser.load(this, _dictPickDir, ".txt", nullptr, /*prependParent=*/true);
+  _browser.root = _dictPath;
+  uint8_t n = _browser.load(this, _dictPickDir, ".txt");
   if (n == 0 && _dictPickDir == _dictPath) {
     ShowStatusAction::show("No dictionary files in nfc/dictionaries/");
     _goMifareClassic();

--- a/firmware/src/screens/module/MFRC522Screen.h
+++ b/firmware/src/screens/module/MFRC522Screen.h
@@ -101,6 +101,7 @@ private:
   // Dictionary attack file selection
   static constexpr const char* _dictPath = "/unigeek/nfc/dictionaries";
   BrowseFileView _browser;
+  String         _dictPickDir;     // current dir in the dict picker
 
   std::string _uidToString(byte* uid, byte len) {
     std::string s;

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -206,7 +206,14 @@ void PN532I2cScreen::onBack() {
       _goMain();
       break;
     case STATE_DICT_SELECT:
-      _goMifare();
+      if (_dictPickDir == "/" || _dictPickDir.length() == 0) {
+        _dictPickDir = "";
+        _goMifare();
+      } else {
+        int slash = _dictPickDir.lastIndexOf('/');
+        _dictPickDir = (slash > 0) ? _dictPickDir.substring(0, slash) : "/";
+        _doDictionaryPicker();
+      }
       break;
     case STATE_NTAG_MENU:
       _goMain();
@@ -600,8 +607,9 @@ void PN532I2cScreen::_doDictionaryPicker() {
   if (!_hasCard) { ShowStatusAction::show("Authenticate first"); _goMifare(); return; }
 
   _state = STATE_DICT_SELECT;
-  uint8_t n = _browser.load(this, _dictPath, ".txt");
-  if (n == 0) {
+  if (_dictPickDir.length() == 0) _dictPickDir = _dictPath;
+  uint8_t n = _browser.load(this, _dictPickDir, ".txt", nullptr, /*prependParent=*/true);
+  if (n == 0 && _dictPickDir == _dictPath) {
     ShowStatusAction::show("No dictionary files");
     _goMifare();
     return;
@@ -626,7 +634,13 @@ static bool _parseHexKeyI2c(const String& line, uint8_t out[6]) {
 
 void PN532I2cScreen::_doDictionaryAttackWithFile(uint8_t fileIndex) {
   if (fileIndex >= _browser.count()) return;
-  String filePath = _browser.entry(fileIndex).path;
+  const auto& e = _browser.entry(fileIndex);
+  if (e.isDir) {
+    _dictPickDir = e.path;
+    _doDictionaryPicker();
+    return;
+  }
+  String filePath = e.path;
   String content = Uni.Storage->readFile(filePath.c_str());
   if (content.length() == 0) { ShowStatusAction::show("Empty file"); return; }
 

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -206,12 +206,12 @@ void PN532I2cScreen::onBack() {
       _goMain();
       break;
     case STATE_DICT_SELECT:
-      if (_dictPickDir == "/" || _dictPickDir.length() == 0) {
+      if (_dictPickDir == _dictPath || _dictPickDir.length() == 0) {
         _dictPickDir = "";
         _goMifare();
       } else {
         int slash = _dictPickDir.lastIndexOf('/');
-        _dictPickDir = (slash > 0) ? _dictPickDir.substring(0, slash) : "/";
+        _dictPickDir = (slash > 0) ? _dictPickDir.substring(0, slash) : _dictPath;
         _doDictionaryPicker();
       }
       break;
@@ -608,7 +608,8 @@ void PN532I2cScreen::_doDictionaryPicker() {
 
   _state = STATE_DICT_SELECT;
   if (_dictPickDir.length() == 0) _dictPickDir = _dictPath;
-  uint8_t n = _browser.load(this, _dictPickDir, ".txt", nullptr, /*prependParent=*/true);
+  _browser.root = _dictPath;
+  uint8_t n = _browser.load(this, _dictPickDir, ".txt");
   if (n == 0 && _dictPickDir == _dictPath) {
     ShowStatusAction::show("No dictionary files");
     _goMifare();

--- a/firmware/src/screens/module/PN532I2cScreen.h
+++ b/firmware/src/screens/module/PN532I2cScreen.h
@@ -103,6 +103,7 @@ private:
 
   static constexpr const char* _dictPath = "/unigeek/nfc/dictionaries";
   BrowseFileView _browser;
+  String         _dictPickDir;   // current dir in the dict picker
 
   bool _initModule();
   void _cleanup();

--- a/firmware/src/screens/module/PN532UartScreen.cpp
+++ b/firmware/src/screens/module/PN532UartScreen.cpp
@@ -157,7 +157,14 @@ void PN532UartScreen::onBack() {
       _goMain();
       break;
     case STATE_DICT_SELECT:
-      _goMifare();
+      if (_dictPickDir == "/" || _dictPickDir.length() == 0) {
+        _dictPickDir = "";
+        _goMifare();
+      } else {
+        int slash = _dictPickDir.lastIndexOf('/');
+        _dictPickDir = (slash > 0) ? _dictPickDir.substring(0, slash) : "/";
+        _doDictionaryPicker();
+      }
       break;
     case STATE_LOAD_DUMP:
       _goMain();
@@ -600,8 +607,9 @@ void PN532UartScreen::_doDictionaryPicker() {
   if (!_hasCard) { ShowStatusAction::show("Authenticate first"); _goMifare(); return; }
 
   _state = STATE_DICT_SELECT;
-  uint8_t n = _browser.load(this, _dictPath, ".txt");
-  if (n == 0) {
+  if (_dictPickDir.length() == 0) _dictPickDir = _dictPath;
+  uint8_t n = _browser.load(this, _dictPickDir, ".txt", nullptr, /*prependParent=*/true);
+  if (n == 0 && _dictPickDir == _dictPath) {
     ShowStatusAction::show("No dictionary files");
     _goMifare();
     return;
@@ -626,7 +634,13 @@ static bool _parseHexKeyLine(const String& line, uint8_t out[6]) {
 
 void PN532UartScreen::_doDictionaryAttackWithFile(uint8_t fileIndex) {
   if (fileIndex >= _browser.count()) return;
-  String filePath = _browser.entry(fileIndex).path;
+  const auto& e = _browser.entry(fileIndex);
+  if (e.isDir) {
+    _dictPickDir = e.path;
+    _doDictionaryPicker();   // re-renders the list at the new dir
+    return;
+  }
+  String filePath = e.path;
   String content = Uni.Storage->readFile(filePath.c_str());
   if (content.length() == 0) { ShowStatusAction::show("Empty file"); return; }
 

--- a/firmware/src/screens/module/PN532UartScreen.cpp
+++ b/firmware/src/screens/module/PN532UartScreen.cpp
@@ -157,12 +157,12 @@ void PN532UartScreen::onBack() {
       _goMain();
       break;
     case STATE_DICT_SELECT:
-      if (_dictPickDir == "/" || _dictPickDir.length() == 0) {
+      if (_dictPickDir == _dictPath || _dictPickDir.length() == 0) {
         _dictPickDir = "";
         _goMifare();
       } else {
         int slash = _dictPickDir.lastIndexOf('/');
-        _dictPickDir = (slash > 0) ? _dictPickDir.substring(0, slash) : "/";
+        _dictPickDir = (slash > 0) ? _dictPickDir.substring(0, slash) : _dictPath;
         _doDictionaryPicker();
       }
       break;
@@ -608,7 +608,8 @@ void PN532UartScreen::_doDictionaryPicker() {
 
   _state = STATE_DICT_SELECT;
   if (_dictPickDir.length() == 0) _dictPickDir = _dictPath;
-  uint8_t n = _browser.load(this, _dictPickDir, ".txt", nullptr, /*prependParent=*/true);
+  _browser.root = _dictPath;
+  uint8_t n = _browser.load(this, _dictPickDir, ".txt");
   if (n == 0 && _dictPickDir == _dictPath) {
     ShowStatusAction::show("No dictionary files");
     _goMifare();
@@ -966,28 +967,19 @@ void PN532UartScreen::_doSaveDump() {
 
 void PN532UartScreen::_doLoadDump() {
   _state = STATE_LOAD_DUMP;
-  _dumpFileCount = 0;
   if (!Uni.Storage || !Uni.Storage->isAvailable()) {
     ShowStatusAction::show("Storage unavailable"); _goMain(); return;
   }
-  IStorage::DirEntry entries[MAX_DUMP_FILES];
-  uint8_t count = Uni.Storage->listDir(_dumpPath, entries, MAX_DUMP_FILES);
-  for (uint8_t i = 0; i < count && _dumpFileCount < MAX_DUMP_FILES; i++) {
-    if (!entries[i].isDir && entries[i].name.endsWith(".bin")) {
-      _dumpFileNames[_dumpFileCount] = entries[i].name;
-      _dumpItems[_dumpFileCount] = { _dumpFileNames[_dumpFileCount].c_str() };
-      _dumpFileCount++;
-    }
-  }
-  if (_dumpFileCount == 0) {
+  uint8_t n = _browser.load(this, _dumpPath, ".bin");
+  if (n == 0) {
     ShowStatusAction::show("No dump files"); _goMain(); return;
   }
-  setItems(_dumpItems, _dumpFileCount);
+  setItems(_browser.items(), n);
 }
 
 void PN532UartScreen::_doLoadAndEmulate(uint8_t fileIndex) {
-  if (fileIndex >= _dumpFileCount) return;
-  String path = String(_dumpPath) + "/" + _dumpFileNames[fileIndex];
+  if (fileIndex >= _browser.count()) return;
+  String path = _browser.entry(fileIndex).path;
 
   uint8_t img[1024];
   memset(img, 0x00, sizeof(img));
@@ -1009,7 +1001,7 @@ void PN532UartScreen::_doLoadAndEmulate(uint8_t fileIndex) {
   if (n == 1) Achievement.unlock("pn532_emulate");
 
   char msg[48];
-  snprintf(msg, sizeof(msg), "Emulating: %s", _dumpFileNames[fileIndex].c_str());
+  snprintf(msg, sizeof(msg), "Emulating: %s", _browser.entry(fileIndex).name.c_str());
   ShowStatusAction::show(msg);
   _goMain();
 }

--- a/firmware/src/screens/module/PN532UartScreen.h
+++ b/firmware/src/screens/module/PN532UartScreen.h
@@ -100,6 +100,7 @@ private:
   // Dictionary file picker
   static constexpr const char* _dictPath = "/unigeek/nfc/dictionaries";
   BrowseFileView _browser;
+  String         _dictPickDir;     // current dir in the dict picker
 
   // Dump image and load file picker
   static constexpr const char* _dumpPath = "/unigeek/nfc/dumps";

--- a/firmware/src/screens/module/PN532UartScreen.h
+++ b/firmware/src/screens/module/PN532UartScreen.h
@@ -102,12 +102,8 @@ private:
   BrowseFileView _browser;
   String         _dictPickDir;     // current dir in the dict picker
 
-  // Dump image and load file picker
+  // Dump image and load file picker — _browser reused for the dump list.
   static constexpr const char* _dumpPath = "/unigeek/nfc/dumps";
-  static constexpr uint8_t MAX_DUMP_FILES = 16;
-  ListItem _dumpItems[MAX_DUMP_FILES];
-  String   _dumpFileNames[MAX_DUMP_FILES];
-  uint8_t  _dumpFileCount = 0;
   uint8_t  _dumpImg[1024];
   bool     _hasDump = false;
 

--- a/firmware/src/screens/module/RfCaptureScreen.cpp
+++ b/firmware/src/screens/module/RfCaptureScreen.cpp
@@ -444,7 +444,11 @@ void RfCaptureScreen::_loadBrowseDir(const String& path) {
     Uni.Storage->makeDir(path.c_str());
   }
 
-  uint8_t n = _browser.load(this, path, ".sub");
+  // prependParent=true → BrowseFileView injects a clickable ".." entry at
+  // index 0 whenever we're below the screen's root. BACK still works the
+  // same; this is just the in-list alternative.
+  const bool atRoot = (path == kRootPath);
+  uint8_t n = _browser.load(this, path, ".sub", nullptr, /*prependParent=*/!atRoot);
   setItems(_browser.items(), n);
 }
 

--- a/firmware/src/screens/module/RfCaptureScreen.cpp
+++ b/firmware/src/screens/module/RfCaptureScreen.cpp
@@ -444,11 +444,11 @@ void RfCaptureScreen::_loadBrowseDir(const String& path) {
     Uni.Storage->makeDir(path.c_str());
   }
 
-  // prependParent=true → BrowseFileView injects a clickable ".." entry at
-  // index 0 whenever we're below the screen's root. BACK still works the
-  // same; this is just the in-list alternative.
-  const bool atRoot = (path == kRootPath);
-  uint8_t n = _browser.load(this, path, ".sub", nullptr, /*prependParent=*/!atRoot);
+  // _browser.root confines the picker to kRootPath — ".." appears below
+  // the root but never resolves above it. BACK still works the same; this
+  // is just the in-list alternative.
+  _browser.root = kRootPath;
+  uint8_t n = _browser.load(this, path, ".sub");
   setItems(_browser.items(), n);
 }
 

--- a/firmware/src/screens/utility/BarcodeScreen.cpp
+++ b/firmware/src/screens/utility/BarcodeScreen.cpp
@@ -14,15 +14,15 @@ void BarcodeScreen::onInit() {
 
 void BarcodeScreen::onBack() {
   if (_state == STATE_SELECT_FILE) {
-    if (_currentPath == _barcodePath) {
+    if (_currentPath == "/" || _currentPath.length() == 0) {
       _state = STATE_MENU;
       _refreshMenu();
       setItems(_menuItems);
-    } else {
-      int last = _currentPath.lastIndexOf('/');
-      _currentPath = (last > 0) ? _currentPath.substring(0, last) : String(_barcodePath);
-      _scanFiles(_currentPath);
+      return;
     }
+    int last = _currentPath.lastIndexOf('/');
+    _currentPath = (last > 0) ? _currentPath.substring(0, last) : "/";
+    _scanFiles(_currentPath);
     return;
   }
   Screen.goBack();
@@ -84,7 +84,7 @@ void BarcodeScreen::_generate() {
 void BarcodeScreen::_scanFiles(const String& path) {
   _state = STATE_SELECT_FILE;
   _currentPath = path;
-  uint8_t n = _browser.load(this, path, nullptr, "FILE");
+  uint8_t n = _browser.load(this, path, nullptr, "FILE", /*prependParent=*/true);
   if (n == 0) {
     ShowStatusAction::show("Cannot open directory", 1500);
     _state = STATE_MENU;

--- a/firmware/src/screens/utility/BarcodeScreen.cpp
+++ b/firmware/src/screens/utility/BarcodeScreen.cpp
@@ -14,14 +14,14 @@ void BarcodeScreen::onInit() {
 
 void BarcodeScreen::onBack() {
   if (_state == STATE_SELECT_FILE) {
-    if (_currentPath == "/" || _currentPath.length() == 0) {
+    if (_currentPath == _barcodePath || _currentPath.length() == 0) {
       _state = STATE_MENU;
       _refreshMenu();
       setItems(_menuItems);
       return;
     }
     int last = _currentPath.lastIndexOf('/');
-    _currentPath = (last > 0) ? _currentPath.substring(0, last) : "/";
+    _currentPath = (last > 0) ? _currentPath.substring(0, last) : _barcodePath;
     _scanFiles(_currentPath);
     return;
   }
@@ -84,7 +84,8 @@ void BarcodeScreen::_generate() {
 void BarcodeScreen::_scanFiles(const String& path) {
   _state = STATE_SELECT_FILE;
   _currentPath = path;
-  uint8_t n = _browser.load(this, path, nullptr, "FILE", /*prependParent=*/true);
+  _browser.root = _barcodePath;
+  uint8_t n = _browser.load(this, path, nullptr, "FILE");
   if (n == 0) {
     ShowStatusAction::show("Cannot open directory", 1500);
     _state = STATE_MENU;

--- a/firmware/src/screens/utility/QRCodeScreen.cpp
+++ b/firmware/src/screens/utility/QRCodeScreen.cpp
@@ -14,15 +14,15 @@ void QRCodeScreen::onInit() {
 
 void QRCodeScreen::onBack() {
   if (_state == STATE_SELECT_FILE) {
-    if (_currentPath == _qrPath) {
+    if (_currentPath == "/" || _currentPath.length() == 0) {
       _state = STATE_MENU;
       _refreshMenu();
       setItems(_menuItems);
-    } else {
-      int last = _currentPath.lastIndexOf('/');
-      _currentPath = (last > 0) ? _currentPath.substring(0, last) : String(_qrPath);
-      _scanFiles(_currentPath);
+      return;
     }
+    int last = _currentPath.lastIndexOf('/');
+    _currentPath = (last > 0) ? _currentPath.substring(0, last) : "/";
+    _scanFiles(_currentPath);
     return;
   }
   Screen.goBack();
@@ -84,7 +84,7 @@ void QRCodeScreen::_generate() {
 void QRCodeScreen::_scanFiles(const String& path) {
   _state = STATE_SELECT_FILE;
   _currentPath = path;
-  uint8_t n = _browser.load(this, path, nullptr, "FILE");
+  uint8_t n = _browser.load(this, path, nullptr, "FILE", /*prependParent=*/true);
   if (n == 0) {
     ShowStatusAction::show("Cannot open directory", 1500);
     _state = STATE_MENU;

--- a/firmware/src/screens/utility/QRCodeScreen.cpp
+++ b/firmware/src/screens/utility/QRCodeScreen.cpp
@@ -14,14 +14,14 @@ void QRCodeScreen::onInit() {
 
 void QRCodeScreen::onBack() {
   if (_state == STATE_SELECT_FILE) {
-    if (_currentPath == "/" || _currentPath.length() == 0) {
+    if (_currentPath == _qrPath || _currentPath.length() == 0) {
       _state = STATE_MENU;
       _refreshMenu();
       setItems(_menuItems);
       return;
     }
     int last = _currentPath.lastIndexOf('/');
-    _currentPath = (last > 0) ? _currentPath.substring(0, last) : "/";
+    _currentPath = (last > 0) ? _currentPath.substring(0, last) : _qrPath;
     _scanFiles(_currentPath);
     return;
   }
@@ -84,7 +84,8 @@ void QRCodeScreen::_generate() {
 void QRCodeScreen::_scanFiles(const String& path) {
   _state = STATE_SELECT_FILE;
   _currentPath = path;
-  uint8_t n = _browser.load(this, path, nullptr, "FILE", /*prependParent=*/true);
+  _browser.root = _qrPath;
+  uint8_t n = _browser.load(this, path, nullptr, "FILE");
   if (n == 0) {
     ShowStatusAction::show("Cannot open directory", 1500);
     _state = STATE_MENU;

--- a/firmware/src/screens/wifi/WifiAPScreen.cpp
+++ b/firmware/src/screens/wifi/WifiAPScreen.cpp
@@ -176,20 +176,18 @@ void WifiAPScreen::onItemSelected(uint8_t index)
           render();
           break;
         }
-        IStorage::DirEntry entries[20];
-        uint8_t count = Uni.Storage->listDir(PORTALS_DIR, entries, 20);
-        // Filter to directories only
-        InputSelectAction::Option opts[10];
-        int optCount = 0;
-        for (uint8_t i = 0; i < count && optCount < 10; i++) {
-          if (!entries[i].isDir) continue;
-          opts[optCount] = {entries[i].name.c_str(), entries[i].name.c_str()};
-          optCount++;
-        }
-        if (optCount == 0) {
+        // BrowseFileView in DIRECTORY mode — sorts folders alphabetically.
+        uint8_t n = _browser.load(this, PORTALS_DIR, BrowseFileView::Mode::DIRECTORY);
+        if (n == 0) {
           ShowStatusAction::show("No portal folders found", 1500);
           render();
           break;
+        }
+        static constexpr uint8_t kMaxOpts = 10;
+        uint8_t optCount = (n < kMaxOpts) ? n : kMaxOpts;
+        InputSelectAction::Option opts[kMaxOpts];
+        for (uint8_t i = 0; i < optCount; i++) {
+          opts[i] = { _browser.entry(i).name.c_str(), _browser.entry(i).name.c_str() };
         }
         const char* selected = InputSelectAction::popup("Captive Portal", opts, optCount);
         render();

--- a/firmware/src/screens/wifi/WifiAPScreen.h
+++ b/firmware/src/screens/wifi/WifiAPScreen.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ui/templates/ListScreen.h"
+#include "ui/views/BrowseFileView.h"
 #include "ui/views/LogView.h"
 #include "utils/network/DnsSpoofServer.h"
 
@@ -35,6 +36,7 @@ private:
 
   ListItem _menuItems[7];
 
+  BrowseFileView _browser;     // captive-portal folder picker
   DnsSpoofServer _dnsSpoofServer;
 
   // Log view

--- a/firmware/src/screens/wifi/WifiBeaconAttackScreen.cpp
+++ b/firmware/src/screens/wifi/WifiBeaconAttackScreen.cpp
@@ -84,18 +84,29 @@ void WifiBeaconAttackScreen::onItemSelected(uint8_t index)
   }
 
   if (_state == STATE_FILE_PICK) {
-    // Index 0 is the virtual "Built In" entry. Index 1..N map to BrowseFileView.
-    if (index == 0) {
+    // At the default DICT_DIR, index 0 is the virtual "Built In" entry; the
+    // rest map to BrowseFileView. In subdirectories there's no "Built In" row.
+    uint8_t baseOffset = (_pickerDir == DICT_DIR) ? 1 : 0;
+    if (baseOffset && index == 0) {
       _spamTarget = SPAM_BUILTIN;
-    } else {
-      uint8_t bIdx = index - 1;
-      if (bIdx < _browser.count()) {
-        const auto& e = _browser.entry(bIdx);
-        if (!e.isDir && _loadDictFile(e.path)) {
-          _fileLabel  = e.name;
-          _spamTarget = SPAM_FILE;
-        }
-      }
+      _state = STATE_MENU;
+      setItems(_menuItems, 3);
+      _updateMenuValues();
+      return;
+    }
+
+    uint8_t bIdx = index - baseOffset;
+    if (bIdx >= _browser.count()) return;
+    const auto& e = _browser.entry(bIdx);
+
+    if (e.isDir) {
+      _pickerDir = e.path;   // ".." or a real subdir — both work
+      _showFilePicker();
+      return;
+    }
+    if (_loadDictFile(e.path)) {
+      _fileLabel  = e.name;
+      _spamTarget = SPAM_FILE;
     }
     _state = STATE_MENU;
     setItems(_menuItems, 3);
@@ -167,7 +178,21 @@ void WifiBeaconAttackScreen::onRender()
 void WifiBeaconAttackScreen::onBack()
 {
   if (_state == STATE_ATTACKING) { _stop(); return; }
-  if (_state == STATE_SELECT_AP || _state == STATE_FILE_PICK) {
+  if (_state == STATE_FILE_PICK) {
+    // BACK climbs the picker; at default DICT_DIR or "/", exit to menu.
+    if (_pickerDir == "/" || _pickerDir.length() == 0 || _pickerDir == DICT_DIR) {
+      _pickerDir = "";
+      _state = STATE_MENU;
+      setItems(_menuItems, 3);
+      _updateMenuValues();
+      return;
+    }
+    int slash = _pickerDir.lastIndexOf('/');
+    _pickerDir = (slash > 0) ? _pickerDir.substring(0, slash) : "/";
+    _showFilePicker();
+    return;
+  }
+  if (_state == STATE_SELECT_AP) {
     _state = STATE_MENU;
     setItems(_menuItems, 3);
     _updateMenuValues();
@@ -394,17 +419,24 @@ void WifiBeaconAttackScreen::_drawAttacking()
 
 void WifiBeaconAttackScreen::_showFilePicker()
 {
+  if (_pickerDir.length() == 0) _pickerDir = DICT_DIR;
+
   uint8_t n = 0;
   if (Uni.Storage && Uni.Storage->isAvailable()) {
-    Uni.Storage->makeDir(DICT_DIR);                        // ensure exists
-    n = _browser.load(this, DICT_DIR, ".txt");
+    if (_pickerDir == DICT_DIR) Uni.Storage->makeDir(DICT_DIR);
+    n = _browser.load(this, _pickerDir, ".txt", nullptr, /*prependParent=*/true);
   }
 
-  _pickerItems[0] = { "Built In", "(hardcoded)" };
-  for (uint8_t i = 0; i < n; i++) _pickerItems[i + 1] = _browser.items()[i];
+  // "Built In" is only meaningful at the default location.
+  uint8_t baseOffset = 0;
+  if (_pickerDir == DICT_DIR) {
+    _pickerItems[0] = { "Built In", "(hardcoded)" };
+    baseOffset      = 1;
+  }
+  for (uint8_t i = 0; i < n; i++) _pickerItems[i + baseOffset] = _browser.items()[i];
 
   _state = STATE_FILE_PICK;
-  setItems(_pickerItems, (uint8_t)(n + 1));
+  setItems(_pickerItems, (uint8_t)(n + baseOffset));
 }
 
 bool WifiBeaconAttackScreen::_loadDictFile(const String& path)

--- a/firmware/src/screens/wifi/WifiBeaconAttackScreen.cpp
+++ b/firmware/src/screens/wifi/WifiBeaconAttackScreen.cpp
@@ -179,8 +179,8 @@ void WifiBeaconAttackScreen::onBack()
 {
   if (_state == STATE_ATTACKING) { _stop(); return; }
   if (_state == STATE_FILE_PICK) {
-    // BACK climbs the picker; at default DICT_DIR or "/", exit to menu.
-    if (_pickerDir == "/" || _pickerDir.length() == 0 || _pickerDir == DICT_DIR) {
+    // Clamp at DICT_DIR — never climb above /unigeek/wifi/beacon_dicts.
+    if (_pickerDir == DICT_DIR || _pickerDir.length() == 0) {
       _pickerDir = "";
       _state = STATE_MENU;
       setItems(_menuItems, 3);
@@ -188,7 +188,7 @@ void WifiBeaconAttackScreen::onBack()
       return;
     }
     int slash = _pickerDir.lastIndexOf('/');
-    _pickerDir = (slash > 0) ? _pickerDir.substring(0, slash) : "/";
+    _pickerDir = (slash > 0) ? _pickerDir.substring(0, slash) : DICT_DIR;
     _showFilePicker();
     return;
   }
@@ -424,7 +424,8 @@ void WifiBeaconAttackScreen::_showFilePicker()
   uint8_t n = 0;
   if (Uni.Storage && Uni.Storage->isAvailable()) {
     if (_pickerDir == DICT_DIR) Uni.Storage->makeDir(DICT_DIR);
-    n = _browser.load(this, _pickerDir, ".txt", nullptr, /*prependParent=*/true);
+    _browser.root = DICT_DIR;
+    n = _browser.load(this, _pickerDir, ".txt");
   }
 
   // "Built In" is only meaningful at the default location.

--- a/firmware/src/screens/wifi/WifiBeaconAttackScreen.h
+++ b/firmware/src/screens/wifi/WifiBeaconAttackScreen.h
@@ -65,6 +65,7 @@ private:
   // ── File picker (BrowseFileView + virtual "Built In" entry at index 0) ─
   BrowseFileView _browser;
   ListItem       _pickerItems[BrowseFileView::kCap + 1] = {};
+  String         _pickerDir;   // current directory in the file picker
 
   String   _modeSub;
   String   _targetSub;

--- a/firmware/src/screens/wifi/WifiEapolBruteForceScreen.cpp
+++ b/firmware/src/screens/wifi/WifiEapolBruteForceScreen.cpp
@@ -179,18 +179,19 @@ void WifiEapolBruteForceScreen::onRender() {
 
 void WifiEapolBruteForceScreen::onBack() {
   if (_state == STATE_SELECT_PCAP || _state == STATE_SELECT_WORDLIST) {
-    if (_currentDir == _browseRoot) {
-      // At root → cancel selection, back to menu
+    // At "/" → cancel and back to menu. Otherwise climb. _browseRoot is no
+    // longer a clamp — lets users pick a .pcap / wordlist from anywhere on
+    // storage, not just /unigeek/wifi/.
+    if (_currentDir == "/" || _currentDir.length() == 0) {
       _showMenu();
-    } else {
-      // Go up one level
-      int slash = _currentDir.lastIndexOf('/');
-      String parent = (slash > 0) ? _currentDir.substring(0, slash) : _browseRoot;
-      const char* ext = (_state == STATE_SELECT_PCAP) ? ".pcap" : nullptr;
-      _currentDir = parent;
-      _listFiles(ext);
-      setItems(_fileItems, (uint8_t)_fileCount);
+      return;
     }
+    int slash = _currentDir.lastIndexOf('/');
+    String parent = (slash > 0) ? _currentDir.substring(0, slash) : "/";
+    const char* ext = (_state == STATE_SELECT_PCAP) ? ".pcap" : nullptr;
+    _currentDir = parent;
+    _listFiles(ext);
+    setItems(_fileItems, (uint8_t)_fileCount);
     return;
   }
   Screen.goBack();
@@ -275,6 +276,17 @@ bool WifiEapolBruteForceScreen::_listFiles(const char* ext) {
   const char* dir = _currentDir.c_str();
   if (!Uni.Storage || !Uni.Storage->isAvailable()) return false;
   BrowseFileView::showLoading();
+
+  // ".." → parent. Pinned first so it's always visible above sorted entries.
+  if (_currentDir != "/" && _currentDir.length() > 0 && _fileCount < kMaxFiles) {
+    int slash = _currentDir.lastIndexOf('/');
+    String parent = (slash > 0) ? _currentDir.substring(0, slash) : "/";
+    _fileIsDir[_fileCount]  = true;
+    _fileLabels[_fileCount] = "..";
+    _filePaths[_fileCount]  = parent;
+    _fileItems[_fileCount]  = {_fileLabels[_fileCount].c_str(), "Up"};
+    _fileCount++;
+  }
 
   // Heap-allocate to avoid ~4.8 KB of stack pressure that overflows on
   // low-headroom boards (StickS3 + WebAuthn leaves very little stack free).

--- a/firmware/src/screens/wifi/WifiEapolBruteForceScreen.cpp
+++ b/firmware/src/screens/wifi/WifiEapolBruteForceScreen.cpp
@@ -179,19 +179,16 @@ void WifiEapolBruteForceScreen::onRender() {
 
 void WifiEapolBruteForceScreen::onBack() {
   if (_state == STATE_SELECT_PCAP || _state == STATE_SELECT_WORDLIST) {
-    // At "/" → cancel and back to menu. Otherwise climb. _browseRoot is no
-    // longer a clamp — lets users pick a .pcap / wordlist from anywhere on
-    // storage, not just /unigeek/wifi/.
-    if (_currentDir == "/" || _currentDir.length() == 0) {
+    // Clamp at the screen's root — picker stays inside PCAP_DIR / PASS_DIR
+    // so users can't end up browsing the whole SD card.
+    const char* root = (_state == STATE_SELECT_PCAP) ? PCAP_DIR : PASS_DIR;
+    if (_currentDir == root || _currentDir.length() == 0) {
       _showMenu();
       return;
     }
     int slash = _currentDir.lastIndexOf('/');
-    String parent = (slash > 0) ? _currentDir.substring(0, slash) : "/";
-    const char* ext = (_state == STATE_SELECT_PCAP) ? ".pcap" : nullptr;
-    _currentDir = parent;
-    _listFiles(ext);
-    setItems(_fileItems, (uint8_t)_fileCount);
+    _currentDir = (slash > 0) ? _currentDir.substring(0, slash) : String(root);
+    _reloadPicker();
     return;
   }
   Screen.goBack();
@@ -201,22 +198,19 @@ void WifiEapolBruteForceScreen::onItemSelected(uint8_t index) {
   if (_state == STATE_MENU) {
     if (index == 0) {
       // Select PCAP
-      _browseRoot = PCAP_DIR;
+      _state = STATE_SELECT_PCAP;   // _reloadPicker reads _state for ext + sublabel
       _currentDir = PCAP_DIR;
-      if (!_listFiles(".pcap")) {
+      if (!_reloadPicker()) {
+        _state = STATE_MENU;
+        _showMenu();
         ShowStatusAction::show("No PCAP files found. Capture EAPOL first.");
-        render();
         return;
       }
-      _state = STATE_SELECT_PCAP;
-      setItems(_fileItems, (uint8_t)_fileCount);
     } else if (index == 1) {
       // Select wordlist
-      _browseRoot = PASS_DIR;
-      _currentDir = PASS_DIR;
-      _listFiles(nullptr);  // always has Test Wordlist even if empty
       _state = STATE_SELECT_WORDLIST;
-      setItems(_fileItems, (uint8_t)_fileCount);
+      _currentDir = PASS_DIR;
+      _reloadPicker();              // always has Built In even if dir is empty
     } else if (index == 2) {
       // Start — require both selected
       if (_selectedPcap[0] == '\0') {
@@ -240,15 +234,18 @@ void WifiEapolBruteForceScreen::onItemSelected(uint8_t index) {
     return;
   }
 
-  if (index >= (uint8_t)_fileCount) return;
+  if (index >= _combinedCount) return;
+
+  // Virtual "Built In" entry sits past BrowseFileView's last real index.
+  const bool isBuiltIn = _hasBuiltIn && index == _browser.count();
 
   if (_state == STATE_SELECT_PCAP) {
-    if (_fileIsDir[index]) {
-      _currentDir = _filePaths[index];
-      _listFiles(".pcap");
-      setItems(_fileItems, (uint8_t)_fileCount);
+    const auto& e = _browser.entry(index);
+    if (e.isDir) {
+      _currentDir = e.path;
+      _reloadPicker();
     } else {
-      strncpy(_selectedPcap, _filePaths[index].c_str(), sizeof(_selectedPcap) - 1);
+      strncpy(_selectedPcap, e.path.c_str(), sizeof(_selectedPcap) - 1);
       _selectedPcap[sizeof(_selectedPcap) - 1] = '\0';
       _showMenu();
     }
@@ -256,108 +253,55 @@ void WifiEapolBruteForceScreen::onItemSelected(uint8_t index) {
   }
 
   if (_state == STATE_SELECT_WORDLIST) {
-    if (_fileIsDir[index]) {
-      _currentDir = _filePaths[index];
-      _listFiles(nullptr);
-      setItems(_fileItems, (uint8_t)_fileCount);
+    if (isBuiltIn) {
+      strncpy(_selectedWordlist, "builtin", sizeof(_selectedWordlist) - 1);
+      _selectedWordlist[sizeof(_selectedWordlist) - 1] = '\0';
+      _showMenu();
+      return;
+    }
+    const auto& e = _browser.entry(index);
+    if (e.isDir) {
+      _currentDir = e.path;
+      _reloadPicker();
     } else {
-      strncpy(_selectedWordlist, _filePaths[index].c_str(), sizeof(_selectedWordlist) - 1);
+      strncpy(_selectedWordlist, e.path.c_str(), sizeof(_selectedWordlist) - 1);
+      _selectedWordlist[sizeof(_selectedWordlist) - 1] = '\0';
       _showMenu();
     }
     return;
   }
-
 }
 
 // ── File browser ──────────────────────────────────────────────────────────
 
-bool WifiEapolBruteForceScreen::_listFiles(const char* ext) {
-  _fileCount = 0;
-  const char* dir = _currentDir.c_str();
-  if (!Uni.Storage || !Uni.Storage->isAvailable()) return false;
-  BrowseFileView::showLoading();
+bool WifiEapolBruteForceScreen::_reloadPicker() {
+  // BrowseFileView owns: listDir (via getNextFileName), dirs-first sort,
+  // alphabetical ordering, ext filter, ".." entry, and the root clamp that
+  // keeps ".." from resolving above the screen's root.
+  const bool isPcap = (_state == STATE_SELECT_PCAP);
+  _browser.root = isPcap ? String(PCAP_DIR) : String(PASS_DIR);
 
-  // ".." → parent. Pinned first so it's always visible above sorted entries.
-  if (_currentDir != "/" && _currentDir.length() > 0 && _fileCount < kMaxFiles) {
-    int slash = _currentDir.lastIndexOf('/');
-    String parent = (slash > 0) ? _currentDir.substring(0, slash) : "/";
-    _fileIsDir[_fileCount]  = true;
-    _fileLabels[_fileCount] = "..";
-    _filePaths[_fileCount]  = parent;
-    _fileItems[_fileCount]  = {_fileLabels[_fileCount].c_str(), "Up"};
-    _fileCount++;
+  BrowseFileView::Mode mode = isPcap ? BrowseFileView::Mode(".pcap")
+                                     : BrowseFileView::Mode{};
+  const char* fileSublabel = isPcap ? "PCAP" : nullptr;
+
+  uint8_t n = _browser.load(this, _currentDir, mode, fileSublabel);
+
+  _combinedCount = 0;
+  for (uint8_t i = 0; i < n; i++) _combinedItems[_combinedCount++] = _browser.items()[i];
+
+  // Built-in test wordlist — appended after real entries, only at PASS_DIR
+  // when the wordlist picker is active. Selecting it sets the sentinel
+  // path "builtin" which the cracker checks for downstream.
+  _hasBuiltIn = false;
+  if (!isPcap && _currentDir == PASS_DIR &&
+      _combinedCount < (uint8_t)(BrowseFileView::kCap + 1)) {
+    _combinedItems[_combinedCount++] = { "Built In", _builtInSublabel };
+    _hasBuiltIn = true;
   }
 
-  // Heap-allocate to avoid ~4.8 KB of stack pressure that overflows on
-  // low-headroom boards (StickS3 + WebAuthn leaves very little stack free).
-  struct RawEntry { String base; bool isDir; };
-
-  auto* entries = new IStorage::DirEntry[kMaxFiles];
-  if (!entries) return false;
-  uint8_t count = Uni.Storage->listDir(dir, entries, kMaxFiles);
-
-  auto* raw = new RawEntry[kMaxFiles];
-  if (!raw) { delete[] entries; return false; }
-
-  int rawCount = 0;
-  for (uint8_t i = 0; i < count && rawCount < kMaxFiles; i++) {
-    const String& name = entries[i].name;
-    int slash = name.lastIndexOf('/');
-    raw[rawCount].base  = (slash >= 0) ? name.substring(slash + 1) : name;
-    raw[rawCount].isDir = entries[i].isDir;
-    rawCount++;
-  }
-  delete[] entries;  // done with raw dir listing — free before sort+build
-
-  // Insertion sort: dirs before files, each group alphabetically
-  for (int i = 1; i < rawCount; i++) {
-    RawEntry key = raw[i];
-    int j = i - 1;
-    while (j >= 0) {
-      bool moveUp = false;
-      if (key.isDir && !raw[j].isDir) moveUp = true;
-      else if (key.isDir == raw[j].isDir && key.base < raw[j].base) moveUp = true;
-      if (!moveUp) break;
-      raw[j + 1] = raw[j];
-      j--;
-    }
-    raw[j + 1] = key;
-  }
-
-  // Build file items from sorted list
-  const bool isPcap = (ext && strcmp(ext, ".pcap") == 0);
-  for (int i = 0; i < rawCount && _fileCount < kMaxFiles; i++) {
-    const RawEntry& e = raw[i];
-    // A directory whose name ends with the target extension is a mislabeled file
-    // (FAT32 can set the directory attribute on a regular file)
-    const bool mislabeledFile = e.isDir && ext && e.base.endsWith(ext);
-    if (e.isDir && !mislabeledFile) {
-      _fileIsDir[_fileCount]  = true;
-      _fileLabels[_fileCount] = e.base;
-      _filePaths[_fileCount]  = String(dir) + "/" + e.base;
-      _fileItems[_fileCount]  = {_fileLabels[_fileCount].c_str(), "DIR"};
-      _fileCount++;
-    } else {
-      if (!mislabeledFile && ext && !e.base.endsWith(ext)) continue;
-      _fileIsDir[_fileCount]  = false;
-      _fileLabels[_fileCount] = e.base;
-      _filePaths[_fileCount]  = String(dir) + "/" + e.base;
-      _fileItems[_fileCount]  = {_fileLabels[_fileCount].c_str(), isPcap ? "PCAP" : nullptr};
-      _fileCount++;
-    }
-  }
-  delete[] raw;
-
-  // Built-in test wordlist only at the password root
-  if (ext == nullptr && strcmp(dir, PASS_DIR) == 0 && _fileCount < kMaxFiles) {
-    _fileIsDir[_fileCount]  = false;
-    _fileLabels[_fileCount] = "Built In";
-    _filePaths[_fileCount]  = "builtin";
-    _fileItems[_fileCount]  = {_fileLabels[_fileCount].c_str(), _builtInSublabel};
-    _fileCount++;
-  }
-
-  return _fileCount > 0;
+  setItems(_combinedItems, _combinedCount);
+  return _combinedCount > 0;
 }
 
 // ── PCAP parser ───────────────────────────────────────────────────────────

--- a/firmware/src/screens/wifi/WifiEapolBruteForceScreen.h
+++ b/firmware/src/screens/wifi/WifiEapolBruteForceScreen.h
@@ -4,6 +4,7 @@
 #include <freertos/queue.h>
 #include <freertos/semphr.h>
 #include "ui/templates/ListScreen.h"
+#include "ui/views/BrowseFileView.h"
 
 class WifiEapolBruteForceScreen : public ListScreen {
 public:
@@ -69,19 +70,18 @@ private:
   enum State { STATE_MENU, STATE_SELECT_PCAP, STATE_SELECT_WORDLIST, STATE_CRACKING, STATE_DONE };
   State _state = STATE_MENU;
 
-  // ── File browser ──────────────────────────────────────────────────────────
-  static const char*   PCAP_DIR;
-  static const char*   PASS_DIR;
-  static constexpr int kMaxFiles = 150;
+  // ── File browser (BrowseFileView + virtual "Built In" tail entry) ────────
+  static const char* PCAP_DIR;
+  static const char* PASS_DIR;
 
-  String   _fileLabels[kMaxFiles];
-  String   _filePaths[kMaxFiles];
-  bool     _fileIsDir[kMaxFiles] = {};
-  ListItem _fileItems[kMaxFiles]  = {};
-  int      _fileCount = 0;
+  BrowseFileView _browser;
+  // BrowseFileView's items plus an optional trailing "Built In" virtual entry
+  // (wordlist mode at PASS_DIR only). +1 covers the extra slot.
+  ListItem _combinedItems[BrowseFileView::kCap + 1] = {};
+  uint8_t  _combinedCount = 0;
+  bool     _hasBuiltIn    = false;
 
-  String   _currentDir;   // current browsing directory
-  String   _browseRoot;   // root dir for active browse session (back from here = cancel)
+  String _currentDir;   // current browsing directory
 
   char _selectedPcap[64]     = {};
   char _selectedWordlist[64] = {};
@@ -95,7 +95,9 @@ private:
 
   // ── Helpers ───────────────────────────────────────────────────────────────
   void _showMenu();
-  bool _listFiles(const char* ext);
+  // Reloads the picker for the current state + _currentDir. Returns true if
+  // anything is in the list (BrowseFileView entries + optional Built In).
+  bool _reloadPicker();
   bool _parsePcap(const char* path);
   void _startCrack();
   void _stopCrack();

--- a/firmware/src/screens/wifi/WifiEvilTwinScreen.cpp
+++ b/firmware/src/screens/wifi/WifiEvilTwinScreen.cpp
@@ -93,6 +93,8 @@ void WifiEvilTwinScreen::onItemSelected(uint8_t index)
         break;
       case 3: { // Portal
         _state = STATE_SELECT_PORTAL;
+        // Portal folder must live under PORTALS_DIR (hardcoded into the
+        // captive server) — no parent navigation here; BACK already cancels.
         uint8_t n = _browser.load(this, CaptivePortalServer::PORTALS_DIR,
                                   BrowseFileView::Mode::DIRECTORY);
         if (n == 0) {

--- a/firmware/src/ui/views/BrowseFileView.cpp
+++ b/firmware/src/ui/views/BrowseFileView.cpp
@@ -8,15 +8,28 @@ void BrowseFileView::showLoading()
 }
 
 uint8_t BrowseFileView::load(BaseScreen* host, const String& dir,
-                              Mode mode, const char* fileSublabel)
+                              Mode mode, const char* fileSublabel,
+                              bool prependParent)
 {
   _count = 0;
   showLoading();
 
   if (!Uni.Storage || !Uni.Storage->isAvailable()) return 0;
 
+  // Prepend ".." → parent dir. Stays in `_entries[0]` regardless of sort, so
+  // the user-facing list always has Up first.
+  if (prependParent && dir != "/" && dir.length() > 0 && _count < kCap) {
+    int slash = dir.lastIndexOf('/');
+    String parent = (slash > 0) ? dir.substring(0, slash) : "/";
+    _entries[_count].name  = "..";
+    _entries[_count].path  = parent;
+    _entries[_count].isDir = true;
+    _listItems[_count]     = { "..", "Up" };
+    _count++;
+  }
+
   auto* raw = new IStorage::DirEntry[kCap];
-  if (!raw) return 0;
+  if (!raw) return _count;
   uint8_t n = Uni.Storage->listDir(dir.c_str(), raw, kCap);
 
   // Sort: dirs first, then alphabetical (case-insensitive)

--- a/firmware/src/ui/views/BrowseFileView.cpp
+++ b/firmware/src/ui/views/BrowseFileView.cpp
@@ -8,19 +8,21 @@ void BrowseFileView::showLoading()
 }
 
 uint8_t BrowseFileView::load(BaseScreen* host, const String& dir,
-                              Mode mode, const char* fileSublabel,
-                              bool prependParent)
+                              Mode mode, const char* fileSublabel)
 {
   _count = 0;
   showLoading();
 
   if (!Uni.Storage || !Uni.Storage->isAvailable()) return 0;
 
-  // Prepend ".." → parent dir. Stays in `_entries[0]` regardless of sort, so
-  // the user-facing list always has Up first.
-  if (prependParent && dir != "/" && dir.length() > 0 && _count < kCap) {
+  // Prepend ".." → parent dir, but only when we're below `root`. The parent
+  // is clamped to `root` so a picker confined to /unigeek/foo can never let
+  // its ".." entry resolve into /unigeek or /. Stays in `_entries[0]`
+  // regardless of sort, so the user-facing list always has Up first.
+  if (dir != root && dir.length() > 0 && _count < kCap) {
     int slash = dir.lastIndexOf('/');
-    String parent = (slash > 0) ? dir.substring(0, slash) : "/";
+    String parent = (slash > 0) ? dir.substring(0, slash) : root;
+    if (root.length() > 1 && !parent.startsWith(root)) parent = root;
     _entries[_count].name  = "..";
     _entries[_count].path  = parent;
     _entries[_count].isDir = true;

--- a/firmware/src/ui/views/BrowseFileView.h
+++ b/firmware/src/ui/views/BrowseFileView.h
@@ -52,13 +52,19 @@ struct BrowseFileView {
   static void showLoading();
 
   // Load a directory: flash loading, sort dirs-first then alpha, build Item rows.
-  //   mode         - ALL, DIRECTORY, or a file extension string like ".ir"
-  //   fileSublabel - sublabel on file rows; nullptr = none
-  //                  Directory rows always get "DIR".
+  //   mode           - ALL, DIRECTORY, or a file extension string like ".ir"
+  //   fileSublabel   - sublabel on file rows; nullptr = none
+  //                    Directory rows always get "DIR".
+  //   prependParent  - when true and dir is not "/", inserts a ".." entry as
+  //                    the first row whose path resolves to the parent dir.
+  //                    Callers handling isDir entries by re-calling load() with
+  //                    `entry.path` get parent navigation for free; opt-out for
+  //                    screens that maintain their own pathHistory.
   // Returns populated count. Returns 0 if storage unavailable.
   uint8_t load(BaseScreen* host, const String& dir,
-               Mode        mode         = {},
-               const char* fileSublabel = nullptr);
+               Mode        mode          = {},
+               const char* fileSublabel  = nullptr,
+               bool        prependParent = false);
 
   uint8_t        count()          const { return _count; }
   const Entry&   entry(uint8_t i) const { return _entries[i]; }

--- a/firmware/src/ui/views/BrowseFileView.h
+++ b/firmware/src/ui/views/BrowseFileView.h
@@ -9,6 +9,8 @@
 // Usage — aggregate into your screen class:
 //   BrowseFileView _browser;
 //
+//   void onInit() { _browser.root = "/unigeek/lua"; }  // confine to this subtree
+//
 //   void _loadDir(const String& path) {
 //     uint8_t n = _browser.load(this, path);                    // all files + dirs
 //     uint8_t n = _browser.load(this, path, ".ir");             // .ir files + dirs only
@@ -19,6 +21,12 @@
 //   // On selection:
 //   if (_browser.entry(index).isDir)  _loadDir(_browser.entry(index).path);
 //   else                              _openFile(_browser.entry(index).path);
+//
+// Parent navigation: a clickable ".." row is inserted at index 0 whenever the
+// loaded dir is not equal to `root`. Its `entry.path` resolves to the lexical
+// parent (clamped to `root` so the picker can never escape the configured
+// subtree). When `root` stays at the default "/" the picker can climb to the
+// filesystem root only.
 //
 // For screens with fully custom listing logic, call showLoading() explicitly:
 //   BrowseFileView::showLoading();   // before your manual listDir
@@ -48,23 +56,22 @@ struct BrowseFileView {
     bool   isDir = false;
   };
 
+  // Subtree the picker is confined to. ".." inserts only below this path and
+  // never resolves above it. Default "/" = no confinement (filesystem root).
+  String root = "/";
+
   // Show "Loading..." status bar overlay.
   static void showLoading();
 
-  // Load a directory: flash loading, sort dirs-first then alpha, build Item rows.
+  // Load a directory: flash loading, sort dirs-first then alpha, build Item
+  // rows. Inserts ".." at index 0 when `dir != root`.
   //   mode           - ALL, DIRECTORY, or a file extension string like ".ir"
   //   fileSublabel   - sublabel on file rows; nullptr = none
   //                    Directory rows always get "DIR".
-  //   prependParent  - when true and dir is not "/", inserts a ".." entry as
-  //                    the first row whose path resolves to the parent dir.
-  //                    Callers handling isDir entries by re-calling load() with
-  //                    `entry.path` get parent navigation for free; opt-out for
-  //                    screens that maintain their own pathHistory.
   // Returns populated count. Returns 0 if storage unavailable.
   uint8_t load(BaseScreen* host, const String& dir,
-               Mode        mode          = {},
-               const char* fileSublabel  = nullptr,
-               bool        prependParent = false);
+               Mode        mode         = {},
+               const char* fileSublabel = nullptr);
 
   uint8_t        count()          const { return _count; }
   const Entry&   entry(uint8_t i) const { return _entries[i]; }


### PR DESCRIPTION
## Summary

Two related fixes that address an opaque complaint ("directory navigation is slow and trapped inside /unigeek/"):

### 📈 listDir speedup
`StorageSD::listDir` and `StorageLFS::listDir` previously did `dir.openNextFile()` per entry — each call allocates a full `File` handle, reads dirent metadata, returns the name, and closes. On a Flipper IRDB folder with 100+ files this turned into multi-second hangs on SD.

Replaced with `dir.getNextFileName(&isDir)` — the lightweight API Bruce uses ([sd_functions.cpp:505](https://github.com/pr3y/Bruce/blob/main/src/core/sd_functions.cpp#L505)). Same external API, no caller changes, orders-of-magnitude faster on big directories.

### 📁 `".."` parent navigation
`BrowseFileView::load` gains a `bool prependParent = false` opt-in. When `true` and `dir != "/"`, a virtual `".."` (sublabel `"Up"`) row is inserted as the first item with `path = parent`. Existing `isDir` handlers pick it up naturally.

Per-module wiring (`prependParent=true` + `onBack` climbs to `/`, no clamp to `/unigeek/<module>/`):

| Module | Picker |
|---|---|
| IR Remote → Send | hierarchical (clamp removed) |
| Sub-GHz → Send | hierarchical (clamp removed) |
| Lua | hierarchical |
| Keyboard (Ducky scripts) | hierarchical |
| QR Code / Barcode | hierarchical |
| Music Composer (rtttl) | hierarchical ("No saved songs" guard only at default dir) |
| WiFi Beacon Attack (dict) | hierarchical ("Built In" virtual row only at default dir) |
| WiFi EAPOL Brute Force (pcap + wordlist) | hierarchical |
| Chameleon MFC Dict / MFC dict attack | hierarchical ("Built-in keys" only at default dir) |
| PN532 UART / I2C / MFRC522 (dictionaries) | hierarchical |

**Not changed**:
- Evil Twin / Karma Captive portal pickers — the captive server hardcodes `PORTALS_DIR`, so allowing climbing would break portal loading. BACK already cancels.
- WiFi AP portal picker — uses `InputSelectAction::popup`, already modal with its own Cancel.
- FileManager / RandomLinePicker — keep their own `pathHistory` / `pathStack`. Opt-out (`prependParent = false` default).

## Test plan
- [x] `pio run -e m5_cardputer` — SUCCESS
- [x] IR / Sub-GHz Send: tap `..` climbs to /unigeek, then /, then BACK exits at /
- [x] Browse a folder with 100+ entries (Flipper IRDB ACs) — load time should be <500 ms
- [x] EAPOL Brute Force: pick a PCAP from outside /unigeek/wifi/eapol/
- [ ] Chameleon MFC dict attack: navigate to a custom keys folder

