### PR TITLE
lua: add uni.subghz with auto-detect CC1101 / M5 RF433 backend

### DIFF
--- a/firmware/src/utils/interpreter/LuaEngine.cpp
+++ b/firmware/src/utils/interpreter/LuaEngine.cpp
@@ -2,20 +2,41 @@
 #include "core/Device.h"
 #include "core/INavigation.h"
 #include "core/ConfigManager.h"
+#include "core/PinConfigManager.h"
 #include "core/RandomSeed.h"
 #include "ui/actions/InputTextAction.h"
 #include "ui/actions/InputNumberAction.h"
 #include "ui/actions/InputSelectAction.h"
 #include "ui/actions/ShowStatusAction.h"
+#include "utils/rf/CC1101Util.h"
+#include "utils/rf/M5RF433Util.h"
 #include <esp_heap_caps.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <time.h>
 #include <cJSON.h>
 #include <stdlib.h>
+#include <math.h>
 #include <WiFi.h>
 #include <WiFiClientSecure.h>
 #include <HTTPClient.h>
+
+// Mirror M5RF433Screen.cpp's pin-fallback logic for the GPIO bit-bang backend.
+// Per-board pins_arduino.h is auto-included by PlatformIO via the variant.
+#if defined(M5RF433_TX_PIN)
+  static constexpr int8_t kLuaRf433DefaultTx = (int8_t)M5RF433_TX_PIN;
+#elif defined(GROVE_SDA)
+  static constexpr int8_t kLuaRf433DefaultTx = (int8_t)GROVE_SDA;
+#else
+  static constexpr int8_t kLuaRf433DefaultTx = -1;
+#endif
+#if defined(M5RF433_RX_PIN)
+  static constexpr int8_t kLuaRf433DefaultRx = (int8_t)M5RF433_RX_PIN;
+#elif defined(GROVE_SCL)
+  static constexpr int8_t kLuaRf433DefaultRx = (int8_t)GROVE_SCL;
+#else
+  static constexpr int8_t kLuaRf433DefaultRx = -1;
+#endif
 
 char LuaEngine::exitSentinel = '\0';
 
@@ -132,6 +153,9 @@ void LuaEngine::deinit() {
   // Tear down WiFi if the script was the one that brought it up, and clear
   // any HTTP transport state so the next script starts on a clean network.
   _cleanupNetwork();
+  // Release the radio if the script opened uni.subghz — leaving SPI or the
+  // RX ISR live across scripts would race the next launch.
+  _cleanupSubghz();
 }
 
 // ── Script loading ────────────────────────────────────────────────────
@@ -286,6 +310,7 @@ void LuaEngine::_registerBindings() {
   lua_pushcfunction(_lua, _lua_load_config); lua_setfield(_lua, -2, "uni.config");
   lua_pushcfunction(_lua, _lua_load_wifi);   lua_setfield(_lua, -2, "uni.wifi");
   lua_pushcfunction(_lua, _lua_load_http);   lua_setfield(_lua, -2, "uni.http");
+  lua_pushcfunction(_lua, _lua_load_subghz); lua_setfield(_lua, -2, "uni.subghz");
   lua_pop(_lua, 2);
 
   // Sprite metatable lives in the registry; attached to each sprite userdata.
@@ -1529,4 +1554,378 @@ int LuaEngine::_config_get(lua_State* L) {
   String val = Config.get(key, "");
   lua_pushstring(L, val.c_str());
   return 1;
+}
+
+// ── uni.subghz ────────────────────────────────────────────────────────
+//
+// Unified facade over the two RF backends in this firmware:
+//   - CC1101Util  — SPI module, variable 280–928 MHz, supports scan
+//   - M5RF433Util — Grove bit-bang, fixed 433.92 MHz, no scan
+// Backend is picked lazily on the first operation that needs the radio
+// (CC1101 preferred when the chip responds; M5 RF433 as fallback). The
+// Signal struct is shared between both (M5RF433Util typedefs it), so the
+// Lua-side signal table marshals identically for either path. Cleanup is
+// driven from deinit() so a crashing script can't strand SPI / RX ISR.
+
+namespace {
+
+void _signalFromLuaTable(lua_State* L, int idx, CC1101Util::Signal& out) {
+  int abs = idx > 0 ? idx : lua_gettop(L) + idx + 1;
+  lua_getfield(L, abs, "frequency"); if (lua_isnumber(L, -1)) out.frequency = (float)lua_tonumber(L, -1); lua_pop(L, 1);
+  lua_getfield(L, abs, "preset");    if (lua_isstring(L, -1)) out.preset    = lua_tostring(L, -1);       lua_pop(L, 1);
+  lua_getfield(L, abs, "protocol");  if (lua_isstring(L, -1)) out.protocol  = lua_tostring(L, -1);       lua_pop(L, 1);
+  lua_getfield(L, abs, "rawData");   if (lua_isstring(L, -1)) out.rawData   = lua_tostring(L, -1);       lua_pop(L, 1);
+  lua_getfield(L, abs, "key");       if (lua_isnumber(L, -1)) out.key       = (uint64_t)lua_tonumber(L, -1); lua_pop(L, 1);
+  lua_getfield(L, abs, "te");        if (lua_isnumber(L, -1)) out.te        = (int)lua_tonumber(L, -1);  lua_pop(L, 1);
+  lua_getfield(L, abs, "bit");       if (lua_isnumber(L, -1)) out.bit       = (int)lua_tonumber(L, -1);  lua_pop(L, 1);
+  lua_getfield(L, abs, "mf_name");   if (lua_isstring(L, -1)) out.mf_name   = lua_tostring(L, -1);       lua_pop(L, 1);
+  lua_getfield(L, abs, "serial");    if (lua_isnumber(L, -1)) out.serial    = (uint32_t)lua_tonumber(L, -1); lua_pop(L, 1);
+  lua_getfield(L, abs, "btn");       if (lua_isnumber(L, -1)) out.btn       = (uint8_t)lua_tonumber(L, -1); lua_pop(L, 1);
+  lua_getfield(L, abs, "cnt");       if (lua_isnumber(L, -1)) out.cnt       = (uint16_t)lua_tonumber(L, -1); lua_pop(L, 1);
+  lua_getfield(L, abs, "fix");       if (lua_isnumber(L, -1)) out.fix       = (uint32_t)lua_tonumber(L, -1); lua_pop(L, 1);
+  lua_getfield(L, abs, "encrypted"); if (lua_isnumber(L, -1)) out.encrypted = (uint32_t)lua_tonumber(L, -1); lua_pop(L, 1);
+  lua_getfield(L, abs, "hop");       if (lua_isnumber(L, -1)) out.hop       = (uint32_t)lua_tonumber(L, -1); lua_pop(L, 1);
+}
+
+void _signalToLuaTable(lua_State* L, const CC1101Util::Signal& sig) {
+  lua_newtable(L);
+  lua_pushnumber(L, sig.frequency);         lua_setfield(L, -2, "frequency");
+  lua_pushstring(L, sig.preset.c_str());    lua_setfield(L, -2, "preset");
+  lua_pushstring(L, sig.protocol.c_str());  lua_setfield(L, -2, "protocol");
+  lua_pushstring(L, sig.rawData.c_str());   lua_setfield(L, -2, "rawData");
+  // KeeLoq fits in 32 bits; uint64_t key is rarely larger, but lua_Number is
+  // double so values above 2^53 lose precision. Acceptable for current decoders.
+  lua_pushnumber(L, (lua_Number)sig.key);   lua_setfield(L, -2, "key");
+  lua_pushnumber(L, sig.te);                lua_setfield(L, -2, "te");
+  lua_pushnumber(L, sig.bit);               lua_setfield(L, -2, "bit");
+  lua_pushstring(L, sig.mf_name.c_str());   lua_setfield(L, -2, "mf_name");
+  lua_pushnumber(L, sig.serial);            lua_setfield(L, -2, "serial");
+  lua_pushnumber(L, sig.btn);               lua_setfield(L, -2, "btn");
+  lua_pushnumber(L, sig.cnt);               lua_setfield(L, -2, "cnt");
+  lua_pushnumber(L, sig.fix);               lua_setfield(L, -2, "fix");
+  lua_pushnumber(L, sig.encrypted);         lua_setfield(L, -2, "encrypted");
+  lua_pushnumber(L, sig.hop);               lua_setfield(L, -2, "hop");
+}
+
+}  // namespace
+
+bool LuaEngine::_subghzEnsureOpen() {
+  if (_subghzBackend != SUBGHZ_NONE) return true;
+
+  // CC1101 first: read pin config (board default flows through PIN_CONFIG_*_DEFAULT).
+  // begin() does a SPI chip-ID handshake — false means no chip on the bus.
+  int8_t cs   = (int8_t)PinConfig.get(PIN_CONFIG_CC1101_CS,   PIN_CONFIG_CC1101_CS_DEFAULT).toInt();
+  int8_t gdo0 = (int8_t)PinConfig.get(PIN_CONFIG_CC1101_GDO0, PIN_CONFIG_CC1101_GDO0_DEFAULT).toInt();
+  if (cs >= 0 && gdo0 >= 0 && Uni.Spi != nullptr) {
+    if (!_subghzCc) _subghzCc = new CC1101Util();
+    if (_subghzCc && _subghzCc->begin(Uni.Spi, cs, gdo0)) {
+      _subghzBackend = SUBGHZ_CC1101;
+      return true;
+    }
+    if (_subghzCc) _subghzCc->end();
+  }
+
+  // Fallback: M5 RF433 — pin defaults follow M5RF433Screen.cpp (M5RF433_TX_PIN
+  // override, else GROVE_SDA/SCL). There's no chip ID to probe, so we only
+  // gate on pins being defined.
+  if (kLuaRf433DefaultTx >= 0 || kLuaRf433DefaultRx >= 0) {
+    if (!_subghzRf) _subghzRf = new M5RF433Util();
+    if (_subghzRf && _subghzRf->begin(kLuaRf433DefaultTx, kLuaRf433DefaultRx)) {
+      _subghzBackend = SUBGHZ_RF433;
+      return true;
+    }
+  }
+  return false;
+}
+
+void LuaEngine::_cleanupSubghz() {
+  if (_subghzCc) {
+    if (_subghzReceiving) _subghzCc->endReceive();
+    if (_subghzScanning)  _subghzCc->endScan();
+    _subghzCc->end();
+    delete _subghzCc;
+    _subghzCc = nullptr;
+  }
+  if (_subghzRf) {
+    if (_subghzReceiving) _subghzRf->endReceive();
+    if (_subghzJamming)   _subghzRf->stopJam();
+    _subghzRf->end();
+    delete _subghzRf;
+    _subghzRf = nullptr;
+  }
+  _subghzBackend   = SUBGHZ_NONE;
+  _subghzReceiving = false;
+  _subghzScanning  = false;
+  _subghzJamming   = false;
+}
+
+int LuaEngine::_lua_load_subghz(lua_State* L) {
+  lua_newtable(L);
+  lua_pushcfunction(L, _subghz_info);         lua_setfield(L, -2, "info");
+  lua_pushcfunction(L, _subghz_setFrequency); lua_setfield(L, -2, "setFrequency");
+  lua_pushcfunction(L, _subghz_getFrequency); lua_setfield(L, -2, "getFrequency");
+  lua_pushcfunction(L, _subghz_setRxFilter);  lua_setfield(L, -2, "setRxFilter");
+  lua_pushcfunction(L, _subghz_beginReceive); lua_setfield(L, -2, "beginReceive");
+  lua_pushcfunction(L, _subghz_pollReceive);  lua_setfield(L, -2, "pollReceive");
+  lua_pushcfunction(L, _subghz_endReceive);   lua_setfield(L, -2, "endReceive");
+  lua_pushcfunction(L, _subghz_send);         lua_setfield(L, -2, "send");
+  lua_pushcfunction(L, _subghz_beginScan);    lua_setfield(L, -2, "beginScan");
+  lua_pushcfunction(L, _subghz_stepScan);     lua_setfield(L, -2, "stepScan");
+  lua_pushcfunction(L, _subghz_endScan);      lua_setfield(L, -2, "endScan");
+  lua_pushcfunction(L, _subghz_getScanFreq);  lua_setfield(L, -2, "getScanFreq");
+  lua_pushcfunction(L, _subghz_getScanRssi);  lua_setfield(L, -2, "getScanRssi");
+  lua_pushcfunction(L, _subghz_startJam);     lua_setfield(L, -2, "startJam");
+  lua_pushcfunction(L, _subghz_jamBurst);     lua_setfield(L, -2, "jamBurst");
+  lua_pushcfunction(L, _subghz_stopJam);      lua_setfield(L, -2, "stopJam");
+  lua_pushcfunction(L, _subghz_parseSub);     lua_setfield(L, -2, "parseSub");
+  lua_pushcfunction(L, _subghz_formatSub);    lua_setfield(L, -2, "formatSub");
+  lua_pushcfunction(L, _subghz_close);        lua_setfield(L, -2, "close");
+  return 1;
+}
+
+int LuaEngine::_subghz_info(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  bool open = eng && eng->_subghzEnsureOpen();
+  lua_newtable(L);
+  if (!open || !eng) {
+    lua_pushnil(L);        lua_setfield(L, -2, "backend");
+    lua_pushboolean(L, 0); lua_setfield(L, -2, "canTune");
+    lua_pushboolean(L, 0); lua_setfield(L, -2, "canScan");
+    return 1;
+  }
+  if (eng->_subghzBackend == SUBGHZ_CC1101) {
+    lua_pushstring(L, "cc1101");                       lua_setfield(L, -2, "backend");
+    lua_pushboolean(L, 1);                             lua_setfield(L, -2, "canTune");
+    lua_pushboolean(L, 1);                             lua_setfield(L, -2, "canScan");
+    lua_pushnumber(L, eng->_subghzCc->getFrequency()); lua_setfield(L, -2, "freq");
+  } else {
+    lua_pushstring(L, "rf433");                        lua_setfield(L, -2, "backend");
+    lua_pushboolean(L, 0);                             lua_setfield(L, -2, "canTune");
+    lua_pushboolean(L, 0);                             lua_setfield(L, -2, "canScan");
+    lua_pushnumber(L, M5RF433Util::FIXED_FREQ);        lua_setfield(L, -2, "freq");
+  }
+  return 1;
+}
+
+int LuaEngine::_subghz_setFrequency(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (!eng || !eng->_subghzEnsureOpen()) { lua_pushboolean(L, 0); return 1; }
+  if (eng->_subghzBackend != SUBGHZ_CC1101) {
+    lua_pushboolean(L, 0);
+    lua_pushstring(L, "unsupported on rf433");
+    return 2;
+  }
+  float mhz = (float)luaL_checknumber(L, 1);
+  lua_pushboolean(L, eng->_subghzCc->setFrequency(mhz) ? 1 : 0);
+  return 1;
+}
+
+int LuaEngine::_subghz_getFrequency(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (!eng || !eng->_subghzEnsureOpen()) { lua_pushnumber(L, 0); return 1; }
+  if (eng->_subghzBackend == SUBGHZ_CC1101) {
+    lua_pushnumber(L, eng->_subghzCc->getFrequency());
+  } else {
+    lua_pushnumber(L, M5RF433Util::FIXED_FREQ);
+  }
+  return 1;
+}
+
+int LuaEngine::_subghz_setRxFilter(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (!eng || !eng->_subghzEnsureOpen()) { lua_pushboolean(L, 0); return 1; }
+  const char* mode = luaL_checkstring(L, 1);
+  auto f = (strcmp(mode, "raw") == 0) ? CC1101Util::RX_FILTER_RAW
+                                      : CC1101Util::RX_FILTER_CODE;
+  if (eng->_subghzBackend == SUBGHZ_CC1101)     eng->_subghzCc->setRxFilter(f);
+  else if (eng->_subghzBackend == SUBGHZ_RF433) eng->_subghzRf->setRxFilter(f);
+  lua_pushboolean(L, 1);
+  return 1;
+}
+
+int LuaEngine::_subghz_beginReceive(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (!eng || !eng->_subghzEnsureOpen()) { lua_pushboolean(L, 0); return 1; }
+  bool ok = false;
+  if (eng->_subghzBackend == SUBGHZ_CC1101)     ok = eng->_subghzCc->beginReceive();
+  else if (eng->_subghzBackend == SUBGHZ_RF433) ok = eng->_subghzRf->beginReceive();
+  eng->_subghzReceiving = ok;
+  lua_pushboolean(L, ok ? 1 : 0);
+  return 1;
+}
+
+int LuaEngine::_subghz_pollReceive(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (!eng || eng->_subghzBackend == SUBGHZ_NONE) { lua_pushnil(L); return 1; }
+  CC1101Util::Signal sig;
+  bool got = false;
+  if (eng->_subghzBackend == SUBGHZ_CC1101)     got = eng->_subghzCc->pollReceive(sig);
+  else if (eng->_subghzBackend == SUBGHZ_RF433) got = eng->_subghzRf->pollReceive(sig);
+  if (!got) { lua_pushnil(L); return 1; }
+  _signalToLuaTable(L, sig);
+  return 1;
+}
+
+int LuaEngine::_subghz_endReceive(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (!eng) return 0;
+  if (eng->_subghzBackend == SUBGHZ_CC1101 && eng->_subghzCc) eng->_subghzCc->endReceive();
+  if (eng->_subghzBackend == SUBGHZ_RF433  && eng->_subghzRf) eng->_subghzRf->endReceive();
+  eng->_subghzReceiving = false;
+  return 0;
+}
+
+int LuaEngine::_subghz_send(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (!eng || !eng->_subghzEnsureOpen()) { lua_pushboolean(L, 0); return 1; }
+  luaL_checktype(L, 1, LUA_TTABLE);
+  CC1101Util::Signal sig;
+  _signalFromLuaTable(L, 1, sig);
+  // RX must be torn down while TX runs: every pulse driven on GDO0/TX would
+  // otherwise re-fire the receive ISR and corrupt the buffer. Re-arm RX
+  // afterwards if the script was listening before send().
+  bool wasRx = eng->_subghzReceiving;
+  if (eng->_subghzBackend == SUBGHZ_CC1101) {
+    if (sig.frequency > 0 &&
+        fabsf(sig.frequency - eng->_subghzCc->getFrequency()) > 0.01f) {
+      eng->_subghzCc->setFrequency(sig.frequency);
+    }
+    if (wasRx) eng->_subghzCc->endReceive();
+    eng->_subghzCc->sendSignal(sig);
+    if (wasRx) eng->_subghzCc->beginReceive();
+  } else {
+    if (wasRx) eng->_subghzRf->endReceive();
+    eng->_subghzRf->sendSignal(sig);
+    if (wasRx) eng->_subghzRf->beginReceive();
+  }
+  lua_pushboolean(L, 1);
+  return 1;
+}
+
+int LuaEngine::_subghz_beginScan(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (!eng || !eng->_subghzEnsureOpen()) { lua_pushboolean(L, 0); return 1; }
+  if (eng->_subghzBackend != SUBGHZ_CC1101) {
+    lua_pushboolean(L, 0);
+    lua_pushstring(L, "unsupported on rf433");
+    return 2;
+  }
+  bool ok = eng->_subghzCc->beginScan();
+  eng->_subghzScanning = ok;
+  lua_pushboolean(L, ok ? 1 : 0);
+  return 1;
+}
+
+int LuaEngine::_subghz_stepScan(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (!eng || eng->_subghzBackend != SUBGHZ_CC1101 || !eng->_subghzCc) {
+    lua_pushboolean(L, 0);
+    return 1;
+  }
+  lua_pushboolean(L, eng->_subghzCc->stepScan() ? 1 : 0);
+  return 1;
+}
+
+int LuaEngine::_subghz_endScan(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (eng && eng->_subghzBackend == SUBGHZ_CC1101 && eng->_subghzCc) {
+    eng->_subghzCc->endScan();
+  }
+  if (eng) eng->_subghzScanning = false;
+  return 0;
+}
+
+int LuaEngine::_subghz_getScanFreq(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (eng && eng->_subghzBackend == SUBGHZ_CC1101 && eng->_subghzCc) {
+    lua_pushnumber(L, eng->_subghzCc->getScanFreq());
+  } else {
+    lua_pushnumber(L, 0);
+  }
+  return 1;
+}
+
+int LuaEngine::_subghz_getScanRssi(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (eng && eng->_subghzBackend == SUBGHZ_CC1101 && eng->_subghzCc) {
+    lua_pushnumber(L, eng->_subghzCc->getScanRssi());
+  } else {
+    lua_pushnumber(L, -120);
+  }
+  return 1;
+}
+
+int LuaEngine::_subghz_startJam(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (!eng || !eng->_subghzEnsureOpen()) { lua_pushboolean(L, 0); return 1; }
+  if (eng->_subghzBackend == SUBGHZ_CC1101) {
+    eng->_subghzCc->startTx();
+  } else {
+    eng->_subghzRf->startJam();
+  }
+  eng->_subghzJamming = true;
+  lua_pushboolean(L, 1);
+  return 1;
+}
+
+int LuaEngine::_subghz_jamBurst(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (!eng || !eng->_subghzJamming) { lua_pushboolean(L, 0); return 1; }
+  if (eng->_subghzBackend == SUBGHZ_RF433 && eng->_subghzRf) {
+    eng->_subghzRf->jamBurst();
+  } else if (eng->_subghzBackend == SUBGHZ_CC1101) {
+    // Mirror SubGHzScreen::_radioJamBurst — CC1101Util parks the chip in TX
+    // mode via startTx(); the caller pulses GDO0 directly to drive the carrier.
+    int8_t gdo0 = (int8_t)PinConfig.get(PIN_CONFIG_CC1101_GDO0,
+                                        PIN_CONFIG_CC1101_GDO0_DEFAULT).toInt();
+    if (gdo0 < 0) { lua_pushboolean(L, 0); return 1; }
+    for (int i = 0; i < 50; i++) {
+      uint32_t pw  = 5 + (micros() % 46);
+      uint32_t gap = 5 + (micros() % 96);
+      digitalWrite(gdo0, HIGH); delayMicroseconds(pw);
+      digitalWrite(gdo0, LOW);  delayMicroseconds(gap);
+    }
+  }
+  lua_pushboolean(L, 1);
+  return 1;
+}
+
+int LuaEngine::_subghz_stopJam(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (!eng) return 0;
+  if (eng->_subghzBackend == SUBGHZ_CC1101 && eng->_subghzCc) {
+    int8_t gdo0 = (int8_t)PinConfig.get(PIN_CONFIG_CC1101_GDO0,
+                                        PIN_CONFIG_CC1101_GDO0_DEFAULT).toInt();
+    if (gdo0 >= 0) digitalWrite(gdo0, LOW);
+  } else if (eng->_subghzBackend == SUBGHZ_RF433 && eng->_subghzRf) {
+    eng->_subghzRf->stopJam();
+  }
+  eng->_subghzJamming = false;
+  // Match SubGHzScreen::_radioStopJam — full teardown so the chip starts
+  // each subsequent op from a clean state.
+  eng->_cleanupSubghz();
+  return 0;
+}
+
+int LuaEngine::_subghz_parseSub(lua_State* L) {
+  const char* content = luaL_checkstring(L, 1);
+  CC1101Util::Signal sig;
+  if (!CC1101Util::loadFile(String(content), sig)) { lua_pushnil(L); return 1; }
+  _signalToLuaTable(L, sig);
+  return 1;
+}
+
+int LuaEngine::_subghz_formatSub(lua_State* L) {
+  luaL_checktype(L, 1, LUA_TTABLE);
+  CC1101Util::Signal sig;
+  _signalFromLuaTable(L, 1, sig);
+  String out = CC1101Util::saveToString(sig);
+  lua_pushstring(L, out.c_str());
+  return 1;
+}
+
+int LuaEngine::_subghz_close(lua_State* L) {
+  LuaEngine* eng = _fromState(L);
+  if (eng) eng->_cleanupSubghz();
+  return 0;
 }

--- a/firmware/src/utils/interpreter/LuaEngine.h
+++ b/firmware/src/utils/interpreter/LuaEngine.h
@@ -7,6 +7,9 @@ extern "C" {
   #include "lualib.h"
 }
 
+class CC1101Util;
+class M5RF433Util;
+
 class LuaEngine {
 public:
   // Unique address used as a sentinel to distinguish clean exit() from errors.
@@ -197,6 +200,47 @@ private:
   // Tear down anything the script touched on the network side: WiFi (only if
   // the script started it) and any cached HTTP transport state.
   void _cleanupNetwork();
+
+  // uni.subghz — single facade over CC1101 (SPI) and M5 RF433 (GPIO bit-bang).
+  // The backend is decided lazily on the first call to _subghzEnsureOpen():
+  // CC1101 is tried first when its CS/GDO0 pins are configured and SPI is
+  // available; falls back to M5 RF433 when the board exposes Grove pins.
+  enum SubGhzBackend : uint8_t {
+    SUBGHZ_NONE   = 0,
+    SUBGHZ_CC1101 = 1,
+    SUBGHZ_RF433  = 2,
+  };
+  SubGhzBackend _subghzBackend   = SUBGHZ_NONE;
+  CC1101Util*   _subghzCc        = nullptr;
+  M5RF433Util*  _subghzRf        = nullptr;
+  bool          _subghzReceiving = false;
+  bool          _subghzScanning  = false;
+  bool          _subghzJamming   = false;
+
+  bool _subghzEnsureOpen();
+  void _cleanupSubghz();
+
+  // Lazy loader + bindings for uni.subghz.
+  static int _lua_load_subghz(lua_State* L);
+  static int _subghz_info(lua_State* L);
+  static int _subghz_setFrequency(lua_State* L);
+  static int _subghz_getFrequency(lua_State* L);
+  static int _subghz_setRxFilter(lua_State* L);
+  static int _subghz_beginReceive(lua_State* L);
+  static int _subghz_pollReceive(lua_State* L);
+  static int _subghz_endReceive(lua_State* L);
+  static int _subghz_send(lua_State* L);
+  static int _subghz_beginScan(lua_State* L);
+  static int _subghz_stepScan(lua_State* L);
+  static int _subghz_endScan(lua_State* L);
+  static int _subghz_getScanFreq(lua_State* L);
+  static int _subghz_getScanRssi(lua_State* L);
+  static int _subghz_startJam(lua_State* L);
+  static int _subghz_jamBurst(lua_State* L);
+  static int _subghz_stopJam(lua_State* L);
+  static int _subghz_parseSub(lua_State* L);
+  static int _subghz_formatSub(lua_State* L);
+  static int _subghz_close(lua_State* L);
 
   // uni.input.* — popup-bridge to firmware Input*Action classes.
   static int _input_text(lua_State* L);


### PR DESCRIPTION
## Summary

Adds `uni.subghz` to the Lua engine — a single facade over the two existing RF backends (`CC1101Util` SPI module and `M5RF433Util` Grove bit-bang), with the backend picked lazily on the first call needing the radio.

- CC1101 is tried first via SPI chip-ID probe; M5 RF433 is the GPIO fallback.
- Both backends share `CC1101Util::Signal` (via typedef), so the Lua-side signal table marshals identically through both paths.
- CC1101-only ops (`setFrequency`, `beginScan`) return `false, "unsupported on rf433"` on the GPIO backend.

## API

```lua
local subghz = require("uni.subghz")

subghz.info()                          -- { backend, freq, canTune, canScan }
subghz.setFrequency(433.92) / getFrequency()
subghz.setRxFilter("code"|"raw")
subghz.beginReceive() / pollReceive() / endReceive()
subghz.send(signalTable)               -- auto-hops freq on CC1101
subghz.beginScan() / stepScan() / endScan() / getScanFreq() / getScanRssi()
subghz.startJam() / jamBurst() / stopJam()
subghz.parseSub(content) / formatSub(signalTable)   -- Bruce .sub I/O
subghz.close()                         -- optional; deinit() does it too
```

## Design notes

- **Lifecycle**: `_cleanupSubghz()` runs from `LuaEngine::deinit()` so a crashing script can't leave the RX ISR armed or the CC1101 parked in TX. Mirrors how `_cleanupNetwork()` handles WiFi teardown.
- **TX/RX coexistence**: `send()` remembers whether RX was active, tears it down before transmitting, and re-arms after. Without this, pulses driven on GDO0 / RF433 TX re-fire the receive ISR and corrupt the buffer — same trap `SubGHzScreen::_radioSendCaptured` already documents.
- **Frequency hopping**: when `Signal.frequency` differs from the current CC1101 freq by >0.01 MHz, `send()` retunes before transmitting. Matches Bruce's send semantics.
- **Jam burst on CC1101**: replicates `SubGHzScreen::_radioJamBurst` (50 pulses with random width/gap directly on GDO0) since `CC1101Util::startTx()` only parks the chip — the carrier is driven manually.
- **Pin defaults**: CC1101 reads `cc1101_cs` / `cc1101_gdo0` from `PinConfigManager`, falling back to the board's `pins_arduino.h` defaults. RF433 falls back to `M5RF433_TX_PIN` / `RX_PIN` if defined, otherwise `GROVE_SDA` / `SCL`. Same logic `M5RF433Screen.cpp` already uses.

## Build verification

- `t_embed_cc1101` — CC1101 native ✅
- `m5_cardputer` — both backends viable on shared Grove pins ✅
- `m5_cardputer_adv` — same as cardputer, flashed and runtime-tested ✅
- `t_display_s3` — no RF pins at all (confirms conditional defaults degrade to `-1` cleanly) ✅

## Runtime test

Validated on `m5_cardputer_adv` with a demo script exercising `info` / `beginReceive` / `pollReceive` / `send` flows. `subghz.info()` returns the live backend (`rf433` when the Grove unit is plugged, `cc1101` when the SPI module is). Receive captures both RcSwitch-decoded protocols and raw streams.

## Test plan

- [ ] Build any board with `CC1101Util` available (e.g. `t_embed_cc1101`) and verify `subghz.info()` reports `backend = "cc1101"`, `canTune = true`, `canScan = true`.
- [x] Build a board where only M5 RF433 fits (cardputer with the Grove unit) and verify `backend = "rf433"`, `canTune = false`.
- [ ] Run a script that calls `setFrequency` on the RF433 backend; should return `false, "unsupported on rf433"` rather than crashing.
- [ ] Capture a remote with `beginReceive` / `pollReceive`, then replay it via `send` — confirm the captured signal table round-trips correctly.
- [ ] Force a script error during `beginReceive` (e.g. `error("boom")` mid-loop) and verify the next script launch starts with a clean radio (cleanup ran via `deinit()`).
