### PR TITLE
Fix: EAPOL Capture WiFi scan returns no networks (10s framework timeout)

### DIFF
--- a/firmware/src/screens/wifi/WifiEapolCaptureScreen.cpp
+++ b/firmware/src/screens/wifi/WifiEapolCaptureScreen.cpp
@@ -276,9 +276,13 @@ void WifiEapolCaptureScreen::_selectWifi() {
 
   WiFi.mode(WIFI_STA);
   WiFi.disconnect();
-  // 770 ms per channel × 13 channels ≈ 10 s — long sweep so weaker / less
-  // chatty APs have time to broadcast at least one beacon per channel.
-  const int total = WiFi.scanNetworks(false, false, false, 770, 0);
+  // Long-ish sweep so weaker / less chatty APs get airtime, but the per-channel
+  // dwell MUST stay under the framework's hard 10 s sync-scan timeout
+  // (WiFiScan.cpp waits WIFI_SCAN_DONE_BIT for 10000 ms, else WIFI_SCAN_FAILED).
+  // 600 ms × up to 14 channels = 8.4 s — comfortably below 10 s. The previous
+  // 770 ms × 13 channels = 10.01 s tipped over the timeout in 13-channel
+  // regulatory domains (EU/BR), so every scan returned "No networks found".
+  const int total = WiFi.scanNetworks(false, false, false, 600, 0);
 
   if (total <= 0) {
     ShowStatusAction::show("No networks found");


### PR DESCRIPTION
## Problem
In **EAPOL Capture → Target WiFi**, scanning consistently returns *"No networks found"* after running the full ~10 s, on 13-channel regulatory domains (EU/BR).

## Root cause
`_selectWifi()` called `WiFi.scanNetworks(false, false, false, 770, 0)` — **770 ms/channel** across all channels.

arduino-esp32's synchronous `scanNetworks` waits for `WIFI_SCAN_DONE_BIT` with a **hard-coded 10000 ms timeout** (`WiFiScan.cpp`) and returns `WIFI_SCAN_FAILED` (-2) otherwise.

In 13-channel domains: **770 ms × 13 = 10.01 s > 10.000 s** → the wait expires before the scan completes → `WIFI_SCAN_FAILED` → `total <= 0` → *"No networks found"*, every time. This is why other scan screens (Deauther/EvilTwin) work — they use the default 300 ms dwell.

## Fix
Drop the per-channel dwell to **600 ms** (600 ms × up to 14 channels = 8.4 s), comfortably under the framework's 10 s sync-scan timeout while still giving weaker/less-chatty APs airtime. Added a comment documenting the limit so it isn't reintroduced.

## Testing
Built and flashed to `m5_cardputer_adv` (build SUCCESS). One-line change.

```
- WiFi.scanNetworks(false, false, false, 770, 0);
+ WiFi.scanNetworks(false, false, false, 600, 0);
```
