### PR TITLE
refactor(ir): move IR TX/RX pins to Settings > Pin Setting

### DIFF
--- a/firmware/src/screens/module/IRScreen.cpp
+++ b/firmware/src/screens/module/IRScreen.cpp
@@ -36,13 +36,6 @@ void IRScreen::onInit() {
   _showMenu();
 }
 
-void IRScreen::_updatePinSublabels() {
-  _txPinSub = (_txPin >= 0) ? String("GPIO ") + String(_txPin) : "Not set";
-  _rxPinSub = (_rxPin >= 0) ? String("GPIO ") + String(_rxPin) : "Not set";
-  _menuItems[0] = {"TX Pin", _txPinSub.c_str()};
-  _menuItems[1] = {"RX Pin", _rxPinSub.c_str()};
-}
-
 void IRScreen::_showMenu() {
   _state = STATE_MENU;
   _ir.end();
@@ -51,7 +44,9 @@ void IRScreen::_showMenu() {
   _irAmpEnable(true);
   #endif
   strncpy(_titleBuf, "IR Remote", sizeof(_titleBuf));
-  _updatePinSublabels();
+  // Re-read pins in case they were changed under Settings > Pin Setting.
+  _txPin = (int8_t)PinConfig.getInt(PIN_CONFIG_IR_TX, PIN_CONFIG_IR_TX_DEFAULT);
+  _rxPin = (int8_t)PinConfig.getInt(PIN_CONFIG_IR_RX, PIN_CONFIG_IR_RX_DEFAULT);
   setItems(_menuItems);
 }
 
@@ -139,29 +134,7 @@ void IRScreen::onBack() {
 void IRScreen::onItemSelected(uint8_t index) {
   if (_state == STATE_MENU) {
     switch (index) {
-      case 0: { // TX Pin
-        int pin = InputNumberAction::popup("TX Pin", -1, 48, _txPin);
-        if (!InputNumberAction::wasCancelled()) {
-          _txPin = (int8_t)pin;
-          PinConfig.set(PIN_CONFIG_IR_TX, String(_txPin));
-          PinConfig.save(Uni.Storage);
-        }
-        _updatePinSublabels();
-        render();
-        break;
-      }
-      case 1: { // RX Pin
-        int pin = InputNumberAction::popup("RX Pin", -1, 48, _rxPin);
-        if (!InputNumberAction::wasCancelled()) {
-          _rxPin = (int8_t)pin;
-          PinConfig.set(PIN_CONFIG_IR_RX, String(_rxPin));
-          PinConfig.save(Uni.Storage);
-        }
-        _updatePinSublabels();
-        render();
-        break;
-      }
-      case 2: { // Receive
+      case 0: { // Receive
         if (_rxPin < 0) {
           ShowStatusAction::show("Set RX pin first");
           render();
@@ -183,7 +156,7 @@ void IRScreen::onItemSelected(uint8_t index) {
         setItems(_recvItems, 0);  // prime pointer once; _showReceiveList uses setCount after this
         break;
       }
-      case 3: { // Send
+      case 1: { // Send
         if (_txPin < 0) {
           ShowStatusAction::show("Set TX pin first");
           render();
@@ -197,7 +170,7 @@ void IRScreen::onItemSelected(uint8_t index) {
         _loadBrowseDir(kRootPath);
         break;
       }
-      case 4: { // TV-B-Gone
+      case 2: { // TV-B-Gone
         if (_txPin < 0) {
           ShowStatusAction::show("Set TX pin first");
           render();

--- a/firmware/src/screens/module/IRScreen.h
+++ b/firmware/src/screens/module/IRScreen.h
@@ -33,19 +33,14 @@ private:
   int8_t _rxPin = -1;
   char _titleBuf[32] = "IR Remote";
 
-  // Menu
-  ListItem _menuItems[5] = {
-    {"TX Pin"},
-    {"RX Pin"},
+  // Menu — IR TX/RX pins are configured under Settings > Pin Setting.
+  ListItem _menuItems[3] = {
     {"Receive"},
     {"Send"},
     {"TV-B-Gone"},
   };
-  String _txPinSub;
-  String _rxPinSub;
 
   void _showMenu();
-  void _updatePinSublabels();
 
   // Receive state
   IRUtil::Signal _captured[IRUtil::MAX_SIGNALS];

--- a/firmware/src/screens/setting/PinSettingScreen.cpp
+++ b/firmware/src/screens/setting/PinSettingScreen.cpp
@@ -64,6 +64,15 @@ void PinSettingScreen::onInit() {
   _map[_itemCount] = PIN_PN532_BAUD;
   _itemCount++;
 
+  // IR Remote pins (moved here from the IR Remote screen)
+  _items[_itemCount] = {"IR TX Pin", ""};
+  _map[_itemCount] = PIN_IR_TX;
+  _itemCount++;
+
+  _items[_itemCount] = {"IR RX Pin", ""};
+  _map[_itemCount] = PIN_IR_RX;
+  _itemCount++;
+
 #ifdef GROVE_5V_OUTPUT
   _items[_itemCount] = {"Grove 5V", ""};
   _map[_itemCount] = PIN_GROVE_5V;
@@ -87,6 +96,8 @@ void PinSettingScreen::_refresh() {
   _pn532TxSub = PinConfig.get(PIN_CONFIG_PN532_TX, PIN_CONFIG_PN532_TX_DEFAULT);
   _pn532RxSub = PinConfig.get(PIN_CONFIG_PN532_RX, PIN_CONFIG_PN532_RX_DEFAULT);
   _pn532BaudSub = PinConfig.get(PIN_CONFIG_PN532_BAUD, PIN_CONFIG_PN532_BAUD_DEFAULT);
+  _irTxSub = PinConfig.get(PIN_CONFIG_IR_TX, PIN_CONFIG_IR_TX_DEFAULT);
+  _irRxSub = PinConfig.get(PIN_CONFIG_IR_RX, PIN_CONFIG_IR_RX_DEFAULT);
   _grove5VSub = PinConfig.get(PIN_CONFIG_GROVE_5V, PIN_CONFIG_GROVE_5V_DEFAULT);
 
   for (uint8_t i = 0; i < _itemCount; i++) {
@@ -103,6 +114,8 @@ void PinSettingScreen::_refresh() {
       case PIN_PN532_TX:    _items[i].sublabel = _pn532TxSub.c_str(); break;
       case PIN_PN532_RX:    _items[i].sublabel = _pn532RxSub.c_str(); break;
       case PIN_PN532_BAUD:  _items[i].sublabel = _pn532BaudSub.c_str(); break;
+      case PIN_IR_TX:       _items[i].sublabel = _irTxSub.c_str(); break;
+      case PIN_IR_RX:       _items[i].sublabel = _irRxSub.c_str(); break;
       case PIN_GROVE_5V: _items[i].sublabel = _grove5VSub.c_str(); break;
     }
   }
@@ -218,6 +231,24 @@ void PinSettingScreen::onItemSelected(uint8_t index) {
       int val = InputNumberAction::popup("PN532 Baud Rate", 9600, 921600, cur);
       if (!InputNumberAction::wasCancelled()) {
         PinConfig.set(PIN_CONFIG_PN532_BAUD, String(val));
+        PinConfig.save(Uni.Storage);
+      }
+      break;
+    }
+    case PIN_IR_TX: {
+      int cur = PinConfig.getInt(PIN_CONFIG_IR_TX, PIN_CONFIG_IR_TX_DEFAULT);
+      int val = InputNumberAction::popup("IR TX Pin", -1, 48, cur);
+      if (!InputNumberAction::wasCancelled()) {
+        PinConfig.set(PIN_CONFIG_IR_TX, String(val));
+        PinConfig.save(Uni.Storage);
+      }
+      break;
+    }
+    case PIN_IR_RX: {
+      int cur = PinConfig.getInt(PIN_CONFIG_IR_RX, PIN_CONFIG_IR_RX_DEFAULT);
+      int val = InputNumberAction::popup("IR RX Pin", -1, 48, cur);
+      if (!InputNumberAction::wasCancelled()) {
+        PinConfig.set(PIN_CONFIG_IR_RX, String(val));
         PinConfig.save(Uni.Storage);
       }
       break;

--- a/firmware/src/screens/setting/PinSettingScreen.h
+++ b/firmware/src/screens/setting/PinSettingScreen.h
@@ -22,7 +22,7 @@ private:
 
   BackFactory _backFn = nullptr;
 
-  static const uint8_t MAX_ITEMS = 14;
+  static const uint8_t MAX_ITEMS = 16;
   ListItem _items[MAX_ITEMS];
   uint8_t _itemCount = 0;
 
@@ -31,6 +31,7 @@ private:
                  PIN_CC1101_CS, PIN_CC1101_GDO0,
                  PIN_NRF24_CE, PIN_NRF24_CSN,
                  PIN_PN532_TX, PIN_PN532_RX, PIN_PN532_BAUD,
+                 PIN_IR_TX, PIN_IR_RX,
                  PIN_GROVE_5V };
   PinType _map[MAX_ITEMS];
 
@@ -46,5 +47,7 @@ private:
   String _pn532TxSub;
   String _pn532RxSub;
   String _pn532BaudSub;
+  String _irTxSub;
+  String _irRxSub;
   String _grove5VSub;
 };


### PR DESCRIPTION
The IR Remote screen no longer owns the TX/RX pin items (now just Receive / Send / TV-B-Gone) and re-reads the pins from PinConfig on open. Pin Setting gains clearly-labelled **IR TX Pin** / **IR RX Pin** entries.