### PR TITLE
feat(subghz): Detect Freq history of the last 5 detections

### DIFF
--- a/firmware/src/screens/module/SubGHzScreen.cpp
+++ b/firmware/src/screens/module/SubGHzScreen.cpp
@@ -9,6 +9,17 @@
 #include "ui/views/ProgressView.h"
 #include "utils/rf/KeeloqKeystore.h"
 
+// Detect Freq strength colouring. All recorded hits sit above RSSI_THRESHOLD
+// (-65 dBm); split that detected band into strong (close) / medium / far.
+//   strong  >= -52 dBm → green
+//   medium  >= -60 dBm → yellow
+//   far      < -60 dBm → red
+static uint16_t detectStrengthColor(int rssi) {
+  if (rssi >= -52) return TFT_GREEN;
+  if (rssi >= -60) return TFT_YELLOW;
+  return TFT_RED;
+}
+
 void SubGHzScreen::onInit() {
   _csPin   = PinConfig.get(PIN_CONFIG_CC1101_CS,   PIN_CONFIG_CC1101_CS_DEFAULT).toInt();
   _gdo0Pin = PinConfig.get(PIN_CONFIG_CC1101_GDO0, PIN_CONFIG_CC1101_GDO0_DEFAULT).toInt();
@@ -212,6 +223,7 @@ void SubGHzScreen::_startScan() {
     return;
   }
   _rfDetectFired = false;
+  _clearHistory();
   _rf.beginScan();
   _state = STATE_SCANNING;
   _chromeDrawn = false;
@@ -230,11 +242,13 @@ bool SubGHzScreen::_onUpdateExtra() {
       return true;
     }
   }
-  _rf.stepScan();
-  if (!_rfDetectFired && _rf.getScanRssi() > CC1101Util::RSSI_THRESHOLD) {
-    _rfDetectFired = true;
-    int n = Achievement.inc("rf_detect_freq");
-    if (n == 1) Achievement.unlock("rf_detect_freq");
+  if (_rf.stepScan()) {  // signal above RSSI_THRESHOLD at the current frequency
+    if (!_rfDetectFired) {
+      _rfDetectFired = true;
+      int n = Achievement.inc("rf_detect_freq");
+      if (n == 1) Achievement.unlock("rf_detect_freq");
+    }
+    _recordHit(_rf.getScanFreq(), _rf.getScanRssi());
   }
   render();
   return true;
@@ -248,11 +262,15 @@ bool SubGHzScreen::_onRenderExtra() {
   static constexpr int kRssiCeiling = -30;
   static constexpr int kRssiRange   = kRssiCeiling - kRssiFloor; // 80
 
-  const int footerH = 16;
-  const int infoH   = 26;
-  const int contentH = bodyH() - footerH;
-  const int chartY   = infoH;
-  const int chartH   = contentH - infoH;
+  const int footerH   = 16;
+  const int infoH     = 14;                     // live freq/rssi row
+  const int histLineH = 9;
+  const int histH     = histLineH * (kHistMax + 1); // "Recent:" header + 5 rows
+  const int contentH  = bodyH() - footerH;
+  const int chartY    = infoH;
+  int chartBottom     = contentH - histH;
+  if (chartBottom < chartY + 8) chartBottom = chartY + 8; // keep a chart sliver
+  const int chartH    = chartBottom - chartY;
 
   if (!_chromeDrawn) {
     lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
@@ -272,18 +290,12 @@ bool SubGHzScreen::_onRenderExtra() {
   int barW  = bodyW() / (n ? n : 1);
   if (barW < 1) barW = 1;
 
-  uint8_t bestIdx  = 0;
-  int     bestRssi = -120;
-  for (uint8_t i = 0; i < n; i++) {
-    int r = _rf.getScanRssiAt(i);
-    if (r > bestRssi) { bestRssi = r; bestIdx = i; }
-  }
-
   Sprite sp(&lcd);
   sp.createSprite(bodyW(), contentH);
   sp.fillSprite(TFT_BLACK);
   sp.setTextSize(1);
 
+  // Live RSSI bar chart across all scanned channels.
   for (uint8_t i = 0; i < n; i++) {
     int rssi    = _rf.getScanRssiAt(i);
     int clamped = constrain(rssi, kRssiFloor, kRssiCeiling);
@@ -292,14 +304,14 @@ bool SubGHzScreen::_onRenderExtra() {
     int y       = chartY + chartH - barH;
 
     uint16_t color;
-    if (i == bestIdx && rssi > CC1101Util::RSSI_THRESHOLD)     color = TFT_YELLOW;
-    else if (rssi > CC1101Util::RSSI_THRESHOLD)                color = TFT_GREEN;
-    else if (rssi > kRssiFloor + 10)                           color = 0x2945;
-    else                                                       color = TFT_DARKGREY;
+    if (rssi > CC1101Util::RSSI_THRESHOLD)        color = detectStrengthColor(rssi);
+    else if (rssi > kRssiFloor + 10)              color = 0x2945;
+    else                                          color = TFT_DARKGREY;
 
     if (barH > 0) sp.fillRect(x, y, barW - 1, barH, color);
   }
 
+  // Marker on the channel currently being sampled.
   for (uint8_t i = 0; i < n; i++) {
     if (fabsf(_rf.getScanFreqAt(i) - _rf.getScanFreq()) < 0.01f) {
       sp.drawFastVLine(i * barW + barW / 2, chartY, chartH, TFT_WHITE);
@@ -307,33 +319,70 @@ bool SubGHzScreen::_onRenderExtra() {
     }
   }
 
+  // Live readout: current scan frequency (left) + current RSSI (right).
   sp.setTextDatum(ML_DATUM);
   sp.setTextColor(TFT_WHITE, TFT_BLACK);
   char freqBuf[20];
   snprintf(freqBuf, sizeof(freqBuf), "%.3f MHz", _rf.getScanFreq());
-  sp.drawString(freqBuf, 2, 7);
+  sp.drawString(freqBuf, 2, infoH / 2);
 
   sp.setTextDatum(MR_DATUM);
   char rssiBuf[16];
   snprintf(rssiBuf, sizeof(rssiBuf), "%d dBm", _rf.getScanRssi());
   uint16_t rssiColor = (_rf.getScanRssi() > CC1101Util::RSSI_THRESHOLD) ? TFT_GREEN : TFT_CYAN;
   sp.setTextColor(rssiColor, TFT_BLACK);
-  sp.drawString(rssiBuf, bodyW() - 2, 7);
+  sp.drawString(rssiBuf, bodyW() - 2, infoH / 2);
 
+  // History panel: last 5 detections, most-recent first (persists after the
+  // signal disappears, unlike the live chart).
+  const int histTop = contentH - histH;
   sp.setTextDatum(ML_DATUM);
-  if (bestRssi > CC1101Util::RSSI_THRESHOLD) {
-    sp.setTextColor(TFT_YELLOW, TFT_BLACK);
-    char bestBuf[28];
-    snprintf(bestBuf, sizeof(bestBuf), "> %.3f MHz %ddBm", _rf.getScanFreqAt(bestIdx), bestRssi);
-    sp.drawString(bestBuf, 2, 19);
-  } else {
-    sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-    sp.drawString("No signal", 2, 19);
+  sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
+  sp.drawString("Recent:", 2, histTop + histLineH / 2 + 1);
+
+  for (uint8_t i = 0; i < kHistMax; i++) {
+    int ry = histTop + histLineH * (i + 1) + histLineH / 2 + 1;
+    if (i < _histCount) {
+      sp.setTextColor(detectStrengthColor(_hist[i].rssi), TFT_BLACK);
+      char fb[16];
+      snprintf(fb, sizeof(fb), "%.3f MHz", _hist[i].freq);
+      sp.setTextDatum(ML_DATUM);
+      sp.drawString(fb, 2, ry);
+      char rb[12];
+      snprintf(rb, sizeof(rb), "%d dBm", _hist[i].rssi);
+      sp.setTextDatum(MR_DATUM);
+      sp.drawString(rb, bodyW() - 2, ry);
+    } else {
+      sp.setTextColor(0x2945, TFT_BLACK);
+      sp.setTextDatum(ML_DATUM);
+      sp.drawString("--", 2, ry);
+    }
   }
 
   sp.pushSprite(bodyX(), bodyY());
   sp.deleteSprite();
   return true;
+}
+
+void SubGHzScreen::_recordHit(float freq, int rssi) {
+  uint32_t now = millis();
+  // Dedup across ALL slots, not just the top: the sweep visits every channel,
+  // so two simultaneous strong signals (e.g. 433.92 + 868.35) alternate as the
+  // newest hit. Checking only slot 0 let them flood the list with duplicate
+  // rows. Refreshing the existing slot in place (keeping its peak RSSI, no
+  // reordering) keeps the list stable — it only grows with genuinely new
+  // frequencies.
+  for (uint8_t i = 0; i < _histCount; i++) {
+    if (fabsf(_hist[i].freq - freq) < 0.01f) {
+      if (rssi > _hist[i].rssi) _hist[i].rssi = rssi;
+      _hist[i].when = now;
+      return;
+    }
+  }
+  for (int i = (_histCount < kHistMax ? _histCount : kHistMax - 1); i > 0; i--)
+    _hist[i] = _hist[i - 1];
+  _hist[0] = { freq, rssi, now };
+  if (_histCount < kHistMax) _histCount++;
 }
 
 bool SubGHzScreen::_onBackExtra() {

--- a/firmware/src/screens/module/SubGHzScreen.h
+++ b/firmware/src/screens/module/SubGHzScreen.h
@@ -65,4 +65,15 @@ private:
   void _selectFrequency();
   void _startScan();
   void _reloadMfcodes();
+
+  // ── Detect Freq history (last 5 detections, most-recent first) ──────────
+  // The live RSSI bar chart only reflects the current sweep, so a detected
+  // frequency vanishes the instant the signal stops. This keeps the last 5
+  // hits on screen, coloured by strength, until the next scan session.
+  struct DetectHit { float freq; int rssi; uint32_t when; };
+  static constexpr uint8_t kHistMax = 5;
+  DetectHit _hist[kHistMax]{};
+  uint8_t   _histCount = 0;
+  void _recordHit(float freq, int rssi);
+  void _clearHistory() { _histCount = 0; }
 };


### PR DESCRIPTION
The Detect Freq view only showed a live RSSI bar chart, so a detected frequency vanished the moment the signal stopped.

- Adds a persistent **Recent:** panel with the last 5 detected frequencies (deduped across slots, most-recent first), kept until the next scan session.
- Chart bars **and** history rows are now coloured by signal strength: green (strong) / yellow (medium) / red (far), replacing the single "best" highlight.

Builds clean and flash-tested on `m5_cardputer_adv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)