### PR TITLE
fix(rf/ir): browse the whole SD card from Send + fix receive list redraw

### DIFF
--- a/firmware/src/screens/module/IRScreen.cpp
+++ b/firmware/src/screens/module/IRScreen.cpp
@@ -390,7 +390,9 @@ void IRScreen::_loadBrowseDir(const String& path) {
   if (path == kRootPath) folderName = "IR Files";
   snprintf(_titleBuf, sizeof(_titleBuf), "%s", folderName.c_str());
 
-  _browser.root = kRootPath;
+  // Root at "/" so a ".." row is shown even at kRootPath, letting the picker
+  // climb to the SD card and reach .ir files outside /unigeek/ir.
+  _browser.root = "/";
   uint8_t n = _browser.load(this, path, ".ir");
 
   if (n == 0 && path == kRootPath) {

--- a/firmware/src/screens/module/RfCaptureScreen.cpp
+++ b/firmware/src/screens/module/RfCaptureScreen.cpp
@@ -277,6 +277,14 @@ void RfCaptureScreen::_showReceiveList() {
            _titlePrefix(), _capturedCount, kMaxCapture);
   _rebuildCapturedItems();
   setCount(_capturedCount);
+  // When the list empties (e.g. all signals deleted), force a chrome redraw so
+  // the "Waiting for signal" screen returns instead of a stale/black list.
+  if (_capturedCount == 0) {
+    _chromeDrawn   = false;
+    _selectedIndex = 0;
+  } else if (_selectedIndex >= _capturedCount) {
+    _selectedIndex = _capturedCount - 1;
+  }
   render();
 }
 
@@ -489,10 +497,11 @@ void RfCaptureScreen::_loadBrowseDir(const String& path) {
     Uni.Storage->makeDir(path.c_str());
   }
 
-  // _browser.root confines the picker to kRootPath — ".." appears below
-  // the root but never resolves above it. BACK still works the same; this
-  // is just the in-list alternative.
-  _browser.root = kRootPath;
+  // Let the picker climb the whole card: a ".." row is shown whenever the
+  // loaded dir differs from root. Rooting at "/" means even the default
+  // kRootPath ("/unigeek/rf") gets a ".." so other .sub files on the SD card
+  // are reachable, not just this folder.
+  _browser.root = "/";
   uint8_t n = _browser.load(this, path, ".sub");
   setItems(_browser.items(), n);
 }


### PR DESCRIPTION
Two RF/IR screen fixes:

- **Send file pickers** (Sub-GHz, M5 RF433 via shared `RfCaptureScreen`, and IR) were rooted at their own folder (`/unigeek/rf`, `/unigeek/ir`), so no `..` row appeared at the entry dir and only that folder's files were selectable. Root `BrowseFileView` at `/` so a `..` row shows immediately and the picker can climb to the SD card root.
- **Receive list** no longer goes black after deleting all captured signals: `_showReceiveList()` forces a chrome redraw when the list empties so the "Waiting for signal" screen returns.

Builds clean and flash-tested on `m5_cardputer_adv`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)