### PR TITLE
feat(subghz): Bruce-style Mode/Filter menu on OK in Receive

### DIFF
--- a/firmware/src/screens/module/RfCaptureScreen.cpp
+++ b/firmware/src/screens/module/RfCaptureScreen.cpp
@@ -70,6 +70,9 @@ void RfCaptureScreen::onUpdate() {
         render();
       } else if (dir == INavigation::DIR_BACK) {
         onBack();
+      } else if (dir == INavigation::DIR_PRESS) {
+        // OK opens the receive menu — available even before any capture.
+        onItemSelected(_selectedIndex);
       } else if (_capturedCount > 0) {
         if (dir == INavigation::DIR_UP) {
           _selectedIndex = (_selectedIndex == 0) ? _capturedCount - 1 : _selectedIndex - 1;
@@ -79,8 +82,6 @@ void RfCaptureScreen::onUpdate() {
           _selectedIndex = (_selectedIndex >= _capturedCount - 1) ? 0 : _selectedIndex + 1;
           setCount(_capturedCount);
           render();
-        } else if (dir == INavigation::DIR_PRESS) {
-          onItemSelected(_selectedIndex);
         }
       }
       return;
@@ -229,11 +230,7 @@ void RfCaptureScreen::onItemSelected(uint8_t index) {
   }
 
   if (_state == STATE_RECEIVING) {
-    if (index < _capturedCount) {
-      _handleCaptureSelection(index);
-      // If a deletion freed a slot and receive was stopped, restart it.
-      if (_capturedCount < kMaxCapture) _radioBeginReceive();
-    }
+    _onReceiveOk(index);
     return;
   }
 
@@ -245,6 +242,14 @@ void RfCaptureScreen::onItemSelected(uint8_t index) {
     }
     _showBrowseOptions(index);
     return;
+  }
+}
+
+void RfCaptureScreen::_onReceiveOk(uint8_t index) {
+  if (index < _capturedCount) {
+    _handleCaptureSelection(index);
+    // If a deletion freed a slot and receive was stopped, restart it.
+    if (_capturedCount < kMaxCapture) _radioBeginReceive();
   }
 }
 
@@ -275,6 +280,10 @@ void RfCaptureScreen::_enterJammingMode() {
 void RfCaptureScreen::_showReceiveList() {
   snprintf(_titleBuf, sizeof(_titleBuf), "%s RX (%d/%d)",
            _titlePrefix(), _capturedCount, kMaxCapture);
+  // Back to an empty list (last signal deleted): the count==0 render path is
+  // gated by _chromeDrawn, so clear it to force the "Waiting..." view to redraw
+  // instead of leaving the stale list / popup remnants on screen.
+  if (_capturedCount == 0) _chromeDrawn = false;
   _rebuildCapturedItems();
   setCount(_capturedCount);
   render();

--- a/firmware/src/screens/module/RfCaptureScreen.h
+++ b/firmware/src/screens/module/RfCaptureScreen.h
@@ -99,6 +99,11 @@ protected:
   virtual bool _onItemSelectedExtra(uint8_t /*idx*/) { return false; }
   virtual bool _inhibitExtra() const        { return false; }
 
+  // OK pressed while receiving. Default: open the selected capture's options
+  // (when one is selected). Derived may override to add a settings menu that
+  // is reachable even with no captured signal yet.
+  virtual void _onReceiveOk(uint8_t index);
+
   // ── Shared helpers (called by base + reusable by derived) ──────────────
   void   _enterReceiveMode();
   void   _enterJammingMode();

--- a/firmware/src/screens/module/SubGHzScreen.cpp
+++ b/firmware/src/screens/module/SubGHzScreen.cpp
@@ -198,6 +198,57 @@ void SubGHzScreen::_selectFrequency() {
   render();
 }
 
+// ── Receive OK menu (Bruce-style: Mode + Filter) ─────────────────────────────
+//
+// Receive starts directly into "Waiting for signal...". Pressing OK opens this
+// popup. Mirrors Bruce's select_menu_option(): toggling Mode/Filter re-opens
+// the menu so the new value is visible; "Signal options" (only when a captured
+// row is selected) hands off to the base per-signal popup; "Close" resumes.
+void SubGHzScreen::_onReceiveOk(uint8_t index) {
+  bool hasSignal = index < _capturedCount;
+
+  while (true) {
+    const char* modeLabel   = (_rf.getRxMode() == CC1101Util::RX_MODE_DECODE)
+                              ? "Mode: Decode" : "Mode: RAW";
+    const char* filterLabel = (_rf.getRxFilter() == CC1101Util::RX_FILTER_CODE)
+                              ? "Filter: Code" : "Filter: Raw";
+
+    InputSelectAction::Option opts[4];
+    uint8_t n = 0;
+    if (hasSignal) opts[n++] = {"Signal options", "signal"};
+    opts[n++] = {modeLabel,   "mode"};
+    opts[n++] = {filterLabel, "filter"};
+    opts[n++] = {"Close",     "close"};
+
+    const char* choice = InputSelectAction::popup("Receive", opts, n);
+    if (!choice) break;  // cancelled
+
+    if (strcmp(choice, "mode") == 0) {
+      _rf.setRxMode(_rf.getRxMode() == CC1101Util::RX_MODE_DECODE
+                    ? CC1101Util::RX_MODE_RAW : CC1101Util::RX_MODE_DECODE);
+      if (Uni.Speaker) Uni.Speaker->beep();
+      continue;  // reopen with updated label
+    }
+    if (strcmp(choice, "filter") == 0) {
+      _rf.setRxFilter(_rf.getRxFilter() == CC1101Util::RX_FILTER_CODE
+                      ? CC1101Util::RX_FILTER_RAW : CC1101Util::RX_FILTER_CODE);
+      if (Uni.Speaker) Uni.Speaker->beep();
+      continue;  // reopen with updated label
+    }
+    if (strcmp(choice, "signal") == 0) {
+      _handleCaptureSelection(index);  // own popups + render
+    }
+    break;  // "close", "signal", or anything else
+  }
+
+  // Re-arm RX (a Full buffer detached it) and force a clean redraw — the popup
+  // overlay covered the screen, and the count==0 waiting view would otherwise
+  // be skipped by the _chromeDrawn guard, leaving a black screen.
+  if (_capturedCount < kMaxCapture) _radioBeginReceive();
+  _chromeDrawn = false;
+  render();
+}
+
 // ── Frequency scan (STATE_SCANNING) ─────────────────────────────────────────
 
 void SubGHzScreen::_startScan() {

--- a/firmware/src/screens/module/SubGHzScreen.h
+++ b/firmware/src/screens/module/SubGHzScreen.h
@@ -43,6 +43,10 @@ protected:
   bool _onBackExtra()               override;
   bool _inhibitExtra() const        override { return _state == STATE_SCANNING; }
 
+  // Bruce-style OK menu shown during receive (Mode + Filter, plus the
+  // captured-signal actions when a row is selected).
+  void _onReceiveOk(uint8_t index)  override;
+
 private:
   CC1101Util _rf;
   int8_t _csPin   = -1;

--- a/firmware/src/utils/rf/CC1101Util.cpp
+++ b/firmware/src/utils/rf/CC1101Util.cpp
@@ -140,7 +140,7 @@ bool CC1101Util::beginReceive() {
 bool CC1101Util::pollReceive(Signal& out) {
   if (!_initialized) return false;
 
-  if (_sw.available()) {
+  if (_rxMode == RX_MODE_DECODE && _sw.available()) {
     uint64_t val = _sw.getReceivedValue();
     if (val != 0) {
       out.frequency = _freq;
@@ -163,7 +163,9 @@ bool CC1101Util::pollReceive(Signal& out) {
     _sw.resetAvailable();
   }
 
-  if (_rxFilter == RX_FILTER_RAW && _sw.RAWavailable()) {
+  // Raw pulse capture: always in RAW mode; in DECODE mode only when the filter
+  // is set to RAW (CODE filter drops anything no protocol matched).
+  if ((_rxMode == RX_MODE_RAW || _rxFilter == RX_FILTER_RAW) && _sw.RAWavailable()) {
     delay(400); // let full signal arrive
     unsigned int* raw = _sw.getRAWReceivedRawdata();
     String rawStr;

--- a/firmware/src/utils/rf/CC1101Util.h
+++ b/firmware/src/utils/rf/CC1101Util.h
@@ -25,6 +25,14 @@ public:
     RX_FILTER_RAW,
   };
 
+  // Receive mode — applied by pollReceive().
+  //   RX_MODE_DECODE: attempt RCSwitch protocol decode on every detected signal.
+  //   RX_MODE_RAW   : never decode; capture raw pulse streams only.
+  enum RxMode {
+    RX_MODE_RAW,
+    RX_MODE_DECODE,
+  };
+
   struct Signal {
     float frequency = 0;     // MHz
     String preset = "0";     // modulation preset name or RcSwitch protocol number
@@ -72,6 +80,9 @@ public:
   void     setRxFilter(RxFilter f) { _rxFilter = f; }
   RxFilter getRxFilter() const     { return _rxFilter; }
 
+  void     setRxMode(RxMode m) { _rxMode = m; }
+  RxMode   getRxMode() const   { return _rxMode; }
+
   // Non-blocking frequency scan:
   //   1. call beginScan() once when entering scan state
   //   2. call stepScan() every frame — returns true when a signal is detected
@@ -117,6 +128,7 @@ private:
 
   RCSwitchUtil _sw;  // persistent receiver state for non-blocking polling
   RxFilter     _rxFilter = RX_FILTER_CODE;
+  RxMode       _rxMode   = RX_MODE_DECODE;
 
   // Scan status (updated during receive/scan)
   bool    _scanning = false;


### PR DESCRIPTION
## What
- Receive now starts directly into "Waiting for signal…". Pressing **OK** opens a Bruce-style popup (mirrors `rf_scan`'s `select_menu_option`):
  - **Mode:** Decode ↔ RAW
  - **Filter:** Code ↔ Raw
  - **Signal options** (only when a captured row is selected) → existing per-signal actions
  - **Close**
- Toggling Mode/Filter reopens the menu so the new value is visible.
- New `RxMode` in `CC1101Util`: in **Decode** mode `pollReceive` decodes any detected signal; in **RAW** mode it skips decoding and captures raw pulses only.

## Fix
- Black-screen bug: deleting the last captured signal returned the list to empty, but the `count==0` render path was gated by `_chromeDrawn` and never redrew the waiting view. `_showReceiveList()` now clears the flag when empty.

## Test
- Built clean for `m5_cardputer_adv`.
- Sub-GHz → Receive → OK opens Mode/Filter menu; capture signals, delete all, confirm it returns to "Waiting…" with no black screen.