### PR TITLE
🛰️ subghz: peaky frequency analyzer

### DIFF
--- a/firmware/src/screens/module/SubGHzScreen.cpp
+++ b/firmware/src/screens/module/SubGHzScreen.cpp
@@ -227,8 +227,7 @@ void SubGHzScreen::_startScan() {
     return;
   }
   _rfDetectFired = false;
-  _clearHistory();
-  _rf.beginScan();
+  _rf.beginAnalyze();
   _state = STATE_SCANNING;
   _chromeDrawn = false;
   strcpy(_titleBuf, "Detect Freq");
@@ -241,19 +240,18 @@ bool SubGHzScreen::_onUpdateExtra() {
   if (Uni.Nav->wasPressed()) {
     auto dir = Uni.Nav->readDirection();
     if (dir == INavigation::DIR_BACK || dir == INavigation::DIR_PRESS) {
-      _rf.endScan();
+      _rf.endAnalyze();
       _rf.end();
       _showMenu();
       return true;
     }
   }
-  if (_rf.stepScan()) {  // signal above RSSI_THRESHOLD at the current frequency
+  if (_rf.analyzeStep() && _rf.isPeakLive()) {  // a live peak above the trigger
     if (!_rfDetectFired) {
       _rfDetectFired = true;
       int n = Achievement.inc("rf_detect_freq");
       if (n == 1) Achievement.unlock("rf_detect_freq");
     }
-    _recordHit(_rf.getScanFreq(), _rf.getScanRssi());
   }
   render();
   return true;
@@ -268,15 +266,8 @@ bool SubGHzScreen::_onRenderExtra() {
   static constexpr int kRssiCeiling = -30;
   static constexpr int kRssiRange   = kRssiCeiling - kRssiFloor; // 80
 
-  const int footerH   = 16;
-  const int infoH     = 14;                     // live freq/rssi row
-  const int histLineH = 9;
-  const int histH     = histLineH * (kHistMax + 1); // "Recent:" header + 5 rows
-  const int contentH  = bodyH() - footerH;
-  const int chartY    = infoH;
-  int chartBottom     = contentH - histH;
-  if (chartBottom < chartY + 8) chartBottom = chartY + 8; // keep a chart sliver
-  const int chartH    = chartBottom - chartY;
+  const int footerH  = 16;
+  const int contentH = bodyH() - footerH;
 
   if (!_chromeDrawn) {
     lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
@@ -292,103 +283,58 @@ bool SubGHzScreen::_onRenderExtra() {
     _chromeDrawn = true;
   }
 
-  uint8_t n = _rf.getScanCount();
-  int barW  = bodyW() / (n ? n : 1);
-  if (barW < 1) barW = 1;
+  const int  W    = bodyW();
+  const bool held = _rf.getPeakFreq() > 0;
+  const bool live = _rf.isPeakLive();
+  const int  rssi = _rf.getPeakRssi();
+
+  // Peak frequency colour: dim grey while searching, strength-coloured when a
+  // live carrier is locked, muted while sample-holding the last peak.
+  uint16_t peakColor = !held ? 0x4208 : (live ? detectStrengthColor(rssi) : 0x5AEB);
 
   Sprite sp(&lcd);
-  sp.createSprite(bodyW(), contentH);
+  sp.createSprite(W, contentH);
   sp.fillSprite(TFT_BLACK);
+
+  // ── Big peak frequency (Flipper "peaky" readout) ────────────────────────
+  const int fSize = (W >= 200) ? 3 : 2;
+  const int freqY = contentH * 34 / 100;
+  char fb[16];
+  if (held) snprintf(fb, sizeof(fb), "%.3f", _rf.getPeakFreq());
+  else      snprintf(fb, sizeof(fb), "---.---");
+  sp.setTextDatum(MC_DATUM);
+  sp.setTextSize(fSize);
+  sp.setTextColor(peakColor, TFT_BLACK);
+  sp.drawString(fb, W / 2, freqY);
+
   sp.setTextSize(1);
-
-  // Live RSSI bar chart across all scanned channels.
-  for (uint8_t i = 0; i < n; i++) {
-    int rssi    = _rf.getScanRssiAt(i);
-    int clamped = constrain(rssi, kRssiFloor, kRssiCeiling);
-    int barH    = (clamped - kRssiFloor) * chartH / kRssiRange;
-    int x       = i * barW;
-    int y       = chartY + chartH - barH;
-
-    uint16_t color;
-    if (rssi > CC1101Util::RSSI_THRESHOLD)        color = detectStrengthColor(rssi);
-    else if (rssi > kRssiFloor + 10)              color = 0x2945;
-    else                                          color = TFT_DARKGREY;
-
-    if (barH > 0) sp.fillRect(x, y, barW - 1, barH, color);
-  }
-
-  // Marker on the channel currently being sampled.
-  for (uint8_t i = 0; i < n; i++) {
-    if (fabsf(_rf.getScanFreqAt(i) - _rf.getScanFreq()) < 0.01f) {
-      sp.drawFastVLine(i * barW + barW / 2, chartY, chartH, TFT_WHITE);
-      break;
-    }
-  }
-
-  // Live readout: current scan frequency (left) + current RSSI (right).
-  sp.setTextDatum(ML_DATUM);
-  sp.setTextColor(TFT_WHITE, TFT_BLACK);
-  char freqBuf[20];
-  snprintf(freqBuf, sizeof(freqBuf), "%.3f MHz", _rf.getScanFreq());
-  sp.drawString(freqBuf, 2, infoH / 2);
-
-  sp.setTextDatum(MR_DATUM);
-  char rssiBuf[16];
-  snprintf(rssiBuf, sizeof(rssiBuf), "%d dBm", _rf.getScanRssi());
-  uint16_t rssiColor = (_rf.getScanRssi() > CC1101Util::RSSI_THRESHOLD) ? TFT_GREEN : TFT_CYAN;
-  sp.setTextColor(rssiColor, TFT_BLACK);
-  sp.drawString(rssiBuf, bodyW() - 2, infoH / 2);
-
-  // History panel: last 5 detections, most-recent first (persists after the
-  // signal disappears, unlike the live chart).
-  const int histTop = contentH - histH;
-  sp.setTextDatum(ML_DATUM);
   sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-  sp.drawString("Recent:", 2, histTop + histLineH / 2 + 1);
+  sp.drawString("MHz", W / 2, freqY + fSize * 4 + 7);
 
-  for (uint8_t i = 0; i < kHistMax; i++) {
-    int ry = histTop + histLineH * (i + 1) + histLineH / 2 + 1;
-    if (i < _histCount) {
-      sp.setTextColor(detectStrengthColor(_hist[i].rssi), TFT_BLACK);
-      char fb[16];
-      snprintf(fb, sizeof(fb), "%.3f MHz", _hist[i].freq);
-      sp.setTextDatum(ML_DATUM);
-      sp.drawString(fb, 2, ry);
-      char rb[12];
-      snprintf(rb, sizeof(rb), "%d dBm", _hist[i].rssi);
-      sp.setTextDatum(MR_DATUM);
-      sp.drawString(rb, bodyW() - 2, ry);
-    } else {
-      sp.setTextColor(0x2945, TFT_BLACK);
-      sp.setTextDatum(ML_DATUM);
-      sp.drawString("--", 2, ry);
-    }
+  // ── Status + RSSI value ─────────────────────────────────────────────────
+  char line[24];
+  uint16_t statCol;
+  if (!held)      { strcpy(line, "scanning...");                         statCol = TFT_DARKGREY; }
+  else if (live)  { snprintf(line, sizeof(line), "LIVE  %d dBm", rssi);  statCol = TFT_GREEN;     }
+  else            { snprintf(line, sizeof(line), "hold  %d dBm", rssi);  statCol = TFT_ORANGE;    }
+  sp.setTextColor(statCol, TFT_BLACK);
+  sp.drawString(line, W / 2, contentH * 64 / 100);
+
+  // ── RSSI bar ────────────────────────────────────────────────────────────
+  const int barMargin = 8;
+  const int barW = W - barMargin * 2;
+  const int barH = 7;
+  const int barY = contentH * 80 / 100;
+  sp.drawRect(barMargin, barY, barW, barH, TFT_DARKGREY);
+  if (held) {
+    int clamped = constrain(rssi, kRssiFloor, kRssiCeiling);
+    int fillW   = (clamped - kRssiFloor) * (barW - 2) / kRssiRange;
+    if (fillW > 0) sp.fillRect(barMargin + 1, barY + 1, fillW, barH - 2, peakColor);
   }
 
   sp.pushSprite(bodyX(), bodyY());
   sp.deleteSprite();
   return true;
-}
-
-void SubGHzScreen::_recordHit(float freq, int rssi) {
-  uint32_t now = millis();
-  // Dedup across ALL slots, not just the top: the sweep visits every channel,
-  // so two simultaneous strong signals (e.g. 433.92 + 868.35) alternate as the
-  // newest hit. Checking only slot 0 let them flood the list with duplicate
-  // rows. Refreshing the existing slot in place (keeping its peak RSSI, no
-  // reordering) keeps the list stable — it only grows with genuinely new
-  // frequencies.
-  for (uint8_t i = 0; i < _histCount; i++) {
-    if (fabsf(_hist[i].freq - freq) < 0.01f) {
-      if (rssi > _hist[i].rssi) _hist[i].rssi = rssi;
-      _hist[i].when = now;
-      return;
-    }
-  }
-  for (int i = (_histCount < kHistMax ? _histCount : kHistMax - 1); i > 0; i--)
-    _hist[i] = _hist[i - 1];
-  _hist[0] = { freq, rssi, now };
-  if (_histCount < kHistMax) _histCount++;
 }
 
 bool SubGHzScreen::_onBackExtra() {
@@ -399,7 +345,7 @@ bool SubGHzScreen::_onBackExtra() {
     return true;
   }
   if (_state != STATE_SCANNING) return false;
-  _rf.endScan();
+  _rf.endAnalyze();
   _rf.end();
   _showMenu();
   return true;

--- a/firmware/src/screens/module/SubGHzScreen.h
+++ b/firmware/src/screens/module/SubGHzScreen.h
@@ -71,17 +71,6 @@ private:
   void _startScan();
   void _reloadMfcodes();
 
-  // ── Detect Freq history (last 5 detections, most-recent first) ──────────
-  // The live RSSI bar chart only reflects the current sweep, so a detected
-  // frequency vanishes the instant the signal stops. This keeps the last 5
-  // hits on screen, coloured by strength, until the next scan session.
-  struct DetectHit { float freq; int rssi; uint32_t when; };
-  static constexpr uint8_t kHistMax = 5;
-  DetectHit _hist[kHistMax]{};
-  uint8_t   _histCount = 0;
-  void _recordHit(float freq, int rssi);
-  void _clearHistory() { _histCount = 0; }
-
   // ── Waterfall (RSSI spectrogram) ───────────────────────────────────────
   // A scrolling RSSI heat-map across a [start,end] MHz window, swept per pixel
   // over SPI. The pre-run popup picks the band; the run scrolls one freshly

--- a/firmware/src/utils/rf/CC1101Util.cpp
+++ b/firmware/src/utils/rf/CC1101Util.cpp
@@ -227,6 +227,85 @@ void CC1101Util::endScan() {
   if (_initialized) ELECHOUSE_cc1101.setSidle();
 }
 
+// ── Frequency analyzer (Flipper-style peak detect) ──────────────────────────
+
+static inline bool cc1101_freq_valid(float mhz) {
+  return (mhz >= 280 && mhz <= 350) ||
+         (mhz >= 387 && mhz <= 468) ||
+         (mhz >= 779 && mhz <= 928);
+}
+
+void CC1101Util::beginAnalyze() {
+  if (!_initialized) return;
+  _scanning = true;
+  _peakFreq = 0;
+  _peakRssi = -120;
+  _peakLive = false;
+  _holdCtr  = 0;
+  for (uint8_t i = 0; i < kFreqCount; i++) _scanRssiMap[i] = -120;
+  // Enter RX once and STAY in RX for the whole session (RxBW inherited from
+  // begin() = 256 kHz — the same proven path as beginScan/stepScan). Re-issuing
+  // SetRx() per frame would SIDLE→SRX and reset the AGC, pinning RSSI at the
+  // noise floor so nothing is ever detected.
+  ELECHOUSE_cc1101.SetRx();
+}
+
+bool CC1101Util::analyzeStep() {
+  if (!_initialized || !_scanning) return false;
+
+  // ── Stage 1: coarse sweep — whole band, find the strongest channel. Stay in
+  // RX and only retune (setMHZ); this is the exact RF path stepScan uses. Also
+  // fills _scanRssiMap so the (optional) bar chart keeps updating.
+  int   coarseRssi = -127;
+  float coarseFreq = 0;
+  for (uint8_t i = 0; i < kFreqCount; i++) {
+    float f = kFreqList[i];
+    ELECHOUSE_cc1101.setMHZ(f);
+    delay(2);
+    int rssi = ELECHOUSE_cc1101.getRssi();
+    _scanRssiMap[i] = rssi;
+    _scanFreq = f;
+    _scanRssi = rssi;
+    if (rssi > coarseRssi) { coarseRssi = rssi; coarseFreq = f; }
+  }
+
+  // ── Stage 2: fine refine — ±0.3 MHz around the coarse peak in 20 kHz steps to
+  // pin the exact carrier (a signal at e.g. 433.66, not on the coarse list, is
+  // located here). Same RX/BW path — just a denser retune sweep.
+  if (coarseRssi > kAnalyzerTrigger) {
+    int   fineRssi = -127;
+    float fineFreq = coarseFreq;
+    for (float f = coarseFreq - 0.30f; f <= coarseFreq + 0.3001f; f += 0.02f) {
+      if (!cc1101_freq_valid(f)) continue;
+      ELECHOUSE_cc1101.setMHZ(f);
+      delay(2);
+      int rssi = ELECHOUSE_cc1101.getRssi();
+      if (rssi > fineRssi) { fineRssi = rssi; fineFreq = f; }
+    }
+    _peakFreq = fineFreq;
+    _peakRssi = fineRssi;
+    _peakLive = true;
+    _holdCtr  = kAnalyzerHold;
+    return true;
+  }
+
+  // ── No live signal: hold the last peak for a while (sample-hold), then clear.
+  if (_holdCtr > 0) {
+    _holdCtr--;
+    _peakLive = false;
+    return true;
+  }
+  _peakFreq = 0;
+  _peakRssi = -120;
+  _peakLive = false;
+  return false;
+}
+
+void CC1101Util::endAnalyze() {
+  _scanning = false;
+  if (_initialized) ELECHOUSE_cc1101.setSidle();
+}
+
 void CC1101Util::_initRx() {
   ELECHOUSE_cc1101.setModulation(2);
   ELECHOUSE_cc1101.setPktFormat(3);

--- a/firmware/src/utils/rf/CC1101Util.h
+++ b/firmware/src/utils/rf/CC1101Util.h
@@ -87,6 +87,20 @@ public:
   int  rssiAt(float mhz);
   void endRssiSweep();
 
+  // ── Frequency analyzer (Flipper-style "peaky" peak detect) ────────────────
+  // Call analyzeStep() once per frame. Each call runs a full coarse sweep
+  // across the whole band (also fills the RSSI map) then, if the strongest
+  // channel passes kAnalyzerTrigger, a fine refine (±0.3 MHz @ 20 kHz) to pin
+  // the exact frequency. The last peak is held for kAnalyzerHold frames after
+  // the signal disappears so it stays on screen instead of vanishing the
+  // instant the carrier drops.
+  void  beginAnalyze();
+  bool  analyzeStep();                       // true while a peak is held
+  void  endAnalyze();
+  float getPeakFreq() const { return _peakFreq; }   // MHz, 0 if none held
+  int   getPeakRssi() const { return _peakRssi; }
+  bool  isPeakLive()  const { return _peakLive; }    // true = present right now
+
   // Scan status (still readable — updated during receive/scan)
   bool  isScanning()   const { return _scanning; }
   float getScanFreq()  const { return _scanFreq; }
@@ -130,6 +144,14 @@ private:
   int     _scanRssi = 0;
   uint8_t _scanIdx  = 0;
   int     _scanRssiMap[kScanFreqCount];
+
+  // Frequency analyzer (peak detect + sample-hold)
+  static constexpr int     kAnalyzerTrigger = -75;  // dBm; coarse peak must exceed
+  static constexpr uint8_t kAnalyzerHold    = 16;   // frames to hold after signal stops
+  float   _peakFreq = 0;
+  int     _peakRssi = -120;
+  bool    _peakLive = false;
+  uint8_t _holdCtr  = 0;
 
   float _scanForBestFreq(std::function<bool()> cancelCb);
   void  _initTx();


### PR DESCRIPTION
## What changes
Reworks the Sub-GHz **Detect Freq** screen into a peak detector with sample-hold, replacing the last-5 history list with a single large readout of the captured peak frequency.

**`CC1101Util` — `beginAnalyze` / `analyzeStep` / `endAnalyze`:**
- Two-stage detection: a coarse sweep across the whole band (fills the RSSI map) followed by a fine ±0.3 MHz @ 20 kHz refine around the strongest channel to pin the exact carrier.
- **Sample-hold**: the last peak is held `kAnalyzerHold` frames after the signal drops, so it doesn't vanish the instant the button is released.
- Stays in RX continuously — no per-frame `SetRx` re-strobe (which would reset the AGC and pin RSSI at the noise floor).

**`SubGHzScreen`:**
- `STATE_SCANNING` shows the big peak frequency (coloured by signal strength), a LIVE/hold status + dBm, and an RSSI bar.
- Removed the `Recent[]` history list.

## Files
- `firmware/src/screens/module/SubGHzScreen.cpp` / `.h`
- `firmware/src/utils/rf/CC1101Util.cpp` / `.h`

## How to test
1. Build & flash a CC1101-equipped board (e.g. `t_embed_cc1101`, or a Cardputer with a CC1101 module).
2. Go to **Modules → Sub-GHz → Detect Freq**.
3. Hold a known remote (433.92 / 315 / 868 MHz) near the antenna and press its button: the large readout should snap to the carrier, the colour reflects strength, and the dBm value + RSSI bar should track the signal.
4. Release the button: the peak stays **held** briefly (sample-hold) before returning to live scanning.
5. With no signal present, confirm it sweeps the noise floor without falsely pinning a frequency.

---
