### PR TITLE
🛰️ subghz: port all 38 static protocol decoders

### DIFF
--- a/firmware/src/screens/module/RfCaptureScreen.cpp
+++ b/firmware/src/screens/module/RfCaptureScreen.cpp
@@ -355,9 +355,21 @@ void RfCaptureScreen::_rebuildCapturedItems() {
       snprintf(buf, sizeof(buf), "%s cnt=%u", sig.mf_name.c_str(), sig.cnt);
       _capturedSubLabels[i] = buf;
     } else if (sig.protocol == "RcSwitch") {
-      char buf[32];
-      snprintf(buf, sizeof(buf), "0x%llX P%s %db",
-               (unsigned long long)sig.key, sig.preset.c_str(), sig.bit);
+      // Show the chip/remote name when known (e.g. "HT6P20B"), else "Pxx".
+      const char* pname = CC1101Util::rcSwitchProtoName(sig.preset.toInt());
+      char buf[48];
+      if (pname)
+        snprintf(buf, sizeof(buf), "%s 0x%llX %db",
+                 pname, (unsigned long long)sig.key, sig.bit);
+      else
+        snprintf(buf, sizeof(buf), "P%s 0x%llX %db",
+                 sig.preset.c_str(), (unsigned long long)sig.key, sig.bit);
+      _capturedSubLabels[i] = buf;
+    } else if (sig.protocol != "RAW" && sig.bit > 0) {
+      // Brand-decoded (CAME, Holtek, Linear, ...) — show the protocol name + key.
+      char buf[40];
+      snprintf(buf, sizeof(buf), "%s 0x%llX %db",
+               sig.protocol.c_str(), (unsigned long long)sig.key, sig.bit);
       _capturedSubLabels[i] = buf;
     } else {
       int pulses = 0;

--- a/firmware/src/screens/module/SubGHzScreen.cpp
+++ b/firmware/src/screens/module/SubGHzScreen.cpp
@@ -227,8 +227,7 @@ void SubGHzScreen::_startScan() {
     return;
   }
   _rfDetectFired = false;
-  _clearHistory();
-  _rf.beginScan();
+  _rf.beginAnalyze();
   _state = STATE_SCANNING;
   _chromeDrawn = false;
   strcpy(_titleBuf, "Detect Freq");
@@ -241,19 +240,18 @@ bool SubGHzScreen::_onUpdateExtra() {
   if (Uni.Nav->wasPressed()) {
     auto dir = Uni.Nav->readDirection();
     if (dir == INavigation::DIR_BACK || dir == INavigation::DIR_PRESS) {
-      _rf.endScan();
+      _rf.endAnalyze();
       _rf.end();
       _showMenu();
       return true;
     }
   }
-  if (_rf.stepScan()) {  // signal above RSSI_THRESHOLD at the current frequency
+  if (_rf.analyzeStep() && _rf.isPeakLive()) {  // a live peak above the trigger
     if (!_rfDetectFired) {
       _rfDetectFired = true;
       int n = Achievement.inc("rf_detect_freq");
       if (n == 1) Achievement.unlock("rf_detect_freq");
     }
-    _recordHit(_rf.getScanFreq(), _rf.getScanRssi());
   }
   render();
   return true;
@@ -268,15 +266,8 @@ bool SubGHzScreen::_onRenderExtra() {
   static constexpr int kRssiCeiling = -30;
   static constexpr int kRssiRange   = kRssiCeiling - kRssiFloor; // 80
 
-  const int footerH   = 16;
-  const int infoH     = 14;                     // live freq/rssi row
-  const int histLineH = 9;
-  const int histH     = histLineH * (kHistMax + 1); // "Recent:" header + 5 rows
-  const int contentH  = bodyH() - footerH;
-  const int chartY    = infoH;
-  int chartBottom     = contentH - histH;
-  if (chartBottom < chartY + 8) chartBottom = chartY + 8; // keep a chart sliver
-  const int chartH    = chartBottom - chartY;
+  const int footerH  = 16;
+  const int contentH = bodyH() - footerH;
 
   if (!_chromeDrawn) {
     lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
@@ -292,103 +283,58 @@ bool SubGHzScreen::_onRenderExtra() {
     _chromeDrawn = true;
   }
 
-  uint8_t n = _rf.getScanCount();
-  int barW  = bodyW() / (n ? n : 1);
-  if (barW < 1) barW = 1;
+  const int  W    = bodyW();
+  const bool held = _rf.getPeakFreq() > 0;
+  const bool live = _rf.isPeakLive();
+  const int  rssi = _rf.getPeakRssi();
+
+  // Peak frequency colour: dim grey while searching, strength-coloured when a
+  // live carrier is locked, muted while sample-holding the last peak.
+  uint16_t peakColor = !held ? 0x4208 : (live ? detectStrengthColor(rssi) : 0x5AEB);
 
   Sprite sp(&lcd);
-  sp.createSprite(bodyW(), contentH);
+  sp.createSprite(W, contentH);
   sp.fillSprite(TFT_BLACK);
+
+  // ── Big peak frequency (Flipper "peaky" readout) ────────────────────────
+  const int fSize = (W >= 200) ? 3 : 2;
+  const int freqY = contentH * 34 / 100;
+  char fb[16];
+  if (held) snprintf(fb, sizeof(fb), "%.3f", _rf.getPeakFreq());
+  else      snprintf(fb, sizeof(fb), "---.---");
+  sp.setTextDatum(MC_DATUM);
+  sp.setTextSize(fSize);
+  sp.setTextColor(peakColor, TFT_BLACK);
+  sp.drawString(fb, W / 2, freqY);
+
   sp.setTextSize(1);
-
-  // Live RSSI bar chart across all scanned channels.
-  for (uint8_t i = 0; i < n; i++) {
-    int rssi    = _rf.getScanRssiAt(i);
-    int clamped = constrain(rssi, kRssiFloor, kRssiCeiling);
-    int barH    = (clamped - kRssiFloor) * chartH / kRssiRange;
-    int x       = i * barW;
-    int y       = chartY + chartH - barH;
-
-    uint16_t color;
-    if (rssi > CC1101Util::RSSI_THRESHOLD)        color = detectStrengthColor(rssi);
-    else if (rssi > kRssiFloor + 10)              color = 0x2945;
-    else                                          color = TFT_DARKGREY;
-
-    if (barH > 0) sp.fillRect(x, y, barW - 1, barH, color);
-  }
-
-  // Marker on the channel currently being sampled.
-  for (uint8_t i = 0; i < n; i++) {
-    if (fabsf(_rf.getScanFreqAt(i) - _rf.getScanFreq()) < 0.01f) {
-      sp.drawFastVLine(i * barW + barW / 2, chartY, chartH, TFT_WHITE);
-      break;
-    }
-  }
-
-  // Live readout: current scan frequency (left) + current RSSI (right).
-  sp.setTextDatum(ML_DATUM);
-  sp.setTextColor(TFT_WHITE, TFT_BLACK);
-  char freqBuf[20];
-  snprintf(freqBuf, sizeof(freqBuf), "%.3f MHz", _rf.getScanFreq());
-  sp.drawString(freqBuf, 2, infoH / 2);
-
-  sp.setTextDatum(MR_DATUM);
-  char rssiBuf[16];
-  snprintf(rssiBuf, sizeof(rssiBuf), "%d dBm", _rf.getScanRssi());
-  uint16_t rssiColor = (_rf.getScanRssi() > CC1101Util::RSSI_THRESHOLD) ? TFT_GREEN : TFT_CYAN;
-  sp.setTextColor(rssiColor, TFT_BLACK);
-  sp.drawString(rssiBuf, bodyW() - 2, infoH / 2);
-
-  // History panel: last 5 detections, most-recent first (persists after the
-  // signal disappears, unlike the live chart).
-  const int histTop = contentH - histH;
-  sp.setTextDatum(ML_DATUM);
   sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-  sp.drawString("Recent:", 2, histTop + histLineH / 2 + 1);
+  sp.drawString("MHz", W / 2, freqY + fSize * 4 + 7);
 
-  for (uint8_t i = 0; i < kHistMax; i++) {
-    int ry = histTop + histLineH * (i + 1) + histLineH / 2 + 1;
-    if (i < _histCount) {
-      sp.setTextColor(detectStrengthColor(_hist[i].rssi), TFT_BLACK);
-      char fb[16];
-      snprintf(fb, sizeof(fb), "%.3f MHz", _hist[i].freq);
-      sp.setTextDatum(ML_DATUM);
-      sp.drawString(fb, 2, ry);
-      char rb[12];
-      snprintf(rb, sizeof(rb), "%d dBm", _hist[i].rssi);
-      sp.setTextDatum(MR_DATUM);
-      sp.drawString(rb, bodyW() - 2, ry);
-    } else {
-      sp.setTextColor(0x2945, TFT_BLACK);
-      sp.setTextDatum(ML_DATUM);
-      sp.drawString("--", 2, ry);
-    }
+  // ── Status + RSSI value ─────────────────────────────────────────────────
+  char line[24];
+  uint16_t statCol;
+  if (!held)      { strcpy(line, "scanning...");                         statCol = TFT_DARKGREY; }
+  else if (live)  { snprintf(line, sizeof(line), "LIVE  %d dBm", rssi);  statCol = TFT_GREEN;     }
+  else            { snprintf(line, sizeof(line), "hold  %d dBm", rssi);  statCol = TFT_ORANGE;    }
+  sp.setTextColor(statCol, TFT_BLACK);
+  sp.drawString(line, W / 2, contentH * 64 / 100);
+
+  // ── RSSI bar ────────────────────────────────────────────────────────────
+  const int barMargin = 8;
+  const int barW = W - barMargin * 2;
+  const int barH = 7;
+  const int barY = contentH * 80 / 100;
+  sp.drawRect(barMargin, barY, barW, barH, TFT_DARKGREY);
+  if (held) {
+    int clamped = constrain(rssi, kRssiFloor, kRssiCeiling);
+    int fillW   = (clamped - kRssiFloor) * (barW - 2) / kRssiRange;
+    if (fillW > 0) sp.fillRect(barMargin + 1, barY + 1, fillW, barH - 2, peakColor);
   }
 
   sp.pushSprite(bodyX(), bodyY());
   sp.deleteSprite();
   return true;
-}
-
-void SubGHzScreen::_recordHit(float freq, int rssi) {
-  uint32_t now = millis();
-  // Dedup across ALL slots, not just the top: the sweep visits every channel,
-  // so two simultaneous strong signals (e.g. 433.92 + 868.35) alternate as the
-  // newest hit. Checking only slot 0 let them flood the list with duplicate
-  // rows. Refreshing the existing slot in place (keeping its peak RSSI, no
-  // reordering) keeps the list stable — it only grows with genuinely new
-  // frequencies.
-  for (uint8_t i = 0; i < _histCount; i++) {
-    if (fabsf(_hist[i].freq - freq) < 0.01f) {
-      if (rssi > _hist[i].rssi) _hist[i].rssi = rssi;
-      _hist[i].when = now;
-      return;
-    }
-  }
-  for (int i = (_histCount < kHistMax ? _histCount : kHistMax - 1); i > 0; i--)
-    _hist[i] = _hist[i - 1];
-  _hist[0] = { freq, rssi, now };
-  if (_histCount < kHistMax) _histCount++;
 }
 
 bool SubGHzScreen::_onBackExtra() {
@@ -399,7 +345,7 @@ bool SubGHzScreen::_onBackExtra() {
     return true;
   }
   if (_state != STATE_SCANNING) return false;
-  _rf.endScan();
+  _rf.endAnalyze();
   _rf.end();
   _showMenu();
   return true;

--- a/firmware/src/screens/module/SubGHzScreen.h
+++ b/firmware/src/screens/module/SubGHzScreen.h
@@ -71,17 +71,6 @@ private:
   void _startScan();
   void _reloadMfcodes();
 
-  // ── Detect Freq history (last 5 detections, most-recent first) ──────────
-  // The live RSSI bar chart only reflects the current sweep, so a detected
-  // frequency vanishes the instant the signal stops. This keeps the last 5
-  // hits on screen, coloured by strength, until the next scan session.
-  struct DetectHit { float freq; int rssi; uint32_t when; };
-  static constexpr uint8_t kHistMax = 5;
-  DetectHit _hist[kHistMax]{};
-  uint8_t   _histCount = 0;
-  void _recordHit(float freq, int rssi);
-  void _clearHistory() { _histCount = 0; }
-
   // ── Waterfall (RSSI spectrogram) ───────────────────────────────────────
   // A scrolling RSSI heat-map across a [start,end] MHz window, swept per pixel
   // over SPI. The pre-run popup picks the band; the run scrolls one freshly

--- a/firmware/src/utils/rf/CC1101Util.cpp
+++ b/firmware/src/utils/rf/CC1101Util.cpp
@@ -227,6 +227,85 @@ void CC1101Util::endScan() {
   if (_initialized) ELECHOUSE_cc1101.setSidle();
 }
 
+// ── Frequency analyzer (Flipper-style peak detect) ──────────────────────────
+
+static inline bool cc1101_freq_valid(float mhz) {
+  return (mhz >= 280 && mhz <= 350) ||
+         (mhz >= 387 && mhz <= 468) ||
+         (mhz >= 779 && mhz <= 928);
+}
+
+void CC1101Util::beginAnalyze() {
+  if (!_initialized) return;
+  _scanning = true;
+  _peakFreq = 0;
+  _peakRssi = -120;
+  _peakLive = false;
+  _holdCtr  = 0;
+  for (uint8_t i = 0; i < kFreqCount; i++) _scanRssiMap[i] = -120;
+  // Enter RX once and STAY in RX for the whole session (RxBW inherited from
+  // begin() = 256 kHz — the same proven path as beginScan/stepScan). Re-issuing
+  // SetRx() per frame would SIDLE→SRX and reset the AGC, pinning RSSI at the
+  // noise floor so nothing is ever detected.
+  ELECHOUSE_cc1101.SetRx();
+}
+
+bool CC1101Util::analyzeStep() {
+  if (!_initialized || !_scanning) return false;
+
+  // ── Stage 1: coarse sweep — whole band, find the strongest channel. Stay in
+  // RX and only retune (setMHZ); this is the exact RF path stepScan uses. Also
+  // fills _scanRssiMap so the (optional) bar chart keeps updating.
+  int   coarseRssi = -127;
+  float coarseFreq = 0;
+  for (uint8_t i = 0; i < kFreqCount; i++) {
+    float f = kFreqList[i];
+    ELECHOUSE_cc1101.setMHZ(f);
+    delay(2);
+    int rssi = ELECHOUSE_cc1101.getRssi();
+    _scanRssiMap[i] = rssi;
+    _scanFreq = f;
+    _scanRssi = rssi;
+    if (rssi > coarseRssi) { coarseRssi = rssi; coarseFreq = f; }
+  }
+
+  // ── Stage 2: fine refine — ±0.3 MHz around the coarse peak in 20 kHz steps to
+  // pin the exact carrier (a signal at e.g. 433.66, not on the coarse list, is
+  // located here). Same RX/BW path — just a denser retune sweep.
+  if (coarseRssi > kAnalyzerTrigger) {
+    int   fineRssi = -127;
+    float fineFreq = coarseFreq;
+    for (float f = coarseFreq - 0.30f; f <= coarseFreq + 0.3001f; f += 0.02f) {
+      if (!cc1101_freq_valid(f)) continue;
+      ELECHOUSE_cc1101.setMHZ(f);
+      delay(2);
+      int rssi = ELECHOUSE_cc1101.getRssi();
+      if (rssi > fineRssi) { fineRssi = rssi; fineFreq = f; }
+    }
+    _peakFreq = fineFreq;
+    _peakRssi = fineRssi;
+    _peakLive = true;
+    _holdCtr  = kAnalyzerHold;
+    return true;
+  }
+
+  // ── No live signal: hold the last peak for a while (sample-hold), then clear.
+  if (_holdCtr > 0) {
+    _holdCtr--;
+    _peakLive = false;
+    return true;
+  }
+  _peakFreq = 0;
+  _peakRssi = -120;
+  _peakLive = false;
+  return false;
+}
+
+void CC1101Util::endAnalyze() {
+  _scanning = false;
+  if (_initialized) ELECHOUSE_cc1101.setSidle();
+}
+
 void CC1101Util::_initRx() {
   ELECHOUSE_cc1101.setModulation(2);
   ELECHOUSE_cc1101.setPktFormat(3);

--- a/firmware/src/utils/rf/CC1101Util.cpp
+++ b/firmware/src/utils/rf/CC1101Util.cpp
@@ -6,6 +6,7 @@
 #include "CC1101Util.h"
 #include "RCSwitchUtil.h"
 #include "KeeloqUtil.h"
+#include "SubGhzDecoders.h"
 #include <ELECHOUSE_CC1101_SRC_DRV.h>
 
 // ── Frequency list (Bruce rf_utils.cpp) ─────────────────────────────────────
@@ -137,42 +138,73 @@ bool CC1101Util::beginReceive() {
   return true;
 }
 
+void CC1101Util::_fillRcSwitch(Signal& out) {
+  uint64_t val = _sw.getReceivedValue();
+  out.frequency = _freq;
+  out.key       = val;
+  out.preset    = String(_sw.getReceivedProtocol());
+  out.protocol  = "RcSwitch";
+  out.te        = (int)_sw.getReceivedDelay();
+  out.bit       = (int)_sw.getReceivedBitlength();
+  out.rawData   = "";
+  // KeeLoq auto-decode: protocol 23 frames carry fix+encrypted+btn+serial packed
+  // into a 64-bit value. Unpack the structured fields, then try the manufacturer
+  // keystore (no-op if /unigeek/mfcodes is missing).
+  if (_sw.getReceivedProtocol() == 23) {
+    KeeloqUtil::unpack(val, out.fix, out.encrypted, out.btn, out.serial);
+    KeeloqUtil::identify(out);
+  }
+}
+
 bool CC1101Util::pollReceive(Signal& out) {
   if (!_initialized) return false;
 
-  if (_sw.available()) {
-    uint64_t val = _sw.getReceivedValue();
-    if (val != 0) {
-      out.frequency = _freq;
-      out.key       = val;
-      out.preset    = String(_sw.getReceivedProtocol());
-      out.protocol  = "RcSwitch";
-      out.te        = (int)_sw.getReceivedDelay();
-      out.bit       = (int)_sw.getReceivedBitlength();
-      out.rawData   = "";
-      // KeeLoq auto-decode: protocol 23 frames carry fix+encrypted+btn+serial
-      // packed into a 64-bit value. Always unpack the structured fields; then
-      // try the manufacturer keystore (no-op if /unigeek/mfcodes is missing).
-      if (_sw.getReceivedProtocol() == 23) {
-        KeeloqUtil::unpack(val, out.fix, out.encrypted, out.btn, out.serial);
-        KeeloqUtil::identify(out);
-      }
-      _sw.resetAvailable();
-      return true;
-    }
+  // KeeLoq (RcSwitch proto 23) stays on the fast path: it's a rolling protocol
+  // that needs the manufacturer keystore and has no brand decoder of its own.
+  // Emitting it here also stops the brand decoders from ever mis-grabbing a
+  // KeeLoq frame.
+  if (_sw.available() && _sw.getReceivedValue() != 0 &&
+      _sw.getReceivedProtocol() == 23) {
+    _fillRcSwitch(out);
     _sw.resetAvailable();
+    return true;
   }
 
-  if (_rxFilter == RX_FILTER_RAW && _sw.RAWavailable()) {
-    delay(400); // let full signal arrive
+  // Everything else is decided on the COMPLETED raw frame so the brand decoders
+  // are AUTHORITATIVE: they identify the real protocol (CAME, Holtek, Linear,
+  // ...) and win over the generic RcSwitch table for overlapping protocols.
+  // RcSwitch is the fallback when no brand decoder matches; generic RAW is last.
+  if (_sw.RAWavailable()) {
+    delay(400); // let the full repeating signal land in the buffer
     unsigned int* raw = _sw.getRAWReceivedRawdata();
+    uint16_t n = 0;
+    while (raw[n] != 0 && n < 1024) n++;
+
     String rawStr;
-    for (int i = 0; raw[i] != 0; i++) {
+    for (uint16_t i = 0; i < n; i++) {
       if (i > 0) rawStr += ' ';
       int sign = (i % 2 == 0) ? 1 : -1;
       rawStr += String(sign * (int)raw[i]);
     }
-    if (rawStr.length() > 0) {
+
+    // 1) Brand/manufacturer decoders — authoritative, both filter modes. The raw
+    //    stream is kept on the Signal so it can still be replayed.
+    if (n >= 8 && SubGhzDecoders::decode(raw, n, out)) {
+      out.frequency = _freq;
+      out.rawData   = rawStr;
+      _sw.resetAvailable();
+      return true;
+    }
+
+    // 2) RcSwitch table decode (if the ISR recognised one of its 23 protocols).
+    if (_sw.available() && _sw.getReceivedValue() != 0) {
+      _fillRcSwitch(out);
+      _sw.resetAvailable();
+      return true;
+    }
+
+    // 3) Generic RAW capture — only when the user enabled raw capture.
+    if (_rxFilter == RX_FILTER_RAW && rawStr.length() > 0) {
       out.frequency = _freq;
       out.preset    = "0";
       out.protocol  = "RAW";
@@ -378,7 +410,11 @@ void CC1101Util::sendSignal(const Signal& sig) {
   ELECHOUSE_cc1101.setPA(12);
   ELECHOUSE_cc1101.SetTx();
 
-  if (sig.protocol == "RAW") {
+  // Brand-decoded signals (CAME, Holtek, ...) keep their captured raw pulse
+  // train and are replayed from it — we decode these protocols but have no
+  // dedicated encoder, so RCSwitch re-encoding would transmit the wrong timing.
+  // Only true RcSwitch protocols go through the RCSwitch library.
+  if (sig.protocol != "RcSwitch" && sig.rawData.length() > 0) {
     const String& data = sig.rawData;
     int start = 0;
     for (int i = 0; i <= (int)data.length(); i++) {
@@ -399,7 +435,6 @@ void CC1101Util::sendSignal(const Signal& sig) {
     digitalWrite(_gdo0Pin, LOW);
 
   } else {
-    // RcSwitch / Princeton / CAME / Nice / unknown → RCSwitch library
     _sendRcSwitch(sig);
   }
 
@@ -528,7 +563,13 @@ String CC1101Util::saveToString(const Signal& sig) {
   content += "Preset: " + sig.preset + "\n";
   content += "Protocol: " + sig.protocol + "\n";
 
-  if (sig.protocol == "RcSwitch") {
+  const bool isRcSwitch = (sig.protocol == "RcSwitch");
+  // Brand-decoded signals carry a numeric Key + bit length just like RcSwitch;
+  // write the structured header so the capture round-trips (loadFile keys off
+  // Key/Bit). They additionally keep the raw pulse train below for replay.
+  const bool hasHeader = isRcSwitch || (sig.protocol != "RAW" && sig.bit > 0);
+
+  if (hasHeader) {
     if (sig.te > 0)  content += "TE: "  + String(sig.te)  + "\n";
     if (sig.bit > 0) content += "Bit: " + String(sig.bit) + "\n";
     char keyBuf[20];
@@ -537,7 +578,7 @@ String CC1101Util::saveToString(const Signal& sig) {
 
     // KeeLoq extras when the manufacturer was identified at capture time —
     // Flipper Zero .sub spec fields, also recognised by Bruce's reader.
-    if (sig.preset == "23" && sig.mf_name.length() > 0) {
+    if (isRcSwitch && sig.preset == "23" && sig.mf_name.length() > 0) {
       content += "Manufacturer: " + sig.mf_name + "\n";
       char hexBuf[16];
       snprintf(hexBuf, sizeof(hexBuf), "0x%07lX", (unsigned long)sig.serial);
@@ -545,8 +586,12 @@ String CC1101Util::saveToString(const Signal& sig) {
       content += "Button: " + String(sig.btn) + "\n";
       content += "Counter: " + String(sig.cnt) + "\n";
     }
-  } else {
-    // RAW: split into lines of max 512 values (Flipper compat)
+  }
+
+  // RAW pulse train — emitted for true RAW captures and for brand-decoded
+  // signals (kept for replay, since we have no per-protocol encoder). RcSwitch
+  // is re-encoded from Key and needs none.
+  if (!isRcSwitch && sig.rawData.length() > 0) {
     const String& data = sig.rawData;
     int valCount = 0;
     int lineStart = 0;
@@ -607,13 +652,22 @@ String CC1101Util::signalInfoText(const Signal& sig) {
     return out;
   }
 
-  // Protocol line (Bruce shows "Protocol: <name>(<preset>)" when preset is set)
-  if (sig.preset.length() > 0)
+  // Protocol line. For RcSwitch, show the chip/remote name when known
+  // (e.g. "Protocol: HT6P20B (P6)") instead of the opaque protocol number.
+  const char* rcName = (sig.protocol == "RcSwitch") ? rcSwitchProtoName(sig.preset.toInt()) : nullptr;
+  if (rcName)
+    out += "Protocol: " + String(rcName) + " (P" + sig.preset + ")\n";
+  else if (sig.preset.length() > 0)
     out += "Protocol: " + sig.protocol + " (" + sig.preset + ")\n";
   else
     out += "Protocol: " + sig.protocol + "\n";
 
-  if (sig.protocol == "RcSwitch") {
+  // RcSwitch and brand-decoded signals both carry a numeric key + bit length;
+  // show the structured Key/Binary breakdown for either. Only true RAW captures
+  // (no decoded bits) fall through to the transition dump below.
+  bool decoded = (sig.protocol == "RcSwitch") ||
+                 (sig.protocol != "RAW" && sig.bit > 0);
+  if (decoded) {
     out += "Length: " + String(sig.bit) + " bits\n";
     snprintf(buf, sizeof(buf), "Key: 0x%llX\n", (unsigned long long)sig.key);
     out += buf;
@@ -655,12 +709,44 @@ String CC1101Util::signalInfoText(const Signal& sig) {
   return out;
 }
 
+// Chip/remote names for the 23 RcSwitch protocols (see kProto in RCSwitchUtil).
+// Entries 2-5 are generic timing variants with no well-known name → nullptr.
+const char* CC1101Util::rcSwitchProtoName(int proto) {
+  switch (proto) {
+    case 1:  return "Princeton";
+    case 6:  return "HT6P20B";
+    case 7:  return "HS2303-PT";
+    case 8:  return "Conrad RS-200 RX";
+    case 9:  return "Conrad RS-200 TX";
+    case 10: return "1ByOne Doorbell";
+    case 11: return "HT12E";
+    case 12: return "SM5212";
+    case 13: return "Mumbi RC-10";
+    case 14: return "Blyss Doorbell";
+    case 15: return "sc2260R4";
+    case 16: return "Home NetWerks";
+    case 17: return "ORNO OR-GB";
+    case 18: return "CLARUS BHC993";
+    case 19: return "NEC";
+    case 20: return "CAME 12bit";
+    case 21: return "FAAC 12bit";
+    case 22: return "NICE 12bit";
+    case 23: return "KeeLoq";
+    default: return nullptr;  // generic table entries 2-5
+  }
+}
+
 String CC1101Util::signalLabel(const Signal& sig) {
-  char buf[40];
+  char buf[48];
   if (sig.protocol == "RcSwitch") {
-    snprintf(buf, sizeof(buf), "%.2f MHz P%s", sig.frequency, sig.preset.c_str());
-  } else {
+    const char* pname = rcSwitchProtoName(sig.preset.toInt());
+    if (pname) snprintf(buf, sizeof(buf), "%.2f MHz %s", sig.frequency, pname);
+    else       snprintf(buf, sizeof(buf), "%.2f MHz P%s", sig.frequency, sig.preset.c_str());
+  } else if (sig.protocol == "RAW") {
     snprintf(buf, sizeof(buf), "%.2f MHz RAW", sig.frequency);
+  } else {
+    // Brand-decoded signal — show the real protocol name (CAME, Holtek, ...).
+    snprintf(buf, sizeof(buf), "%.2f MHz %s", sig.frequency, sig.protocol.c_str());
   }
   return String(buf);
 }

--- a/firmware/src/utils/rf/CC1101Util.h
+++ b/firmware/src/utils/rf/CC1101Util.h
@@ -87,6 +87,20 @@ public:
   int  rssiAt(float mhz);
   void endRssiSweep();
 
+  // ── Frequency analyzer (Flipper-style "peaky" peak detect) ────────────────
+  // Call analyzeStep() once per frame. Each call runs a full coarse sweep
+  // across the whole band (also fills the RSSI map) then, if the strongest
+  // channel passes kAnalyzerTrigger, a fine refine (±0.3 MHz @ 20 kHz) to pin
+  // the exact frequency. The last peak is held for kAnalyzerHold frames after
+  // the signal disappears so it stays on screen instead of vanishing the
+  // instant the carrier drops.
+  void  beginAnalyze();
+  bool  analyzeStep();                       // true while a peak is held
+  void  endAnalyze();
+  float getPeakFreq() const { return _peakFreq; }   // MHz, 0 if none held
+  int   getPeakRssi() const { return _peakRssi; }
+  bool  isPeakLive()  const { return _peakLive; }    // true = present right now
+
   // Scan status (still readable — updated during receive/scan)
   bool  isScanning()   const { return _scanning; }
   float getScanFreq()  const { return _scanFreq; }
@@ -130,6 +144,14 @@ private:
   int     _scanRssi = 0;
   uint8_t _scanIdx  = 0;
   int     _scanRssiMap[kScanFreqCount];
+
+  // Frequency analyzer (peak detect + sample-hold)
+  static constexpr int     kAnalyzerTrigger = -75;  // dBm; coarse peak must exceed
+  static constexpr uint8_t kAnalyzerHold    = 16;   // frames to hold after signal stops
+  float   _peakFreq = 0;
+  int     _peakRssi = -120;
+  bool    _peakLive = false;
+  uint8_t _holdCtr  = 0;
 
   float _scanForBestFreq(std::function<bool()> cancelCb);
   void  _initTx();

--- a/firmware/src/utils/rf/CC1101Util.h
+++ b/firmware/src/utils/rf/CC1101Util.h
@@ -89,11 +89,11 @@ public:
 
   // ── Frequency analyzer (Flipper-style "peaky" peak detect) ────────────────
   // Call analyzeStep() once per frame. Each call runs a full coarse sweep
-  // across the whole band (also fills the RSSI map) then, if the strongest
-  // channel passes kAnalyzerTrigger, a fine refine (±0.3 MHz @ 20 kHz) to pin
-  // the exact frequency. The last peak is held for kAnalyzerHold frames after
-  // the signal disappears so it stays on screen instead of vanishing the
-  // instant the carrier drops.
+  // across the whole band (wide RxBW — also fills the RSSI map that drives the
+  // bar chart) then, if the strongest channel passes kAnalyzerTrigger, a fine
+  // refine (narrow RxBW, ±0.3 MHz @ 20 kHz) to pin the exact frequency. The
+  // last peak is held for kAnalyzerHold frames after the signal disappears so
+  // it stays on screen instead of vanishing the instant the carrier drops.
   void  beginAnalyze();
   bool  analyzeStep();                       // true while a peak is held
   void  endAnalyze();
@@ -124,6 +124,9 @@ public:
   static String saveToString(const Signal& sig);
 
   // Display helpers
+  // Friendly name for an RcSwitch protocol number (preset), or nullptr when the
+  // protocol has no well-known chip name (the generic table entries 2-5).
+  static const char* rcSwitchProtoName(int proto);
   static String signalLabel(const Signal& sig);
   // Multi-line, key:value info block (mirrors Bruce's `display_signal_data`).
   // Ready to feed into TextScrollView::setContent.
@@ -157,4 +160,6 @@ private:
   void  _initTx();
   void  _initRx();
   void  _sendRcSwitch(const Signal& sig);
+  // Fill `out` from the current RCSwitch decode (incl. KeeLoq proto-23 unpack).
+  void  _fillRcSwitch(Signal& out);
 };

--- a/firmware/src/utils/rf/SubGhzDecoders.cpp
+++ b/firmware/src/utils/rf/SubGhzDecoders.cpp
@@ -1,0 +1,1584 @@
+#include "SubGhzDecoders.h"
+
+// abs difference of two unsigned durations (Flipper's DURATION_DIFF macro)
+#define DDIFF(x, y) (((x) < (y)) ? ((y) - (x)) : ((x) - (y)))
+
+// Level of sample i for a given phase. The capture's starting level is unknown,
+// so the engine tries phase 0 and 1; even index = HIGH within a phase.
+static inline bool sampleLevel(uint16_t i, uint8_t phase) {
+  return (((uint16_t)(i + phase)) & 1u) == 0u;
+}
+
+// ── CAME / Prastel / Airforce ───────────────────────────────────────────────
+// Port of subghz_protocol_decoder_came_feed (lib/subghz/protocols/came.c).
+static bool decode_came(const unsigned int* dur, uint16_t n, uint8_t phase,
+                        SubGhzDecoders::Match& m) {
+  const uint32_t te_short = 320, te_long = 640, te_delta = 150;
+  enum { Reset, FoundStart, SaveDur, CheckDur };
+  uint32_t step = Reset, te_last = 0;
+  uint64_t data = 0;
+  uint8_t  cnt = 0;
+
+  for (uint16_t i = 0; i < n; i++) {
+    bool     level    = sampleLevel(i, phase);
+    uint32_t duration = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(duration, te_short * 56) < te_delta * 63)
+          step = FoundStart;
+        break;
+      case FoundStart:
+        if (!level) {
+          break;
+        } else if (DDIFF(duration, te_short) < te_delta) {
+          step = SaveDur; data = 0; cnt = 0;
+        } else {
+          step = Reset;
+        }
+        break;
+      case SaveDur:
+        if (!level) {
+          if (duration >= te_short * 4) {
+            step = FoundStart;
+            if (cnt == 12 || cnt == 18 || cnt == 25 || cnt == 42 || cnt == 24) {
+              m.name = "CAME";
+              if (cnt == 25 || cnt == 42) m.name = "Prastel";
+              else if (cnt == 18)         m.name = "Airforce";
+              m.key = data; m.bits = cnt; m.te = (uint16_t)te_short;
+              return true;
+            }
+            break;
+          }
+          te_last = duration; step = CheckDur;
+        } else {
+          step = Reset;
+        }
+        break;
+      case CheckDur:
+        if (level) {
+          if (DDIFF(te_last, te_short) < te_delta && DDIFF(duration, te_long) < te_delta) {
+            data = data << 1 | 0; cnt++; step = SaveDur;
+          } else if (DDIFF(te_last, te_long) < te_delta && DDIFF(duration, te_short) < te_delta) {
+            data = data << 1 | 1; cnt++; step = SaveDur;
+          } else {
+            step = Reset;
+          }
+        } else {
+          step = Reset;
+        }
+        break;
+    }
+  }
+  return false;
+}
+
+// ── Princeton ───────────────────────────────────────────────────────────────
+// Port of subghz_protocol_decoder_princeton_feed. Requires two identical frames
+// before declaring a match (Flipper's last_data == decode_data guard).
+static bool decode_princeton(const unsigned int* dur, uint16_t n, uint8_t phase,
+                             SubGhzDecoders::Match& m) {
+  const uint32_t te_short = 390, te_long = 1170, te_delta = 300;
+  enum { Reset, SaveDur, CheckDur };
+  uint32_t step = Reset, te_last = 0;
+  uint64_t data = 0, last_data = 0;
+  uint8_t  cnt = 0;
+
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase);
+    uint32_t duration = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(duration, te_short * 36) < te_delta * 36) {
+          step = SaveDur; data = 0; cnt = 0;
+        }
+        break;
+      case SaveDur:
+        if (level) { te_last = duration; step = CheckDur; }
+        break;
+      case CheckDur:
+        if (!level) {
+          if (duration >= te_long * 2) {
+            step = SaveDur;
+            if (cnt == 24) {
+              if (last_data == data && last_data) {
+                m.name = "Princeton"; m.key = data; m.bits = 24; m.te = (uint16_t)te_short;
+                return true;
+              }
+              last_data = data;
+            }
+            data = 0; cnt = 0;
+            break;
+          }
+          if (DDIFF(te_last, te_short) < te_delta && DDIFF(duration, te_long) < te_delta * 3) {
+            data = data << 1 | 0; cnt++; step = SaveDur;
+          } else if (DDIFF(te_last, te_long) < te_delta * 3 && DDIFF(duration, te_short) < te_delta) {
+            data = data << 1 | 1; cnt++; step = SaveDur;
+          } else {
+            step = Reset;
+          }
+        } else {
+          step = Reset;
+        }
+        break;
+    }
+  }
+  return false;
+}
+
+// ── Nice FLO ────────────────────────────────────────────────────────────────
+// Port of subghz_protocol_decoder_nice_flo_feed.
+static bool decode_nice_flo(const unsigned int* dur, uint16_t n, uint8_t phase,
+                            SubGhzDecoders::Match& m) {
+  const uint32_t te_short = 700, te_long = 1400, te_delta = 200;
+  enum { Reset, FoundStart, SaveDur, CheckDur };
+  uint32_t step = Reset, te_last = 0;
+  uint64_t data = 0;
+  uint8_t  cnt = 0;
+
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase);
+    uint32_t duration = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(duration, te_short * 36) < te_delta * 36) step = FoundStart;
+        break;
+      case FoundStart:
+        if (!level) break;
+        else if (DDIFF(duration, te_short) < te_delta) { step = SaveDur; data = 0; cnt = 0; }
+        else step = Reset;
+        break;
+      case SaveDur:
+        if (!level) {
+          if (duration >= te_short * 4) {
+            step = FoundStart;
+            if (cnt >= 12) {
+              m.name = "Nice FLO"; m.key = data; m.bits = cnt; m.te = (uint16_t)te_short;
+              return true;
+            }
+            break;
+          }
+          te_last = duration; step = CheckDur;
+        } else {
+          step = Reset;
+        }
+        break;
+      case CheckDur:
+        if (level) {
+          if (DDIFF(te_last, te_short) < te_delta && DDIFF(duration, te_long) < te_delta) {
+            data = data << 1 | 0; cnt++; step = SaveDur;
+          } else if (DDIFF(te_last, te_long) < te_delta && DDIFF(duration, te_short) < te_delta) {
+            data = data << 1 | 1; cnt++; step = SaveDur;
+          } else {
+            step = Reset;
+          }
+        } else {
+          step = Reset;
+        }
+        break;
+    }
+  }
+  return false;
+}
+
+// ── Holtek HT12 ─────────────────────────────────────────────────────────────
+// Port of subghz_protocol_decoder_holtek_feed. 40-bit frame with a fixed 0x5
+// header nibble (HOLTEK_HEADER_MASK / HOLTEK_HEADER) — very specific, low false
+// positives.
+static bool decode_holtek(const unsigned int* dur, uint16_t n, uint8_t phase,
+                          SubGhzDecoders::Match& m) {
+  const uint32_t te_short = 430, te_long = 870, te_delta = 100;
+  enum { Reset, FoundStart, SaveDur, CheckDur };
+  uint32_t step = Reset, te_last = 0;
+  uint64_t data = 0;
+  uint8_t  cnt = 0;
+
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase);
+    uint32_t duration = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(duration, te_short * 36) < te_delta * 36) step = FoundStart;
+        break;
+      case FoundStart:
+        if (level && DDIFF(duration, te_short) < te_delta) { step = SaveDur; data = 0; cnt = 0; }
+        else step = Reset;
+        break;
+      case SaveDur:
+        if (!level) {
+          if (duration >= te_short * 10 + te_delta) {
+            if (cnt == 40 && (data & 0xF000000000ULL) == 0x5000000000ULL) {
+              m.name = "Holtek"; m.key = data; m.bits = 40; m.te = (uint16_t)te_short;
+              return true;
+            }
+            data = 0; cnt = 0; step = FoundStart;
+            break;
+          }
+          te_last = duration; step = CheckDur;
+        } else {
+          step = Reset;
+        }
+        break;
+      case CheckDur:
+        if (level) {
+          if (DDIFF(te_last, te_short) < te_delta && DDIFF(duration, te_long) < te_delta * 2) {
+            data = data << 1 | 0; cnt++; step = SaveDur;
+          } else if (DDIFF(te_last, te_long) < te_delta * 2 && DDIFF(duration, te_short) < te_delta) {
+            data = data << 1 | 1; cnt++; step = SaveDur;
+          } else {
+            step = Reset;
+          }
+        } else {
+          step = Reset;
+        }
+        break;
+    }
+  }
+  return false;
+}
+
+// ── Linear ──────────────────────────────────────────────────────────────────
+// Port of subghz_protocol_decoder_linear_feed. 10-bit DIP code.
+static bool decode_linear(const unsigned int* dur, uint16_t n, uint8_t phase,
+                          SubGhzDecoders::Match& m) {
+  const uint32_t te_short = 500, te_long = 1500, te_delta = 350;
+  enum { Reset, SaveDur, CheckDur };
+  uint32_t step = Reset, te_last = 0;
+  uint64_t data = 0;
+  uint8_t  cnt = 0;
+
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase);
+    uint32_t duration = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(duration, te_short * 42) < te_delta * 15) {
+          data = 0; cnt = 0; step = SaveDur;
+        }
+        break;
+      case SaveDur:
+        if (level) { te_last = duration; step = CheckDur; }
+        else step = Reset;
+        break;
+      case CheckDur:
+        if (!level) {
+          if (duration >= te_short * 5) {
+            step = Reset;
+            if (DDIFF(duration, te_short * 42) > te_delta * 15) break;
+            if (DDIFF(te_last, te_short) < te_delta)      { data = data << 1 | 0; cnt++; }
+            else if (DDIFF(te_last, te_long) < te_delta)  { data = data << 1 | 1; cnt++; }
+            if (cnt == 10) {
+              m.name = "Linear"; m.key = data; m.bits = 10; m.te = (uint16_t)te_short;
+              return true;
+            }
+            break;
+          }
+          if (DDIFF(te_last, te_short) < te_delta && DDIFF(duration, te_long) < te_delta) {
+            data = data << 1 | 0; cnt++; step = SaveDur;
+          } else if (DDIFF(te_last, te_long) < te_delta && DDIFF(duration, te_short) < te_delta) {
+            data = data << 1 | 1; cnt++; step = SaveDur;
+          } else {
+            step = Reset;
+          }
+        } else {
+          step = Reset;
+        }
+        break;
+    }
+  }
+  return false;
+}
+
+// ── Ansonic ─────────────────────────────────────────────────────────────────
+static bool decode_ansonic(const unsigned int* dur, uint16_t n, uint8_t phase,
+                           SubGhzDecoders::Match& m) {
+  const uint32_t ts = 555, tl = 1111, td = 120;
+  enum { Reset, Start, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset: if (!level && DDIFF(d, ts * 35) < td * 35) step = Start; break;
+      case Start:
+        if (!level) break;
+        else if (DDIFF(d, ts) < td) { step = Save; data = 0; cnt = 0; }
+        else step = Reset; break;
+      case Save:
+        if (!level) {
+          if (d >= ts * 4) {
+            step = Start;
+            if (cnt >= 12) { m.name = "Ansonic"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            break;
+          }
+          te_last = d; step = Check;
+        } else step = Reset; break;
+      case Check:
+        if (level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td && DDIFF(d, ts) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── BETT ────────────────────────────────────────────────────────────────────
+static bool decode_bett(const unsigned int* dur, uint16_t n, uint8_t phase,
+                        SubGhzDecoders::Match& m) {
+  const uint32_t ts = 340, tl = 2000, td = 150;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset: if (!level && DDIFF(d, ts * 44) < td * 15) { data = 0; cnt = 0; step = Check; } break;
+      case Save:
+        if (!level) {
+          if (DDIFF(d, ts * 44) < td * 15) {
+            if (cnt == 18) { m.name = "BETT"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 0; cnt = 0; step = Reset; break;
+          } else {
+            if (DDIFF(d, ts) < td || DDIFF(d, tl) < td * 3) step = Check;
+            else step = Reset;
+          }
+        }
+        break;
+      case Check:
+        if (level) {
+          if (DDIFF(d, tl) < td * 3) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(d, ts) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Clemsa ──────────────────────────────────────────────────────────────────
+static bool decode_clemsa(const unsigned int* dur, uint16_t n, uint8_t phase,
+                          SubGhzDecoders::Match& m) {
+  const uint32_t ts = 385, tl = 2695, td = 150;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset: if (!level && DDIFF(d, ts * 51) < td * 25) { step = Save; data = 0; cnt = 0; } break;
+      case Save: if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td * 3) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td * 3 && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(d, ts * 51) < td * 25) {
+            if (DDIFF(te_last, ts) < td) { data = data << 1 | 0; cnt++; }
+            else if (DDIFF(te_last, tl) < td * 3) { data = data << 1 | 1; cnt++; }
+            if (cnt == 18) { m.name = "Clemsa"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            step = Save; data = 0; cnt = 0;
+          } else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Dickert MAHS ────────────────────────────────────────────────────────────
+static bool decode_dickert(const unsigned int* dur, uint16_t n, uint8_t phase,
+                           SubGhzDecoders::Match& m) {
+  const uint32_t ts = 400, tl = 800, td = 100;
+  enum { Reset, Initial, Recording };
+  uint32_t step = Reset, tmp0 = 0, tmp1 = 0; uint8_t tmpcnt = 0;
+  uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (cnt >= 36) { m.name = "Dickert_MAHS"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+        if (!level && DDIFF(d, tl * 50) < td * 70) step = Initial;
+        break;
+      case Initial:
+        if (!level) break;
+        else if (DDIFF(d, ts) < td) { step = Recording; data = 0; cnt = 0; }
+        else step = Reset; break;
+      case Recording:
+        if ((!level && tmpcnt == 0) || (level && tmpcnt == 1)) {
+          if (tmpcnt == 0) tmp0 = d; else tmp1 = d;
+          tmpcnt++;
+          if (tmpcnt == 2) {
+            if (DDIFF(tmp0 + tmp1, 1200) < td) {
+              if (DDIFF(tmp0, tl) < td) { data = data << 1 | 1; cnt++; }
+              else if (DDIFF(tmp0, ts) < td) { data = data << 1 | 0; cnt++; }
+              tmpcnt = 0;
+            } else { tmpcnt = 0; step = Reset; }
+          }
+        } else { tmpcnt = 0; step = Reset; }
+        break;
+    }
+  }
+  return false;
+}
+
+// ── Doitrand ────────────────────────────────────────────────────────────────
+static bool decode_doitrand(const unsigned int* dur, uint16_t n, uint8_t phase,
+                            SubGhzDecoders::Match& m) {
+  const uint32_t ts = 400, tl = 1100, td = 150;
+  enum { Reset, Start, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset: if (!level && DDIFF(d, ts * 62) < td * 30) step = Start; break;
+      case Start:
+        if (level && DDIFF(d, ts * 2) < td * 3) { step = Save; data = 0; cnt = 0; }
+        else step = Reset; break;
+      case Save:
+        if (!level) {
+          if (d >= ts * 10 + td) {
+            step = Start;
+            if (cnt == 37) { m.name = "Doitrand"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 0; cnt = 0; break;
+          } else { te_last = d; step = Check; }
+        }
+        break;
+      case Check:
+        if (level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td * 3) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td * 3 && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Dooya ───────────────────────────────────────────────────────────────────
+static bool decode_dooya(const unsigned int* dur, uint16_t n, uint8_t phase,
+                         SubGhzDecoders::Match& m) {
+  const uint32_t ts = 366, tl = 733, td = 120;
+  enum { Reset, Start, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset: if (!level && DDIFF(d, tl * 12) < td * 20) step = Start; break;
+      case Start:
+        if (!level) {
+          if (DDIFF(d, tl * 2) < td * 3) { step = Save; data = 0; cnt = 0; }
+          else step = Reset;
+        } else if (DDIFF(d, ts * 13) < td * 5) break;
+        else step = Reset; break;
+      case Save:
+        if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (d >= tl * 4) {
+            if (DDIFF(te_last, ts) < td) { data = data << 1 | 0; cnt++; }
+            else if (DDIFF(te_last, tl) < td * 2) { data = data << 1 | 1; cnt++; }
+            else { step = Reset; break; }
+            step = Start;
+            if (cnt == 40) { m.name = "Dooya"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            break;
+          } else if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td * 2) {
+            data = data << 1 | 0; cnt++; step = Save;
+          } else if (DDIFF(te_last, tl) < td * 2 && DDIFF(d, ts) < td) {
+            data = data << 1 | 1; cnt++; step = Save;
+          } else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Elplast ─────────────────────────────────────────────────────────────────
+static bool decode_elplast(const unsigned int* dur, uint16_t n, uint8_t phase,
+                           SubGhzDecoders::Match& m) {
+  const uint32_t ts = 230, tl = 1550, td = 160;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, tl * 8) < td * 13) { data = 0; cnt = 0; step = Save; }
+        break;
+      case Save: if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, tl) < td && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(d, tl * 8) < td * 13) {
+            if (DDIFF(te_last, tl) < td) { data = data << 1 | 1; cnt++; }
+            if (DDIFF(te_last, ts) < td) { data = data << 1 | 0; cnt++; }
+            if (cnt == 18) { m.name = "Elplast"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 0; cnt = 0; step = Reset;
+          } else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Feron ───────────────────────────────────────────────────────────────────
+static bool decode_feron(const unsigned int* dur, uint16_t n, uint8_t phase,
+                         SubGhzDecoders::Match& m) {
+  const uint32_t ts = 350, tl = 750, td = 150;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, tl * 6) < td * 4) { data = 0; cnt = 0; step = Save; }
+        break;
+      case Save: if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(d, ts + 150) < td) {
+            if (DDIFF(te_last, ts) < td) { data = data << 1 | 0; cnt++; }
+            if (DDIFF(te_last, tl) < td) { data = data << 1 | 1; cnt++; }
+            if (cnt == 32) { m.name = "Feron"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 0; cnt = 0; step = Reset;
+          } else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Gate TX ─────────────────────────────────────────────────────────────────
+static bool decode_gate_tx(const unsigned int* dur, uint16_t n, uint8_t phase,
+                           SubGhzDecoders::Match& m) {
+  const uint32_t ts = 350, tl = 700, td = 100;
+  enum { Reset, Start, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset: if (!level && DDIFF(d, ts * 47) < td * 47) step = Start; break;
+      case Start:
+        if (level && DDIFF(d, tl) < td * 3) { step = Save; data = 0; cnt = 0; }
+        else step = Reset; break;
+      case Save:
+        if (!level) {
+          if (d >= ts * 10 + td) {
+            step = Start;
+            if (cnt == 24) { m.name = "GateTX"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 0; cnt = 0; break;
+          } else { te_last = d; step = Check; }
+        }
+        break;
+      case Check:
+        if (level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td * 3) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td * 3 && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Hormann HSM ─────────────────────────────────────────────────────────────
+static bool decode_hormann(const unsigned int* dur, uint16_t n, uint8_t phase,
+                           SubGhzDecoders::Match& m) {
+  const uint32_t ts = 500, tl = 1000, td = 200;
+  const uint64_t PATTERN = 0xFF000000003ULL;
+  enum { Reset, Start, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset: if (level && DDIFF(d, ts * 24) < td * 24) step = Start; break;
+      case Start:
+        if (!level && DDIFF(d, ts) < td) { step = Save; data = 0; cnt = 0; }
+        else step = Reset; break;
+      case Save:
+        if (level) {
+          if (d >= ts * 5 && (data & PATTERN) == PATTERN) {
+            step = Start;
+            if (cnt >= 44) { m.name = "Hormann HSM"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            break;
+          }
+          te_last = d; step = Check;
+        } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Intertechno V3 ──────────────────────────────────────────────────────────
+static bool decode_intertechno_v3(const unsigned int* dur, uint16_t n, uint8_t phase,
+                                  SubGhzDecoders::Match& m) {
+  const uint32_t ts = 275, tl = 1375, td = 150;
+  enum { Reset, StartSync, FoundSync, StartDur, Save, Check, EndDur };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset: if (!level && DDIFF(d, ts * 37) < td * 15) step = StartSync; break;
+      case StartSync:
+        if (level && DDIFF(d, ts) < td) step = FoundSync; else step = Reset; break;
+      case FoundSync:
+        if (!level && DDIFF(d, ts * 10) < td * 3) { step = StartDur; data = 0; cnt = 0; }
+        else step = Reset; break;
+      case StartDur:
+        if (level && DDIFF(d, ts) < td) step = Save; else step = Reset; break;
+      case Save:
+        if (!level) {
+          if (d >= ts * 11) {
+            step = StartSync;
+            if (cnt == 32 || cnt == 36) { m.name = "Intertechno_V3"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            break;
+          }
+          te_last = d; step = Check;
+        } else step = Reset; break;
+      case Check:
+        if (level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, ts) < td) { data = data << 1 | 0; cnt++; step = EndDur; }
+          else if (DDIFF(te_last, tl) < td * 2 && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = EndDur; }
+          else if (DDIFF(te_last, ts) < td * 2 && DDIFF(d, ts) < td && cnt == 27) { data = data << 1 | 0; cnt++; step = EndDur; }
+          else step = Reset;
+        } else step = Reset; break;
+      case EndDur:
+        if (!level && (DDIFF(d, ts) < td || DDIFF(d, tl) < td * 2)) step = StartDur;
+        else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── KeyFinder ───────────────────────────────────────────────────────────────
+static bool decode_keyfinder(const unsigned int* dur, uint16_t n, uint8_t phase,
+                             SubGhzDecoders::Match& m) {
+  const uint32_t ts = 400, tl = 1200, td = 150;
+  enum { Reset, Save, Check, Finish };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0, endc = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, ts * 10) < td * 5) { data = 0; cnt = 0; step = Save; }
+        break;
+      case Save:
+        if (cnt == 24) {
+          if (level && DDIFF(d, ts) < td) {
+            if (++endc == 4) { step = Finish; endc = 0; }
+          } else if (!level && DDIFF(d, ts) < td) {
+            // wait
+          } else {
+            data = 0; cnt = 0; endc = 0; step = Reset;
+          }
+          break;
+        }
+        if (level) { te_last = d; step = Check; } else step = Reset;
+        break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td && DDIFF(d, ts) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+      case Finish:
+        if (cnt == 24) { m.name = "KeyFinder"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+        data = 0; cnt = 0; endc = 0; step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Legrand ─────────────────────────────────────────────────────────────────
+static bool decode_legrand(const unsigned int* dur, uint16_t n, uint8_t phase,
+                           SubGhzDecoders::Match& m) {
+  const uint32_t ts = 375, tl = 1125, td = 150;
+  enum { Reset, FirstBit, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0, last_data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, ts * 16) < td * 8) { step = FirstBit; data = 0; cnt = 0; }
+        break;
+      case FirstBit:
+        if (level) {
+          if (DDIFF(d, ts) < td) { data = data << 1 | 0; cnt++; }
+          if (DDIFF(d, tl) < td * 3) { data = data << 1 | 1; cnt++; }
+          if (cnt > 0) { step = Save; break; }
+        }
+        step = Reset; break;
+      case Save:
+        if (!level) { te_last = d; step = Check; break; }
+        step = Reset; break;
+      case Check:
+        if (level) {
+          uint8_t found = 0;
+          if (DDIFF(te_last, tl) < td * 3 && DDIFF(d, ts) < td) { found = 1; data = data << 1 | 0; cnt++; }
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td * 3) { found = 1; data = data << 1 | 1; cnt++; }
+          if (found) {
+            if (cnt < 18) { step = Save; break; }
+            if (last_data && last_data == data) { m.name = "Legrand"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            last_data = data;
+          }
+        }
+        step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Linear Delta 3 ──────────────────────────────────────────────────────────
+static bool decode_linear_delta3(const unsigned int* dur, uint16_t n, uint8_t phase,
+                                 SubGhzDecoders::Match& m) {
+  const uint32_t ts = 500, tl = 2000, td = 150;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0, last_data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, ts * 70) < td * 24) { data = 0; cnt = 0; step = Save; }
+        break;
+      case Save: if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (d >= ts * 10) {
+            step = Reset;
+            if (DDIFF(te_last, ts) < td) { data = data << 1 | 1; cnt++; }
+            else if (DDIFF(te_last, tl) < td) { data = data << 1 | 0; cnt++; }
+            if (cnt == 8) {
+              if (last_data == data && last_data) { m.name = "LinearDelta3"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+              step = Save; last_data = data;
+            }
+            break;
+          }
+          if (DDIFF(te_last, ts) < td && DDIFF(d, ts * 7) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td && DDIFF(d, tl) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Marantec24 ──────────────────────────────────────────────────────────────
+static bool decode_marantec24(const unsigned int* dur, uint16_t n, uint8_t phase,
+                              SubGhzDecoders::Match& m) {
+  const uint32_t ts = 800, tl = 1600, td = 200;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, tl * 9) < td * 4) { data = 0; cnt = 0; step = Save; }
+        break;
+      case Save: if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, tl) < td && DDIFF(d, ts * 3) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, ts) < td && DDIFF(d, tl * 2) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(d, tl * 9) < td * 4) {
+            if (DDIFF(te_last, tl) < td) { data = data << 1 | 0; cnt++; }
+            if (DDIFF(te_last, ts) < td) { data = data << 1 | 1; cnt++; }
+            if (cnt == 24) { m.name = "Marantec24"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 0; cnt = 0; step = Reset;
+          } else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Mastercode ──────────────────────────────────────────────────────────────
+static bool decode_mastercode(const unsigned int* dur, uint16_t n, uint8_t phase,
+                              SubGhzDecoders::Match& m) {
+  const uint32_t ts = 1072, tl = 2145, td = 150;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, ts * 15) < td * 15) { step = Save; data = 0; cnt = 0; }
+        break;
+      case Save: if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td * 8) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td * 8 && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(d, ts * 15) < td * 15) {
+            if (DDIFF(te_last, ts) < td) { data = data << 1 | 0; cnt++; }
+            else if (DDIFF(te_last, tl) < td * 8) { data = data << 1 | 1; cnt++; }
+            if (cnt == 36) { m.name = "Mastercode"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            step = Save; data = 0; cnt = 0;
+          } else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── MegaCode ────────────────────────────────────────────────────────────────
+static bool decode_megacode(const unsigned int* dur, uint16_t n, uint8_t phase,
+                            SubGhzDecoders::Match& m) {
+  const uint32_t ts = 1000, td = 200;
+  enum { Reset, Start, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0, last_bit = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset: if (!level && DDIFF(d, ts * 13) < td * 17) step = Start; break;
+      case Start:
+        if (level && DDIFF(d, ts) < td) {
+          step = Save; data = 0; cnt = 0;
+          data = data << 1 | 1; cnt++; last_bit = 1;
+        } else step = Reset; break;
+      case Save:
+        if (!level) {
+          if (d >= ts * 10) {
+            step = Reset;
+            if (cnt == 24) { m.name = "MegaCode"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            break;
+          }
+          te_last = last_bit ? d : (d - ts * 3);
+          step = Check;
+        } else step = Reset; break;
+      case Check:
+        if (level) {
+          if (DDIFF(te_last, ts * 5) < td * 5 && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; last_bit = 1; step = Save; }
+          else if (DDIFF(te_last, ts * 2) < td * 2 && DDIFF(d, ts) < td) { data = data << 1 | 0; cnt++; last_bit = 0; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Nero Radio ──────────────────────────────────────────────────────────────
+static bool decode_nero_radio(const unsigned int* dur, uint16_t n, uint8_t phase,
+                              SubGhzDecoders::Match& m) {
+  const uint32_t ts = 200, tl = 400, td = 80;
+  enum { Reset, Pre, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0; uint16_t hc = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (level && DDIFF(d, ts) < td) { step = Pre; te_last = d; hc = 0; }
+        break;
+      case Pre:
+        if (level) {
+          if (DDIFF(d, ts) < td || DDIFF(d, ts * 4) < td) te_last = d;
+          else step = Reset;
+        } else if (DDIFF(d, ts) < td) {
+          if (DDIFF(te_last, ts) < td) { hc++; }
+          else if (DDIFF(te_last, ts * 4) < td) {
+            if (hc > 40) { step = Save; data = 0; cnt = 0; } else step = Reset;
+          } else step = Reset;
+        } else step = Reset;
+        break;
+      case Save:
+        if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (d >= 1250) {
+            if (DDIFF(te_last, ts) < td) { data = data << 1 | 0; cnt++; }
+            else if (DDIFF(te_last, tl) < td) { data = data << 1 | 1; cnt++; }
+            step = Reset;
+            if (cnt == 56 || cnt == 57) { m.name = "Nero Radio"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 0; cnt = 0; break;
+          } else if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Nero Sketch ─────────────────────────────────────────────────────────────
+static bool decode_nero_sketch(const unsigned int* dur, uint16_t n, uint8_t phase,
+                               SubGhzDecoders::Match& m) {
+  const uint32_t ts = 330, tl = 660, td = 150;
+  enum { Reset, Pre, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0; uint16_t hc = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (level && DDIFF(d, ts) < td) { step = Pre; te_last = d; hc = 0; }
+        break;
+      case Pre:
+        if (level) {
+          if (DDIFF(d, ts) < td || DDIFF(d, ts * 4) < td) te_last = d;
+          else step = Reset;
+        } else if (DDIFF(d, ts) < td) {
+          if (DDIFF(te_last, ts) < td) { hc++; }
+          else if (DDIFF(te_last, ts * 4) < td) {
+            if (hc > 40) { step = Save; data = 0; cnt = 0; } else step = Reset;
+          } else step = Reset;
+        } else step = Reset;
+        break;
+      case Save:
+        if (level) {
+          if (d >= ts * 2 + td * 2) {
+            step = Reset;
+            if (cnt == 40) { m.name = "Nero Sketch"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 0; cnt = 0; break;
+          }
+          te_last = d; step = Check;
+        } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Roger ───────────────────────────────────────────────────────────────────
+static bool decode_roger(const unsigned int* dur, uint16_t n, uint8_t phase,
+                         SubGhzDecoders::Match& m) {
+  const uint32_t ts = 500, tl = 1000, td = 270;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, ts * 19) < td * 5) { data = 0; cnt = 0; step = Save; }
+        break;
+      case Save: if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, tl) < td && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(d, ts * 19) < td * 5) {
+            if (DDIFF(te_last, tl) < td) { data = data << 1 | 1; cnt++; }
+            if (DDIFF(te_last, ts) < td) { data = data << 1 | 0; cnt++; }
+            if (cnt == 28) { m.name = "Roger"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 0; cnt = 0; step = Reset;
+          } else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── SMC5326 ─────────────────────────────────────────────────────────────────
+static bool decode_smc5326(const unsigned int* dur, uint16_t n, uint8_t phase,
+                           SubGhzDecoders::Match& m) {
+  const uint32_t ts = 300, tl = 900, td = 200;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0, last_data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, ts * 24) < td * 12) { step = Save; data = 0; cnt = 0; }
+        break;
+      case Save: if (level) { te_last = d; step = Check; } break;
+      case Check:
+        if (!level) {
+          if (d >= tl * 2) {
+            step = Save;
+            if (cnt == 25) {
+              if (last_data == data && last_data) { m.name = "SMC5326"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+              last_data = data;
+            }
+            data = 0; cnt = 0; break;
+          }
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td * 3) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td * 3 && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── GangQi ──────────────────────────────────────────────────────────────────
+static bool decode_gangqi(const unsigned int* dur, uint16_t n, uint8_t phase,
+                          SubGhzDecoders::Match& m) {
+  const uint32_t ts = 500, tl = 1200, td = 200;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, tl * 2) < td * 3) { data = 0; cnt = 0; step = Save; }
+        break;
+      case Save: if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(d, tl * 2) < td * 3) {
+            if (DDIFF(te_last, ts) < td) { data = data << 1 | 0; cnt++; }
+            if (DDIFF(te_last, tl) < td) { data = data << 1 | 1; cnt++; }
+            if (cnt == 34) { m.name = "GangQi"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 0; cnt = 0; step = Reset;
+          } else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Hollarm ─────────────────────────────────────────────────────────────────
+static bool decode_hollarm(const unsigned int* dur, uint16_t n, uint8_t phase,
+                           SubGhzDecoders::Match& m) {
+  const uint32_t ts = 200, tl = 1000, td = 200;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, ts * 12) < td * 2) { data = 0; cnt = 0; step = Save; }
+        break;
+      case Save: if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, ts) < td && DDIFF(d, ts * 8) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(d, ts * 12) < td) {
+            data = data << 1 | 0; cnt++;
+            if (cnt == 42) {
+              uint64_t k = data >> 2;
+              uint8_t bytesum = ((k >> 32) & 0xFF) + ((k >> 24) & 0xFF) +
+                                ((k >> 16) & 0xFF) + ((k >> 8) & 0xFF);
+              if (bytesum == (k & 0xFF)) {
+                m.name = "Hollarm"; m.key = k; m.bits = cnt; m.te = (uint16_t)ts; return true;
+              }
+            }
+            data = 0; cnt = 0; step = Reset;
+          } else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Treadmill37 ─────────────────────────────────────────────────────────────
+static bool decode_treadmill37(const unsigned int* dur, uint16_t n, uint8_t phase,
+                               SubGhzDecoders::Match& m) {
+  const uint32_t ts = 300, tl = 900, td = 150;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, ts * 20) < td * 4) { data = 0; cnt = 0; step = Save; }
+        break;
+      case Save: if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(d, ts * 20) < td * 4) {
+            if (DDIFF(te_last, ts) < td) { data = data << 1 | 0; cnt++; }
+            if (DDIFF(te_last, tl) < td) { data = data << 1 | 1; cnt++; }
+            if (cnt == 37) { m.name = "Treadmill37"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 0; cnt = 0; step = Reset;
+          } else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Holtek HT12X ────────────────────────────────────────────────────────────
+static bool decode_holtek_ht12x(const unsigned int* dur, uint16_t n, uint8_t phase,
+                                SubGhzDecoders::Match& m) {
+  const uint32_t ts = 320, tl = 640, td = 200;
+  enum { Reset, Start, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0, last_data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset: if (!level && DDIFF(d, ts * 28) < td * 20) step = Start; break;
+      case Start:
+        if (level && DDIFF(d, ts) < td) { step = Save; data = 0; cnt = 0; }
+        else step = Reset; break;
+      case Save:
+        if (!level) {
+          if (d >= ts * 10 + td) {
+            if (cnt == 12) {
+              if (last_data == data && last_data) { m.name = "Holtek_HT12X"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+              last_data = data;
+            }
+            data = 0; cnt = 0; step = Start; break;
+          }
+          te_last = d; step = Check;
+        } else step = Reset; break;
+      case Check:
+        if (level) {
+          if (DDIFF(te_last, tl) < td * 2 && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td * 2) { data = data << 1 | 0; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Honeywell WDB (door/chime) ──────────────────────────────────────────────
+static bool decode_honeywell_wdb(const unsigned int* dur, uint16_t n, uint8_t phase,
+                                 SubGhzDecoders::Match& m) {
+  const uint32_t ts = 160, tl = 320, td = 60;
+  enum { Reset, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, ts * 3) < td) { data = 0; cnt = 0; step = Save; }
+        break;
+      case Save:
+        if (level) {
+          if (DDIFF(d, ts * 3) < td) {
+            uint8_t par = 0; uint64_t k = data >> 1;
+            for (uint8_t b = 0; b < 47; b++) par += (uint8_t)((k >> b) & 1);
+            par &= 1;
+            if (cnt == 48 && (uint8_t)(data & 1) == par) { m.name = "Honeywell"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            step = Reset; break;
+          }
+          te_last = d; step = Check;
+        } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td && DDIFF(d, ts) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Chamberlain Code ────────────────────────────────────────────────────────
+// 4-bit symbol encoding (0b0111=bit0, 0b0011=bit1, 0b0001=stop); a captured
+// frame is matched against the 7/8/9-DIP code masks and converted to bits.
+static bool chamb_to_bit(uint64_t* data, uint8_t size) {
+  uint64_t t = *data, res = 0;
+  for (uint8_t i = 0; i < size; i++) {
+    uint64_t sym = t & 0xF;
+    if (sym == 0b0111) { /* bit 0 */ }
+    else if (sym == 0b0011) { res |= (1ULL << i); }
+    else return false;
+    t >>= 4;
+  }
+  *data = res;
+  return true;
+}
+static bool decode_chamberlain(const unsigned int* dur, uint16_t n, uint8_t phase,
+                               SubGhzDecoders::Match& m) {
+  const uint32_t ts = 1000, td = 200;
+  enum { Reset, Start, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset: if (!level && DDIFF(d, ts * 39) < td * 20) step = Start; break;
+      case Start:
+        if (level && DDIFF(d, ts) < td) {
+          data = 0; cnt = 0;
+          data = data << 4 | 0b0001; cnt++;  // stop marker
+          step = Save;
+        } else step = Reset; break;
+      case Save:
+        if (!level) {
+          if (d > ts * 5) {
+            if (cnt >= 10 && cnt <= 11) {
+              uint64_t cd = data; uint8_t cc = cnt; bool ok = false;
+              if ((cd & 0xF000000FF0FULL) == 0x10000001101ULL) {
+                cc = 7; cd &= ~0xF000000FF0FULL; cd = (cd >> 12) | ((cd >> 4) & 0xF); ok = true;
+              } else if ((cd & 0xF00000F00FULL) == 0x1000001001ULL) {
+                cc = 8; cd &= ~0xF00000F00FULL; cd = (cd >> 4) | ((uint64_t)0b0111 << 8); ok = true;
+              } else if ((cd & 0xF000000000FULL) == 0x10000000001ULL) {
+                cc = 9; cd &= ~0xF000000000FULL; cd >>= 4; ok = true;
+              }
+              if (ok && chamb_to_bit(&cd, cc)) { m.name = "Cham_Code"; m.key = cd; m.bits = cc; m.te = (uint16_t)ts; return true; }
+            }
+            step = Reset;
+          } else { te_last = d; step = Check; }
+        } else step = Reset; break;
+      case Check:
+        if (level) {
+          if (DDIFF(te_last, ts * 3) < td && DDIFF(d, ts) < td) { data = data << 4 | 0b0001; cnt++; step = Save; }
+          else if (DDIFF(te_last, ts * 2) < td && DDIFF(d, ts * 2) < td) { data = data << 4 | 0b0011; cnt++; step = Save; }
+          else if (DDIFF(te_last, ts) < td && DDIFF(d, ts * 3) < td) { data = data << 4 | 0b0111; cnt++; step = Save; }
+          else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Magellan ────────────────────────────────────────────────────────────────
+static uint8_t magellan_crc8(const uint8_t* d, uint8_t len) {
+  uint8_t crc = 0;
+  for (uint8_t i = 0; i < len; i++) {
+    crc ^= d[i];
+    for (uint8_t j = 0; j < 8; j++) crc = (crc & 0x80) ? (uint8_t)((crc << 1) ^ 0x31) : (uint8_t)(crc << 1);
+  }
+  return crc;
+}
+static bool decode_magellan(const unsigned int* dur, uint16_t n, uint8_t phase,
+                            SubGhzDecoders::Match& m) {
+  const uint32_t ts = 200, tl = 400, td = 100;
+  enum { Reset, Pre, FoundPre, Save, Check };
+  uint32_t step = Reset, te_last = 0; uint64_t data = 0; uint8_t cnt = 0; uint16_t hc = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    switch (step) {
+      case Reset:
+        if (level && DDIFF(d, ts) < td) { step = Pre; te_last = d; hc = 0; }
+        break;
+      case Pre:
+        if (level) te_last = d;
+        else {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, ts) < td) hc++;
+          else if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td * 2 && hc > 10) step = FoundPre;
+          else step = Reset;
+        }
+        break;
+      case FoundPre:
+        if (level) te_last = d;
+        else {
+          if (DDIFF(te_last, ts * 6) < td * 3 && DDIFF(d, tl) < td * 2) { step = Save; data = 0; cnt = 0; }
+          else step = Reset;
+        }
+        break;
+      case Save:
+        if (level) { te_last = d; step = Check; } else step = Reset; break;
+      case Check:
+        if (!level) {
+          if (DDIFF(te_last, ts) < td && DDIFF(d, tl) < td) { data = data << 1 | 1; cnt++; step = Save; }
+          else if (DDIFF(te_last, tl) < td && DDIFF(d, ts) < td) { data = data << 1 | 0; cnt++; step = Save; }
+          else if (d >= tl * 3) {
+            if (cnt == 32) {
+              uint8_t bytes[3] = { (uint8_t)(data >> 24), (uint8_t)(data >> 16), (uint8_t)(data >> 8) };
+              if ((uint8_t)(data & 0xFF) == magellan_crc8(bytes, 3)) {
+                m.name = "Magellan"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true;
+              }
+            }
+            data = 0; cnt = 0; step = Reset;
+          } else step = Reset;
+        } else step = Reset; break;
+    }
+  }
+  return false;
+}
+
+// ── Manchester decoder (ported from toolbox/manchester_decoder.c) ───────────
+enum { MEShortLow = 0, MEShortHigh = 2, MELongLow = 4, MELongHigh = 6, MEReset = 8 };
+enum { MSStart1 = 0, MSMid1 = 1, MSMid0 = 2, MSStart0 = 3 };
+static bool manch_advance(uint8_t state, uint8_t event, uint8_t* next, bool* data) {
+  static const uint8_t transitions[] = { 0b00000001, 0b10010001, 0b10011011, 0b11111011 };
+  uint8_t ns; bool result = false;
+  if (event == MEReset) ns = MSMid1;
+  else {
+    ns = (transitions[state] >> event) & 0x3;
+    if (ns == state) ns = MSMid1;
+    else if (ns == MSMid0) { if (data) *data = false; result = true; }
+    else if (ns == MSMid1) { if (data) *data = true;  result = true; }
+  }
+  *next = ns;
+  return result;
+}
+
+// ── CAME TWEE ───────────────────────────────────────────────────────────────
+static bool decode_came_twee(const unsigned int* dur, uint16_t n, uint8_t phase,
+                             SubGhzDecoders::Match& m) {
+  const uint32_t ts = 500, tl = 1000, td = 250;
+  enum { Reset, Data };
+  uint32_t step = Reset; uint64_t data = 0; uint8_t cnt = 0, mst = MSMid1;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    uint8_t event = MEReset;
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, tl * 51) < td * 20) {
+          step = Data; data = 0; cnt = 0;
+          manch_advance(mst, MELongLow,  &mst, nullptr);
+          manch_advance(mst, MELongHigh, &mst, nullptr);
+          manch_advance(mst, MEShortLow, &mst, nullptr);
+        }
+        break;
+      case Data:
+        if (!level) {
+          if (DDIFF(d, ts) < td) event = MEShortLow;
+          else if (DDIFF(d, tl) < td) event = MELongLow;
+          else if (d >= tl * 2 + td) {
+            if (cnt == 54) { m.name = "CAME TWEE"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 0; cnt = 0;
+            manch_advance(mst, MELongLow,  &mst, nullptr);
+            manch_advance(mst, MELongHigh, &mst, nullptr);
+            manch_advance(mst, MEShortLow, &mst, nullptr);
+          } else step = Reset;
+        } else {
+          if (DDIFF(d, ts) < td) event = MEShortHigh;
+          else if (DDIFF(d, tl) < td) event = MELongHigh;
+          else step = Reset;
+        }
+        break;
+    }
+    if (event != MEReset) {
+      bool b; if (manch_advance(mst, event, &mst, &b)) { data = (data << 1) | (b ? 0 : 1); cnt++; }
+    }
+  }
+  return false;
+}
+
+// ── Marantec (FSK — needs FSK RX to fire) ───────────────────────────────────
+static bool decode_marantec(const unsigned int* dur, uint16_t n, uint8_t phase,
+                            SubGhzDecoders::Match& m) {
+  const uint32_t ts = 1000, tl = 2000, td = 200;
+  enum { Reset, Data };
+  uint32_t step = Reset; uint64_t data = 0; uint8_t cnt = 0, mst = MSMid1;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    uint8_t event = MEReset;
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, tl * 5) < td * 8) {
+          step = Data; data = 1; cnt = 1; manch_advance(mst, MEReset, &mst, nullptr);
+        }
+        break;
+      case Data:
+        if (!level) {
+          if (DDIFF(d, ts) < td) event = MEShortLow;
+          else if (DDIFF(d, tl) < td) event = MELongLow;
+          else if (d >= tl * 2 + td) {
+            if (cnt == 49) { m.name = "Marantec"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+            data = 1; cnt = 1; manch_advance(mst, MEReset, &mst, nullptr);
+          } else step = Reset;
+        } else {
+          if (DDIFF(d, ts) < td) event = MEShortHigh;
+          else if (DDIFF(d, tl) < td) event = MELongHigh;
+          else step = Reset;
+        }
+        break;
+    }
+    if (event != MEReset) {
+      bool b; if (manch_advance(mst, event, &mst, &b)) { data = (data << 1) | (b ? 1 : 0); cnt++; }
+    }
+  }
+  return false;
+}
+
+// ── Power Smart ─────────────────────────────────────────────────────────────
+static bool decode_power_smart(const unsigned int* dur, uint16_t n, uint8_t phase,
+                               SubGhzDecoders::Match& m) {
+  const uint32_t ts = 225, tl = 450, td = 100;
+  const uint64_t HDR = 0xFD000000AA000000ULL, MASK = 0xFF000000FF000000ULL;
+  uint64_t data = 0; uint8_t mst = MSMid1;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    uint8_t event = MEReset;
+    if (!level) {
+      if (DDIFF(d, ts) < td) event = MEShortLow;
+      else if (DDIFF(d, tl) < td * 2) event = MELongLow;
+    } else {
+      if (DDIFF(d, ts) < td) event = MEShortHigh;
+      else if (DDIFF(d, tl) < td * 2) event = MELongHigh;
+    }
+    if (event != MEReset) {
+      bool b; if (manch_advance(mst, event, &mst, &b)) data = (data << 1) | (b ? 0 : 1);
+      if ((data & MASK) == HDR) {
+        uint32_t d1 = (uint32_t)((data >> 40) & 0xFFFF);
+        uint32_t d2 = (uint32_t)(((~data) >> 8) & 0xFFFF);
+        uint8_t  d3 = (uint8_t)((data >> 32) & 0xFF);
+        uint8_t  d4 = (uint8_t)(((~data) & 0xFF) - 1);
+        if (d1 == d2 && d3 == d4) { m.name = "Power Smart"; m.key = data; m.bits = 64; m.te = (uint16_t)ts; return true; }
+      }
+    } else { data = 0; mst = MSMid1; }
+  }
+  return false;
+}
+
+// ── Revers RB2 ──────────────────────────────────────────────────────────────
+static bool decode_revers_rb2(const unsigned int* dur, uint16_t n, uint8_t phase,
+                              SubGhzDecoders::Match& m) {
+  const uint32_t ts = 250, tl = 500, td = 160;
+  enum { Reset, Header, Data };
+  uint32_t step = Reset; uint64_t data = 0; uint8_t cnt = 0, mst = MSMid1, hc = 0, last_level = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    uint8_t event = MEReset;
+    switch (step) {
+      case Reset:
+        if (!level && DDIFF(d, 600) < td) {
+          step = Header; data = 0; cnt = 0; hc = 0; last_level = 0;
+          manch_advance(mst, MEReset, &mst, nullptr);
+        }
+        break;
+      case Header:
+        if (!level) {
+          if (DDIFF(d, ts) < td) { if (last_level == 1) hc++; last_level = 0; }
+          else { hc = 0; last_level = 0; step = Reset; }
+        } else {
+          if (DDIFF(d, ts) < td) { if (last_level == 0) hc++; last_level = 1; }
+          else { hc = 0; last_level = 0; step = Reset; }
+        }
+        if (hc == 4) { hc = 0; data = 0xF; cnt = 4; step = Data; }
+        break;
+      case Data:
+        if (!level) {
+          if (DDIFF(d, ts) < td) event = MEShortLow;
+          else if (DDIFF(d, tl) < td) event = MELongLow;
+          else step = Reset;
+        } else {
+          if (DDIFF(d, ts) < td) event = MEShortHigh;
+          else if (DDIFF(d, tl) < td) event = MELongHigh;
+          else step = Reset;
+        }
+        break;
+    }
+    if (step == Data && event != MEReset) {
+      bool b;
+      if (manch_advance(mst, event, &mst, &b)) {
+        data = (data << 1) | (b ? 1 : 0); cnt++;
+        if (cnt >= 65) { data = 0; cnt = 0; }
+        else if (cnt >= 64) {
+          uint16_t preamble = (data >> 48) & 0xFF;
+          uint16_t stop = (data & 0x3FF);
+          if (preamble == 0xFF && stop == 0x200) { m.name = "Revers_RB2"; m.key = data; m.bits = cnt; m.te = (uint16_t)ts; return true; }
+        }
+      }
+    }
+  }
+  return false;
+}
+
+// ── Honeywell Security (FSK — needs FSK RX to fire) ─────────────────────────
+static uint16_t honeywell_crc16(const uint8_t* msg, uint8_t nBytes, uint16_t poly, uint16_t init) {
+  uint16_t rem = init;
+  for (uint8_t byte = 0; byte < nBytes; byte++) {
+    rem ^= (uint16_t)(msg[byte] << 8);
+    for (uint8_t bit = 0; bit < 8; bit++) rem = (rem & 0x8000) ? (uint16_t)((rem << 1) ^ poly) : (uint16_t)(rem << 1);
+  }
+  return rem;
+}
+static bool decode_honeywell(const unsigned int* dur, uint16_t n, uint8_t phase,
+                             SubGhzDecoders::Match& m) {
+  const uint32_t ts = 143, tl = 280, td = 51;
+  uint64_t data = 0; uint8_t cnt = 0, mst = MSMid1;
+  for (uint16_t i = 0; i < n; i++) {
+    bool level = sampleLevel(i, phase); uint32_t d = dur[i];
+    uint8_t event = MEReset;
+    if (!level) {
+      if (DDIFF(d, ts) < td) event = MEShortLow;
+      else if (DDIFF(d, tl) < td * 2) event = MELongLow;
+    } else {
+      if (DDIFF(d, ts) < td) event = MEShortHigh;
+      else if (DDIFF(d, tl) < td * 2) event = MELongHigh;
+    }
+    if (event != MEReset) {
+      bool b;
+      if (manch_advance(mst, event, &mst, &b)) {
+        data = (data << 1) | (b ? 1 : 0); cnt++;
+        if (cnt >= 62) {
+          uint16_t preamble = (data >> 48) & 0xFFFF;
+          if (preamble == 0b0011111111111110 || preamble == 0b0111111111111110 ||
+              preamble == 0b1111111111111110) {
+            uint8_t dc[4] = { (uint8_t)(data >> 40), (uint8_t)(data >> 32),
+                              (uint8_t)(data >> 24), (uint8_t)(data >> 16) };
+            uint8_t channel = (data >> 44) & 0xF;
+            uint16_t crc_calc = 0; bool valid = true;
+            if (channel == 0x2 || channel == 0x4 || channel == 0xA) crc_calc = honeywell_crc16(dc, 4, 0x8050, 0);
+            else if (channel == 0x8) crc_calc = honeywell_crc16(dc, 4, 0x8005, 0);
+            else { data = 0; cnt = 0; valid = false; }
+            if (valid && (uint16_t)(data & 0xFFFF) == crc_calc) {
+              m.name = "Honeywell Sec"; m.key = data; m.bits = 64; m.te = (uint16_t)ts; return true;
+            }
+          }
+        }
+      }
+    } else { data = 0; cnt = 0; }
+  }
+  return false;
+}
+
+// ── Engine ──────────────────────────────────────────────────────────────────
+
+typedef bool (*DecoderFn)(const unsigned int*, uint16_t, uint8_t, SubGhzDecoders::Match&);
+
+// Ordered most-specific/strict first (header masks, long bit counts, exact-count
+// matches) so a loose-tolerance decoder can't grab a frame another would parse
+// correctly. Each entry self-syncs on its own header, so unrelated frames are
+// simply ignored.
+static const DecoderFn kDecoders[] = {
+  decode_honeywell,      // 64-bit Manchester (FSK)
+  decode_power_smart,    // 64-bit Manchester, header
+  decode_revers_rb2,     // 64-bit Manchester
+  decode_came_twee,      // 54-bit Manchester
+  decode_marantec,       // 49-bit Manchester (FSK)
+  decode_honeywell_wdb,  // 48-bit, parity
+  decode_nero_radio,     // 56-bit
+  decode_hormann,        // 44-bit, header mask
+  decode_hollarm,        // 42-bit, checksum
+  decode_holtek,         // 40-bit, header mask
+  decode_dooya,          // 40-bit
+  decode_nero_sketch,    // 40-bit
+  decode_doitrand,       // 37-bit
+  decode_treadmill37,    // 37-bit
+  decode_mastercode,     // 36-bit
+  decode_dickert,        // 36-bit
+  decode_gangqi,         // 34-bit
+  decode_magellan,       // 32-bit, CRC8
+  decode_intertechno_v3, // 32/36-bit
+  decode_feron,          // 32-bit
+  decode_roger,          // 28-bit
+  decode_keyfinder,      // 24-bit, repeat-terminated
+  decode_marantec24,     // 24-bit
+  decode_princeton,      // 24-bit, double-frame
+  decode_gate_tx,        // 24-bit
+  decode_megacode,       // 24-bit, PPM
+  decode_smc5326,        // 25-bit, double-frame
+  decode_came,           // 12/24-bit family
+  decode_nice_flo,       // 12-bit
+  decode_holtek_ht12x,   // 12-bit, double-frame
+  decode_chamberlain,    // 7/8/9-DIP symbol code
+  decode_clemsa,         // 18-bit
+  decode_bett,           // 18-bit
+  decode_elplast,        // 18-bit
+  decode_legrand,        // 18-bit, double-frame
+  decode_ansonic,        // 12-bit
+  decode_linear_delta3,  // 8-bit, double-frame
+  decode_linear,         // 10-bit, loose tolerance — last
+};
+static constexpr uint8_t kNumDecoders = sizeof(kDecoders) / sizeof(kDecoders[0]);
+
+bool SubGhzDecoders::decode(const unsigned int* dur, uint16_t count,
+                            CC1101Util::Signal& out) {
+  if (count < 8) return false;
+
+  Match m;
+  for (uint8_t phase = 0; phase < 2; phase++) {
+    for (uint8_t k = 0; k < kNumDecoders; k++) {
+      if (kDecoders[k](dur, count, phase, m)) {
+        out.protocol = m.name;
+        out.preset   = "FuriHalSubGhzPresetOok650Async";
+        out.key      = m.key;
+        out.bit      = (int)m.bits;
+        out.te       = (int)m.te;
+        return true;
+      }
+    }
+  }
+  return false;
+}

--- a/firmware/src/utils/rf/SubGhzDecoders.h
+++ b/firmware/src/utils/rf/SubGhzDecoders.h
@@ -1,0 +1,36 @@
+//
+// SubGhzDecoders — brand/manufacturer protocol decoders ported from Flipper
+// Zero firmware (lib/subghz/protocols/*). Each decoder is a state machine fed
+// the captured raw pulse train (alternating HIGH/LOW durations in µs); when a
+// frame is recognised the Signal is labelled with the real protocol name
+// (CAME, Princeton, Nice FLO, Holtek, Linear, ...) instead of staying RAW.
+//
+// Fed from CC1101Util::pollReceive() on a completed raw frame. The phase of the
+// captured buffer (which edge is HIGH) is unknown, so decode() tries both
+// parities and each state machine self-syncs on its own header.
+//
+// Reference: https://github.com/flipperdevices/flipperzero-firmware
+//            lib/subghz/protocols/  (GPLv3)
+//
+
+#pragma once
+#include <Arduino.h>
+#include "CC1101Util.h"
+
+class SubGhzDecoders {
+public:
+  // Run every brand decoder over a completed raw frame.
+  //   dur   : array of pulse durations in µs (alternating HIGH/LOW)
+  //   count : number of valid entries in `dur`
+  // On a match, fills out.protocol (brand name) + key/bit/te and returns true.
+  // out.rawData / out.frequency are left for the caller to populate.
+  static bool decode(const unsigned int* dur, uint16_t count, CC1101Util::Signal& out);
+
+  // Match produced by a single decoder.
+  struct Match {
+    const char* name = nullptr;
+    uint64_t    key  = 0;
+    uint8_t     bits = 0;
+    uint16_t    te   = 0;
+  };
+};


### PR DESCRIPTION
## What changes
Adds **`SubGhzDecoders`** — a decode engine that runs the captured raw pulse train through brand/manufacturer state machines. Covers all **38 static (non-rolling) protocols**: CAME (+TWEE), Princeton, Nice FLO, Holtek (+HT12X), Linear (+Delta3), Ansonic, BETT, Clemsa, Dickert, Doitrand, Dooya, Elplast, Feron, GateTX, Hormann, Intertechno_V3, KeyFinder, Legrand, Marantec(24), Mastercode, MegaCode, Nero Radio/Sketch, Roger, SMC5326, Treadmill37, GangQi, Hollarm, Honeywell (WDB/Sec), Cham_Code, Magellan, Power Smart, Revers_RB2.

- Ported Manchester / CRC8 / CRC16 / parity helpers. The capture phase is unknown, so each frame is tried at **both parities** and every decoder self-syncs on its own header.
- Decoders are **authoritative**: `pollReceive` decides on the completed raw frame — brand decoders first, then the RcSwitch table, then generic RAW.
- **KeeLoq (proto 23)** stays on the fast path — it's a rolling protocol needing the `mfcodes` keystore and has no brand decoder, so brand decoders never see it.
- Maps RcSwitch protocol numbers to chip names (e.g. `P6 → HT6P20B`) in the list/info/label; keeps raw on brand signals so they still replay; round-trips brand `.sub` save/load.
- FSK protocols (Honeywell Sec, Marantec) are ported but **won't fire until FSK RX exists**.

> ⚠️ **Stacked on #27** (`feat/subghz-freq-analyzer`) — merge #27 first. Until then this PR's diff also contains #27's commit.

## Files
- `firmware/src/utils/rf/SubGhzDecoders.cpp` / `.h` (new, ~1.6k lines)
- `firmware/src/utils/rf/CC1101Util.cpp` / `.h`
- `firmware/src/screens/module/RfCaptureScreen.cpp`

## How to test
1. Build & flash a CC1101-equipped board.
2. **Modules → Sub-GHz → Receive** (capture).
3. Transmit from supported remotes (e.g. CAME, Princeton, Nice FLO, Holtek gate remotes): confirm the decoded **brand/protocol name + data** appear instead of generic RAW.
4. Confirm chip names show for RcSwitch protocols (e.g. `HT6P20B`).
5. Save a decoded brand signal to `.sub`, reload it, and **replay** — confirm it round-trips and transmits.
6. Capture a **KeeLoq** remote: confirm it still decodes via the fast path and is not mishandled by the brand decoders.

---
