### PR TITLE
🐛 subghz: fix KeeLoq replay transmitting with the wrong protocol

### DIFF
--- a/firmware/src/utils/rf/CC1101Util.cpp
+++ b/firmware/src/utils/rf/CC1101Util.cpp
@@ -336,8 +336,12 @@ void CC1101Util::_sendRcSwitch(const Signal& sig) {
   } else if (sig.protocol.startsWith("Princeton")) {
     protoNum = 1;
   } else {
+    // RcSwitch protocol number stored as the preset string. Allow the full
+    // 1..23 table — capping at 12 silently dropped KeeLoq (proto 23) back to
+    // proto 1, so KeeLoq replay (incl. Replay +1) was transmitted without the
+    // KeeLoq preamble/sync and a real receiver would reject it.
     int n = sig.preset.toInt();
-    if (n >= 1 && n <= 12) protoNum = n;
+    if (n >= 1 && n <= 23) protoNum = n;
   }
 
   RCSwitchUtil sw;


### PR DESCRIPTION
## What changes
Fixes KeeLoq replay transmitting with the wrong protocol.

`_sendRcSwitch` capped the protocol selection at `n <= 12`, so a KeeLoq capture (preset `"23"`) silently fell back to **protocol 1 (Princeton)**. The KeeLoq preamble/sync that `RCSwitchUtil::send` only emits for protocol 23 (`syncFactor.high == 0`) was therefore never sent, and a real receiver would reject the frame — breaking both plain **KeeLoq replay** and **Replay +1**.

The counter increment + re-encrypt in `KeeloqUtil::step` was already correct; only the transmit framing was wrong. The fix allows the full **1..23** RcSwitch table, so KeeLoq (and protocols 13–22) are transmitted with their own framing.

## Files
- `firmware/src/utils/rf/CC1101Util.cpp` (+5 / −1)

## How to test
1. Build & flash a CC1101-equipped board.
2. Capture a KeeLoq remote (**Modules → Sub-GHz → Receive**) or load a KeeLoq `.sub`.
3. **Replay** it (and **Replay +1**) toward a paired receiver: confirm the receiver now **accepts** the frame (it was rejected before this fix).
4. *(Optional)* Capture the transmitted signal on a second device and verify it's sent as **proto 23** (KeeLoq preamble/sync present), not Princeton.

---
