### PR TITLE
⚙️ settings: add Hide Module to show/hide Modules menu entries

### DIFF
--- a/firmware/src/core/ConfigManager.h
+++ b/firmware/src/core/ConfigManager.h
@@ -56,6 +56,8 @@
 #define APP_CONFIG_LED_MODE_DEFAULT             "off"
 #define APP_CONFIG_MASCOT                       "mascot"
 #define APP_CONFIG_MASCOT_DEFAULT               "hacker"
+#define APP_CONFIG_HIDDEN_MODULES               "hidden_modules"
+#define APP_CONFIG_HIDDEN_MODULES_DEFAULT       "0"
 
 class ConfigManager
 {

--- a/firmware/src/screens/module/ModuleMenuScreen.cpp
+++ b/firmware/src/screens/module/ModuleMenuScreen.cpp
@@ -12,7 +12,15 @@
 #include "screens/setting/PinSettingScreen.h"
 
 void ModuleMenuScreen::onInit() {
-  setItems(_items);
+  _visibleCount = 0;
+  for (uint8_t id = 0; id < ModuleRegistry::MOD_COUNT; id++) {
+    if (ModuleRegistry::isHidden(id)) continue;
+    _items[_visibleCount].label    = ModuleRegistry::LABELS[id];
+    _items[_visibleCount].sublabel = nullptr;
+    _ids[_visibleCount]            = id;
+    _visibleCount++;
+  }
+  setItems(_items, _visibleCount);
 }
 
 void ModuleMenuScreen::onBack() {
@@ -20,15 +28,16 @@ void ModuleMenuScreen::onBack() {
 }
 
 void ModuleMenuScreen::onItemSelected(uint8_t index) {
-  switch (index) {
-    case 0: Screen.push(new MFRC522Screen());     break;
-    case 1: Screen.push(new PN532UartScreen());   break;
-    case 2: Screen.push(new PN532I2cScreen());    break;
-    case 3: Screen.push(new GPSScreen());         break;
-    case 4: Screen.push(new IRScreen());          break;
-    case 5: Screen.push(new SubGHzScreen());      break;
-    case 6: Screen.push(new M5RF433Screen());     break;
-    case 7: Screen.push(new NRF24Screen());       break;
-    case 8: Screen.push(new PinSettingScreen());  break;
+  if (index >= _visibleCount) return;
+  switch (_ids[index]) {
+    case ModuleRegistry::MOD_MFRC522_I2C: Screen.push(new MFRC522Screen());    break;
+    case ModuleRegistry::MOD_PN532_UART:  Screen.push(new PN532UartScreen());  break;
+    case ModuleRegistry::MOD_PN532_I2C:   Screen.push(new PN532I2cScreen());   break;
+    case ModuleRegistry::MOD_GPS:         Screen.push(new GPSScreen());        break;
+    case ModuleRegistry::MOD_IR:          Screen.push(new IRScreen());         break;
+    case ModuleRegistry::MOD_SUBGHZ:      Screen.push(new SubGHzScreen());     break;
+    case ModuleRegistry::MOD_M5_RF433:    Screen.push(new M5RF433Screen());    break;
+    case ModuleRegistry::MOD_NRF24:       Screen.push(new NRF24Screen());      break;
+    case ModuleRegistry::MOD_PIN_SETTING: Screen.push(new PinSettingScreen()); break;
   }
 }

--- a/firmware/src/screens/module/ModuleMenuScreen.h
+++ b/firmware/src/screens/module/ModuleMenuScreen.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ui/templates/ListScreen.h"
+#include "screens/module/ModuleRegistry.h"
 
 class ModuleMenuScreen : public ListScreen
 {
@@ -12,15 +13,9 @@ public:
   void onItemSelected(uint8_t index) override;
 
 private:
-  ListItem _items[9] = {
-    {"MFRC522 I2C"},
-    {"PN532 UART"},
-    {"PN532 I2C"},
-    {"GPS"},
-    {"IR Remote"},
-    {"Sub-GHz"},
-    {"M5 RF433"},
-    {"NRF24L01"},
-    {"Pin Setting"},
-  };
+  // Built fresh on each entry: only the modules not hidden in config are
+  // listed, with _ids mapping each visible row back to its ModuleRegistry id.
+  ListItem _items[ModuleRegistry::MOD_COUNT];
+  uint8_t  _ids[ModuleRegistry::MOD_COUNT];
+  uint8_t  _visibleCount = 0;
 };

--- a/firmware/src/screens/module/ModuleRegistry.h
+++ b/firmware/src/screens/module/ModuleRegistry.h
@@ -1,0 +1,58 @@
+#pragma once
+//
+// Single source of truth for the entries shown in the Modules menu.
+//
+// Module ids are positional and persisted as a bitmask in the
+// APP_CONFIG_HIDDEN_MODULES config key, so entries must only ever be appended
+// (never reordered) or existing hide-flags will shift onto the wrong module.
+//
+#include <Arduino.h>
+#include "core/ConfigManager.h"
+
+namespace ModuleRegistry
+{
+  enum : uint8_t {
+    MOD_MFRC522_I2C = 0,
+    MOD_PN532_UART,
+    MOD_PN532_I2C,
+    MOD_GPS,
+    MOD_IR,
+    MOD_SUBGHZ,
+    MOD_M5_RF433,
+    MOD_NRF24,
+    MOD_PIN_SETTING,
+    MOD_COUNT
+  };
+
+  static const char* const LABELS[MOD_COUNT] = {
+    "MFRC522 I2C",
+    "PN532 UART",
+    "PN532 I2C",
+    "GPS",
+    "IR Remote",
+    "Sub-GHz",
+    "M5 RF433",
+    "NRF24L01",
+    "Pin Setting",
+  };
+
+  inline uint32_t hiddenMask()
+  {
+    return (uint32_t)Config.get(APP_CONFIG_HIDDEN_MODULES,
+                                APP_CONFIG_HIDDEN_MODULES_DEFAULT).toInt();
+  }
+
+  inline bool isHidden(uint8_t id)
+  {
+    return id < MOD_COUNT && (hiddenMask() & (1UL << id));
+  }
+
+  inline void setHidden(uint8_t id, bool hidden)
+  {
+    if (id >= MOD_COUNT) return;
+    uint32_t mask = hiddenMask();
+    if (hidden) mask |= (1UL << id);
+    else        mask &= ~(1UL << id);
+    Config.set(APP_CONFIG_HIDDEN_MODULES, String((unsigned long)mask));
+  }
+}

--- a/firmware/src/screens/setting/HideModuleScreen.cpp
+++ b/firmware/src/screens/setting/HideModuleScreen.cpp
@@ -1,0 +1,32 @@
+#include "screens/setting/HideModuleScreen.h"
+#include "core/Device.h"
+#include "core/ConfigManager.h"
+#include "core/ScreenManager.h"
+
+void HideModuleScreen::onInit() {
+  for (uint8_t i = 0; i < ModuleRegistry::MOD_COUNT; i++) {
+    _items[i].label    = ModuleRegistry::LABELS[i];
+    _items[i].sublabel = nullptr;
+  }
+  setItems(_items);
+  _refresh();
+}
+
+void HideModuleScreen::_refresh() {
+  for (uint8_t i = 0; i < ModuleRegistry::MOD_COUNT; i++) {
+    _subs[i]           = ModuleRegistry::isHidden(i) ? "Hidden" : "Shown";
+    _items[i].sublabel = _subs[i].c_str();
+  }
+  render();
+}
+
+void HideModuleScreen::onItemSelected(uint8_t index) {
+  if (index >= ModuleRegistry::MOD_COUNT) return;
+  ModuleRegistry::setHidden(index, !ModuleRegistry::isHidden(index));
+  Config.save(Uni.Storage);
+  _refresh();
+}
+
+void HideModuleScreen::onBack() {
+  Screen.goBack();
+}

--- a/firmware/src/screens/setting/HideModuleScreen.h
+++ b/firmware/src/screens/setting/HideModuleScreen.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+#include "screens/module/ModuleRegistry.h"
+
+// Toggle which entries appear in the Modules menu. State is persisted in the
+// APP_CONFIG_HIDDEN_MODULES bitmask so hidden modules stay hidden across reboots.
+class HideModuleScreen : public ListScreen
+{
+public:
+  const char* title() override { return "Hide Module"; }
+
+  void onInit() override;
+  void onItemSelected(uint8_t index) override;
+  void onBack() override;
+
+private:
+  void _refresh();
+
+  String   _subs[ModuleRegistry::MOD_COUNT];
+  ListItem _items[ModuleRegistry::MOD_COUNT];
+};

--- a/firmware/src/screens/setting/SettingScreen.cpp
+++ b/firmware/src/screens/setting/SettingScreen.cpp
@@ -14,6 +14,7 @@
 #include "ui/actions/ShowStatusAction.h"
 #include "utils/Mascot.h"
 #include "screens/setting/PinSettingScreen.h"
+#include "screens/setting/HideModuleScreen.h"
 #include "screens/setting/DeviceStatusScreen.h"
 #include "screens/setting/AboutScreen.h"
 #ifdef DEVICE_HAS_TOUCH_NAV
@@ -325,6 +326,11 @@ void SettingScreen::onItemSelected(uint8_t index) {
 
     case SETT_PIN_SETTING: {
       Screen.push(new PinSettingScreen());
+      break;
+    }
+
+    case SETT_HIDE_MODULE: {
+      Screen.push(new HideModuleScreen());
       break;
     }
 

--- a/firmware/src/screens/setting/SettingScreen.h
+++ b/firmware/src/screens/setting/SettingScreen.h
@@ -56,6 +56,7 @@ private:
     SETT_SERIAL_FM,
     SETT_SCREEN_MIRROR,
     SETT_PIN_SETTING,
+    SETT_HIDE_MODULE,
     SETT_DEVICE_STATUS,
     SETT_ABOUT,
     SETT_COUNT
@@ -131,6 +132,7 @@ private:
     {"Serial File Manager", ""},
     {"Screen Mirror",    ""},
     {"Pin Setting"},
+    {"Hide Module"},
     {"Device Status"},
     {"About"},
   };


### PR DESCRIPTION
## What changes
Adds a **Hide Module** screen under **Settings** that toggles which entries appear in the **Modules** menu. Hidden state is persisted, so hidden modules stay hidden across reboots.

- New config key `APP_CONFIG_HIDDEN_MODULES` — stored as a **bitmask** in the persisted `/unigeek/config` file (default `0` = nothing hidden).
- `ModuleRegistry.h` (new) — single source of truth for the module labels/ids plus `isHidden()` / `setHidden()` helpers over the bitmask.
- `ModuleMenuScreen` now builds its list from the registry on each entry, skipping hidden ids and mapping each visible row back to its module id.
- `HideModuleScreen` (new) — per-module **Shown/Hidden** toggle, saved to config immediately on press.
- Wired a **Hide Module** entry into `SettingScreen` (after Pin Setting).

Module ids are positional in the bitmask, so registry entries must only be appended, never reordered (documented in the header).

## Files
- `firmware/src/core/ConfigManager.h`
- `firmware/src/screens/module/ModuleRegistry.h` (new)
- `firmware/src/screens/module/ModuleMenuScreen.cpp` / `.h`
- `firmware/src/screens/setting/HideModuleScreen.cpp` / `.h` (new)
- `firmware/src/screens/setting/SettingScreen.cpp` / `.h`

## How to test
1. Build & flash any board (verified on `m5_cardputer_adv` and `t_display`).
2. **Settings → Hide Module**: toggle a few modules to **Hidden**.
3. Open the **Modules** menu: confirm the hidden ones are gone and the remaining ones still open correctly.
4. **Power-cycle** the device: confirm hidden modules stay hidden.
5. Back in **Settings → Hide Module**, set them to **Shown**: confirm they reappear in Modules.
6. Edge case: hide *every* module → the Modules menu is empty but **Back** still works, and you can re-enable from Settings.

---
