### PR TITLE
🛜 firmware: Sub-GHz — fix band scans calibrating only at the configured Frequency

### DIFF
--- a/firmware/src/screens/module/SubGHzScreen.cpp
+++ b/firmware/src/screens/module/SubGHzScreen.cpp
@@ -419,7 +419,7 @@ void SubGHzScreen::_runWaterfall() {
     render();
     return;
   }
-  _rf.beginRssiSweep();
+  _rf.beginRssiSweep((_wfStart + _wfEnd) * 0.5f);
 
   _wfLine      = 0;
   _wfMaxRssi   = -120;

--- a/firmware/src/utils/rf/CC1101Util.cpp
+++ b/firmware/src/utils/rf/CC1101Util.cpp
@@ -239,11 +239,9 @@ bool CC1101Util::beginScan() {
 bool CC1101Util::stepScan() {
   if (!_initialized || !_scanning) return false;
   float f = kFreqList[_scanIdx % kFreqCount];
-  ELECHOUSE_cc1101.setMHZ(f);
   _scanFreq = f;
   _scanIdx++;
-  delay(2);
-  int rssi = ELECHOUSE_cc1101.getRssi();
+  int rssi = _tunedRssi(f);   // recalibrates per point — independent of configured freq
   _scanRssi = rssi;
   uint8_t slot = (_scanIdx - 1) % kFreqCount;
   _scanRssiMap[slot] = rssi;
@@ -275,26 +273,34 @@ void CC1101Util::beginAnalyze() {
   _peakLive = false;
   _holdCtr  = 0;
   for (uint8_t i = 0; i < kFreqCount; i++) _scanRssiMap[i] = -120;
-  // Enter RX once and STAY in RX for the whole session (RxBW inherited from
-  // begin() = 256 kHz — the same proven path as beginScan/stepScan). Re-issuing
-  // SetRx() per frame would SIDLE→SRX and reset the AGC, pinning RSSI at the
-  // noise floor so nothing is ever detected.
+  // RxBW inherited from begin() = 256 kHz. RSSI is read per point via _tunedRssi(),
+  // which re-enters RX (SIDLE→SRX) at each frequency so the VCO recalibrates for
+  // that point — otherwise the sweep stays calibrated for the configured Frequency
+  // and reads noise elsewhere. The per-point kSweepSettleUs delay lets the AGC
+  // settle (a bare SetRx with no settle reads the noise floor).
   ELECHOUSE_cc1101.SetRx();
+}
+
+// Tune + recalibrate + settle, then read RSSI. See header for rationale.
+int CC1101Util::_tunedRssi(float mhz) {
+  ELECHOUSE_cc1101.setMHZ(mhz);   // FREQ registers + manual Calibrate()
+  ELECHOUSE_cc1101.SetRx();       // SIDLE→SRX → FS_AUTOCAL recalibrates at `mhz`
+  delayMicroseconds(kSweepSettleUs);
+  return ELECHOUSE_cc1101.getRssi();
 }
 
 bool CC1101Util::analyzeStep() {
   if (!_initialized || !_scanning) return false;
 
-  // ── Stage 1: coarse sweep — whole band, find the strongest channel. Stay in
-  // RX and only retune (setMHZ); this is the exact RF path stepScan uses. Also
-  // fills _scanRssiMap so the (optional) bar chart keeps updating.
+  // ── Stage 1: coarse sweep — whole band, find the strongest channel. Each point
+  // is read via _tunedRssi(), which recalibrates the VCO at that frequency so the
+  // sweep is independent of the configured Frequency. Also fills _scanRssiMap so
+  // the (optional) bar chart keeps updating.
   int   coarseRssi = -127;
   float coarseFreq = 0;
   for (uint8_t i = 0; i < kFreqCount; i++) {
     float f = kFreqList[i];
-    ELECHOUSE_cc1101.setMHZ(f);
-    delay(2);
-    int rssi = ELECHOUSE_cc1101.getRssi();
+    int rssi = _tunedRssi(f);
     _scanRssiMap[i] = rssi;
     _scanFreq = f;
     _scanRssi = rssi;
@@ -303,15 +309,13 @@ bool CC1101Util::analyzeStep() {
 
   // ── Stage 2: fine refine — ±0.3 MHz around the coarse peak in 20 kHz steps to
   // pin the exact carrier (a signal at e.g. 433.66, not on the coarse list, is
-  // located here). Same RX/BW path — just a denser retune sweep.
+  // located here). Recalibrates per point via _tunedRssi() — just a denser sweep.
   if (coarseRssi > kAnalyzerTrigger) {
     int   fineRssi = -127;
     float fineFreq = coarseFreq;
     for (float f = coarseFreq - 0.30f; f <= coarseFreq + 0.3001f; f += 0.02f) {
       if (!cc1101_freq_valid(f)) continue;
-      ELECHOUSE_cc1101.setMHZ(f);
-      delay(2);
-      int rssi = ELECHOUSE_cc1101.getRssi();
+      int rssi = _tunedRssi(f);
       if (rssi > fineRssi) { fineRssi = rssi; fineFreq = f; }
     }
     _peakFreq = fineFreq;
@@ -347,10 +351,16 @@ void CC1101Util::_initRx() {
 
 // ── Fast RSSI sweep (Waterfall) ──────────────────────────────────────────────
 
-void CC1101Util::beginRssiSweep() {
+void CC1101Util::beginRssiSweep(float calibMhz) {
   if (!_initialized) return;
   ELECHOUSE_cc1101.setRxBW(200);
+  // Calibrate the VCO at the swept band's midpoint, not the configured Frequency:
+  // SetRx() (SIDLE→SRX) triggers FS_AUTOCAL at whatever frequency is loaded, so
+  // retune there first. Per-pixel rssiAt() then relocks within the band without a
+  // fresh autocal, keeping the sweep fast.
+  if (calibMhz > 0) ELECHOUSE_cc1101.setMHZ(calibMhz);
   ELECHOUSE_cc1101.SetRx();
+  delayMicroseconds(kSweepSettleUs);  // let RSSI settle after the fresh calibration
 }
 
 int CC1101Util::rssiAt(float mhz) {

--- a/firmware/src/utils/rf/CC1101Util.h
+++ b/firmware/src/utils/rf/CC1101Util.h
@@ -83,7 +83,10 @@ public:
 
   // Fast RSSI sweep (Waterfall): put the chip in RX once, then read RSSI at an
   // arbitrary frequency per pixel. rssiAt() retunes + settles + reads.
-  void beginRssiSweep();
+  // `calibMhz` is the frequency the one-time VCO calibration is done at — pass the
+  // midpoint of the swept band so the sweep is calibrated for that band rather than
+  // the configured Frequency (otherwise distant pixels read the noise floor).
+  void beginRssiSweep(float calibMhz = 0);
   int  rssiAt(float mhz);
   void endRssiSweep();
 
@@ -149,12 +152,20 @@ private:
   int     _scanRssiMap[kScanFreqCount];
 
   // Frequency analyzer (peak detect + sample-hold)
-  static constexpr int     kAnalyzerTrigger = -75;  // dBm; coarse peak must exceed
-  static constexpr uint8_t kAnalyzerHold    = 16;   // frames to hold after signal stops
+  static constexpr int      kAnalyzerTrigger = -75;   // dBm; coarse peak must exceed
+  static constexpr uint8_t  kAnalyzerHold    = 16;    // frames to hold after signal stops
+  static constexpr uint16_t kSweepSettleUs   = 1500;  // µs RSSI settle after re-entering RX
   float   _peakFreq = 0;
   int     _peakRssi = -120;
   bool    _peakLive = false;
   uint8_t _holdCtr  = 0;
+
+  // Tune to `mhz`, force a fresh VCO calibration (SIDLE→SRX re-triggers FS_AUTOCAL
+  // at the new frequency) and return RSSI after the AGC has settled. Without this
+  // per-point recalibration a band sweep stays calibrated for whatever frequency
+  // was active when RX was entered — i.e. the configured Frequency — so it reads
+  // noise everywhere except near that frequency.
+  int   _tunedRssi(float mhz);
 
   float _scanForBestFreq(std::function<bool()> cancelCb);
   void  _initTx();


### PR DESCRIPTION
## Problem

The CC1101 is configured with `MCSM0 = 0x18` (FS_AUTOCAL = calibrate on `IDLE→RX`), so the VCO is only (re)calibrated on a `SIDLE→SRX` strobe. The band-sweep paths entered RX **once** and then retuned with bare `setMHZ()` in a loop, so the synth stayed calibrated for whatever frequency was active when RX was entered — i.e. the **configured Frequency**.

A sweep starting far from that frequency read the noise floor and detected nothing. Concretely: setting **Frequency = 800 MHz** broke **Detect Freq** for 433 MHz signals.

## Fix

Add `CC1101Util::_tunedRssi()` — retune, re-enter RX to re-trigger FS_AUTOCAL at that point, settle (`kSweepSettleUs`), then read RSSI. Use it in:

- **Detect Freq** (`analyzeStep()`) — both coarse and fine stages
- **Lua `subghz` scan API** (`stepScan()`)

**Waterfall:** `beginRssiSweep()` now takes the calibration frequency and the caller passes the swept band's **midpoint**, so the spectrogram is calibrated for the band on screen rather than the configured Frequency (one calibration at sweep start — no per-pixel cost).

**Unaffected:** Receive, Record RAW and Send operate on a single frequency and calibrate correctly on entry.

## Testing

- Builds clean for `m5_cardputer_adv`.
- Flashed to M5 Cardputer ADV.
- Verified Detect Freq locks onto a 433.92 MHz remote with **Frequency = 800** (previously: noise only), and gives identical results at Frequency 433.92 / 868.

