### PR TITLE
perf: IR — speed up TV-B-Gone sweep (~25%)

### DIFF
--- a/firmware/src/utils/ir/IRUtil.cpp
+++ b/firmware/src/utils/ir/IRUtil.cpp
@@ -353,7 +353,10 @@ void IRUtil::startTvBGone(uint8_t region, void (*progressCb)(uint8_t, uint8_t),
       progressCb(i + 1, numCodes);
     }
 
-    delay(200);
+    // Gap between codes: long enough for a TV's IR receiver to register each
+    // burst, short enough to keep the full sweep brisk (~25% faster than the
+    // original 200 ms). Below ~100 ms some slow receivers start missing codes.
+    delay(130);
   }
 
   if (progressCb) progressCb(numCodes, numCodes);


### PR DESCRIPTION
## perf: IR — speed up TV-B-Gone sweep (~25%)

### What
Shortens the fixed inter-code gap in the TV-B-Gone sweep from **200 ms to 130 ms**.

### Why
Between every transmitted IR code the routine waited a fixed 200 ms. With ~139 codes per region this dominated the total run time. Cutting the gap to 130 ms trims roughly **10 seconds off a full regional sweep** while staying comfortably above the ~100 ms floor where slower TV IR receivers begin to miss codes.

### How
- `IRUtil::startTvBGone()` — single-line change to the inter-code `delay()`, with a comment documenting the 100 ms floor so the value isn't "optimized" below it later.
- No change to code data, ordering, region handling, or the progress callback — only the pacing between bursts.

### Impact / risk
- **Low.** Timing-only change on the transmit path; no API or data-format changes.
- Trade-off: marginally less settle time per code. 130 ms keeps a healthy margin over the observed reliability floor; if any specific TV proves flaky the constant is trivial to bump.

### Files
- `firmware/src/utils/ir/IRUtil.cpp` (+4 / -1)

### Testing
- Built and flashed on M5 Cardputer ADV; full sweep completes noticeably faster with TVs still responding.
