### PR TITLE
fix: progress bars now always complete to 100%

### DIFF
--- a/firmware/src/screens/module/IRScreen.cpp
+++ b/firmware/src/screens/module/IRScreen.cpp
@@ -202,6 +202,7 @@ void IRScreen::onItemSelected(uint8_t index) {
         _ir.startTvBGone(region, _tvbProgressCb, _tvbCancelCb);
 
         _ir.end();
+        ProgressView::finish();
         _activeInstance = nullptr;
 
         if (_tvbCancelled) {

--- a/firmware/src/screens/module/MFRC522Screen.cpp
+++ b/firmware/src/screens/module/MFRC522Screen.cpp
@@ -212,6 +212,7 @@ void MFRC522Screen::_initModule() {
   _moduleReady = true;
   delay(200);
 
+  ProgressView::finish();
   _goMainMenu();
 }
 
@@ -624,6 +625,7 @@ void MFRC522Screen::_callMemoryReader() {
     _rowCount++;
   }
 
+  ProgressView::finish();
   _scrollView.setRows(_rows, _rowCount);
   int nd = Achievement.inc("nfc_dump_memory");
   if (nd == 1) Achievement.unlock("nfc_dump_memory");
@@ -784,6 +786,7 @@ void MFRC522Screen::_callDictAttackWithFile(uint8_t fileIndex) {
     }
   }
 
+  ProgressView::finish();
   if (recovered > 0) {
     int n = Achievement.inc("nfc_dict_attack");
     if (n == 1) Achievement.unlock("nfc_dict_attack");
@@ -1133,6 +1136,7 @@ void MFRC522Screen::_callDarksideAttack() {
     });
 
   _module->PCD_Init();
+  ProgressView::finish();
 
   if (result.success) {
     uint8_t kb[6];

--- a/firmware/src/screens/module/NRF24Screen.cpp
+++ b/firmware/src/screens/module/NRF24Screen.cpp
@@ -119,6 +119,7 @@ void NRF24Screen::onInit() {
     return;
   }
   _radioEnd();
+  ProgressView::finish();
 
   _specScanCh = 0;
   _showMenu();

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -248,6 +248,7 @@ bool PN532I2cScreen::_initModule() {
       _fwSup =  fw        & 0xFF;
       _wire    = Uni.ExI2C;
       _busName = "ExI2C";
+      ProgressView::finish();
       _ready   = true;
       int n = Achievement.inc("pn532_i2c_first_use");
       if (n == 1) Achievement.unlock("pn532_i2c_first_use");
@@ -270,6 +271,7 @@ bool PN532I2cScreen::_initModule() {
       _fwSup =  fw        & 0xFF;
       _wire    = Uni.InI2C;
       _busName = "InI2C";
+      ProgressView::finish();
       _ready   = true;
       int n = Achievement.inc("pn532_i2c_first_use");
       if (n == 1) Achievement.unlock("pn532_i2c_first_use");
@@ -508,6 +510,7 @@ void PN532I2cScreen::_doAuthenticate() {
     }
   }
 
+  ProgressView::finish();
   _goMifare();
 }
 
@@ -583,6 +586,7 @@ void PN532I2cScreen::_doDumpMemory() {
   int n = Achievement.inc("nfc_dump_memory");
   if (n == 1) Achievement.unlock("nfc_dump_memory");
 
+  ProgressView::finish();
   _scrollView.setRows(_rows, _rowCount);
   render();
 }
@@ -691,6 +695,7 @@ void PN532I2cScreen::_doDictionaryAttackWithFile(uint8_t fileIndex) {
     }
   }
 
+  ProgressView::finish();
   if (recovered > 0) {
     int n = Achievement.inc("nfc_dict_attack");
     if (n == 1) Achievement.unlock("nfc_dict_attack");
@@ -728,6 +733,7 @@ void PN532I2cScreen::_doUltralightDump() {
     if (!_nfc->mifareultralight_ReadPage(page, data)) break;
     _pushRow("P" + String(page), _hexBlock(data, 4));
   }
+  ProgressView::finish();
   _scrollView.setRows(_rows, _rowCount);
   render();
 }

--- a/firmware/src/screens/module/PN532UartScreen.cpp
+++ b/firmware/src/screens/module/PN532UartScreen.cpp
@@ -214,6 +214,7 @@ bool PN532UartScreen::_initModule() {
   _isKiller = _pn->isPN532Killer(killer);
   _killerCode = killer;
 
+  ProgressView::finish();
   _ready = true;
   int n = Achievement.inc("pn532_first_use");
   if (n == 1) Achievement.unlock("pn532_first_use");
@@ -507,6 +508,7 @@ void PN532UartScreen::_doAuthenticate() {
     }
   }
 
+  ProgressView::finish();
   _goMifare();
 }
 
@@ -574,6 +576,7 @@ void PN532UartScreen::_doDumpMemory() {
     if (blk < 64) memcpy(&_dumpImg[blk * 16], data, 16);
   }
 
+  ProgressView::finish();
   char summary[32];
   snprintf(summary, sizeof(summary), "%d/%d blocks", readCount, (int)totalBlocks);
   _pushRow("Read", summary);
@@ -692,6 +695,7 @@ void PN532UartScreen::_doDictionaryAttackWithFile(uint8_t fileIndex) {
     }
   }
 
+  ProgressView::finish();
   if (recovered > 0) {
     int n = Achievement.inc("nfc_dict_attack");
     if (n == 1) Achievement.unlock("nfc_dict_attack");
@@ -732,6 +736,7 @@ void PN532UartScreen::_doUltralightDump() {
       _pushRow(label, _hexBlock(&data[i * 4], 4));
     }
   }
+  ProgressView::finish();
   _scrollView.setRows(_rows, _rowCount);
   render();
 }
@@ -928,6 +933,7 @@ void PN532UartScreen::_doEmulate() {
     return;
   }
 
+  ProgressView::finish();
   int n = Achievement.inc("pn532_emulate");
   if (n == 1) Achievement.unlock("pn532_emulate");
 
@@ -997,6 +1003,7 @@ void PN532UartScreen::_doLoadAndEmulate(uint8_t fileIndex) {
   bool modeOk = _pn->killerSetWorkMode(PN532::KILLER_EMULATOR, PN532::KILLER_MFC1K, 0);
   if (!modeOk) { ShowStatusAction::show("Mode switch failed"); _goMain(); return; }
 
+  ProgressView::finish();
   int n = Achievement.inc("pn532_emulate");
   if (n == 1) Achievement.unlock("pn532_emulate");
 

--- a/firmware/src/screens/module/RfCaptureScreen.cpp
+++ b/firmware/src/screens/module/RfCaptureScreen.cpp
@@ -388,6 +388,7 @@ void RfCaptureScreen::_sendCapturedSignal(uint8_t index) {
   ProgressView::init();
   ProgressView::progress(("Replaying " + _capturedTimes[index]).c_str(), 50);
   _radioSendCaptured(_capturedSignals[index]);
+  ProgressView::finish();
   int n = Achievement.inc("rf_send_first");
   if (n == 1) Achievement.unlock("rf_send_first");
   ShowStatusAction::show("Replayed", 1000);
@@ -409,6 +410,7 @@ void RfCaptureScreen::_replayStepKeeloqSignal(uint8_t index) {
   snprintf(buf, sizeof(buf), "Replay %s cnt=%u", sig.mf_name.c_str(), sig.cnt);
   ProgressView::progress(buf, 50);
   _radioSendCaptured(sig);
+  ProgressView::finish();
   _rebuildCapturedItems();
 
   int nk = Achievement.inc("rf_keeloq_step_replay");
@@ -539,6 +541,7 @@ void RfCaptureScreen::_sendBrowseFile(uint8_t index) {
     render();
     return;
   }
+  ProgressView::finish();
   int n = Achievement.inc("rf_send_first");
   if (n == 1) Achievement.unlock("rf_send_first");
   ShowStatusAction::show(("Sent: " + e.name).c_str(), 1000);

--- a/firmware/src/screens/module/SubGHzScreen.cpp
+++ b/firmware/src/screens/module/SubGHzScreen.cpp
@@ -39,6 +39,7 @@ void SubGHzScreen::onInit() {
     return;
   }
   _rf.end();
+  ProgressView::finish();
 
   _showMenu();
 }
@@ -422,6 +423,7 @@ void SubGHzScreen::_recordRawFinish() {
       ProgressView::progress("Replaying RAW", 50);
       if (!_rf.begin(Uni.Spi, _csPin, _gdo0Pin)) { ShowStatusAction::show("CC1101 not found"); continue; }
       _rf.sendSignal(_capturedSignals[0]);
+      ProgressView::finish();
       int n = Achievement.inc("rf_send_first");
       if (n == 1) Achievement.unlock("rf_send_first");
       ShowStatusAction::show("Replayed", 1000);

--- a/firmware/src/screens/wifi/network/CctvSnifferScreen.cpp
+++ b/firmware/src/screens/wifi/network/CctvSnifferScreen.cpp
@@ -252,6 +252,7 @@ void CctvSnifferScreen::_scanLAN()
     [](uint8_t pct) { ProgressView::progress("Ping scanning...", pct * 40 / 100); });
 
   if (hostCount == 0) {
+    ProgressView::finish();
     _log.addLine("[!] No hosts found");
     return;
   }
@@ -269,6 +270,7 @@ void CctvSnifferScreen::_scanLAN()
     ProgressView::progress("Scanning...", 40 + i * 60 / hostCount);
   }
 
+  ProgressView::finish();
   snprintf(buf, sizeof(buf), "[*] %d host(s) on network", hostCount);
   _log.addLine(buf);
 }

--- a/firmware/src/screens/wifi/network/DownloadScreen.cpp
+++ b/firmware/src/screens/wifi/network/DownloadScreen.cpp
@@ -297,6 +297,7 @@ void DownloadScreen::_downloadSampleData() {
     }
   }
 
+  ProgressView::finish();
   if (downloaded > 0) {
     int nd = Achievement.inc("wifi_download_first");
     if (nd == 1)  Achievement.unlock("wifi_download_first");
@@ -365,6 +366,7 @@ void DownloadScreen::_showIRCategories() {
     return;
   }
 
+  ProgressView::finish();
   _state = STATE_IR_CATEGORIES;
   strcpy(_titleBuf, "Infrared Files");
   setItems(_catItems, _catCount);
@@ -454,6 +456,7 @@ void DownloadScreen::_downloadIRCategory(uint8_t index) {
     }
   }
 
+  ProgressView::finish();
   if (downloaded > 0) {
     int nir = Achievement.inc("wifi_download_ir");
     if (nir == 1) Achievement.unlock("wifi_download_ir");
@@ -538,6 +541,7 @@ void DownloadScreen::_showBadUSBOS() {
     _badusbAllFolders[_badusbAllCount++] = line;
   }
 
+  ProgressView::finish();
   _showBadUSBOSFromCache();
 }
 
@@ -687,6 +691,7 @@ void DownloadScreen::_downloadBadUSBCategory(uint8_t index) {
     }
   }
 
+  ProgressView::finish();
   if (downloaded > 0) {
     int n = Achievement.inc("wifi_download_badusb");
     if (n == 1) Achievement.unlock("wifi_download_badusb");

--- a/firmware/src/screens/wifi/network/IPScannerScreen.cpp
+++ b/firmware/src/screens/wifi/network/IPScannerScreen.cpp
@@ -94,6 +94,7 @@ void IPScannerScreen::_scanIP() {
     _foundIPs, MAX_FOUND, true,
     [](uint8_t pct) { ProgressView::progress("IP scanning...", pct); }
   );
+  ProgressView::finish();
 
   if (_foundCount == 0) {
     _foundItems[0] = {"No devices found"};
@@ -123,6 +124,7 @@ void IPScannerScreen::_scanPort(const char* ip) {
 
   ProgressView::init();
   _openCount = PortScanUtil::scan(ip, _openPorts, PortScanUtil::MAX_RESULTS);
+  ProgressView::finish();
 
   if (_openCount == 0) {
     _openItems[0] = {"No ports open"};

--- a/firmware/src/screens/wifi/network/PortScannerScreen.cpp
+++ b/firmware/src/screens/wifi/network/PortScannerScreen.cpp
@@ -68,6 +68,7 @@ void PortScannerScreen::_scan() {
 
   ProgressView::init();
   _resultCount = PortScanUtil::scan(_targetIp.c_str(), _results, PortScanUtil::MAX_RESULTS);
+  ProgressView::finish();
 
   if (_resultCount == 0) {
     _resultItems[0] = {"No ports open"};

--- a/firmware/src/ui/views/ProgressView.h
+++ b/firmware/src/ui/views/ProgressView.h
@@ -159,10 +159,22 @@ private:
     if (!_chromeDrawn) return;
     auto& lcd = Uni.Lcd;
     int innerW = _barW - 2;
+    // Sweep the remaining fill up to 100% in a few short steps so the bar is
+    // always seen completing, even when the caller immediately redraws the body
+    // (menu, status overlay) right after the operation finishes.
     if (_lastFillW < innerW) {
-      lcd.fillRect(_barX + 1 + _lastFillW, _barY + 1, innerW - _lastFillW, BAR_H - 2, _barColor);
-      _lastFillW = innerW;
+      const int steps = 6;
+      int start = _lastFillW;
+      for (int s = 1; s <= steps; s++) {
+        int target = start + (innerW - start) * s / steps;
+        if (target > _lastFillW) {
+          lcd.fillRect(_barX + 1 + _lastFillW, _barY + 1, target - _lastFillW, BAR_H - 2, _barColor);
+          _lastFillW = target;
+        }
+        delay(18);
+      }
     }
+    _lastFillW = innerW;
     _chromeDrawn = false;
   }
 };

--- a/firmware/src/utils/gps/WigleUtil.cpp
+++ b/firmware/src/utils/gps/WigleUtil.cpp
@@ -126,6 +126,7 @@ uint8_t WigleUtil::fetchStats(ScrollListView::Row* rows, uint8_t maxRows) {
   if (r < maxRows) rows[r++] = {"First Upload",   jsonVal(statsBody, "first")};
   if (r < maxRows) rows[r++] = {"Last Upload",    jsonVal(statsBody, "last")};
 
+  ProgressView::finish();
   return r;
 }
 
@@ -241,6 +242,7 @@ bool WigleUtil::uploadFile(IStorage* storage, const String& fileName) {
     if (n > 0) { tmp[n] = '\0'; response += tmp; }
   }
   client.stop();
+  ProgressView::finish();
 
   if (response.indexOf("\"success\":true") >= 0 || response.indexOf("200") >= 0) {
     // Mark as uploaded by renaming


### PR DESCRIPTION
## fix: progress bars now always complete to 100%

### Problem
Most long-running operations set the progress bar to a fixed fraction (30 % / 50 % / 70 %) and then moved on **without ever completing it**. The bar visually froze "half-loaded", making finished operations look stuck or failed.

### Fix
`ProgressView::_finish()` now **sweeps the remaining fill up to 100 % in short animated steps** (6 steps, ~18 ms each) instead of a single jump. The animation is visible even when the caller redraws the screen body (menu / status overlay) immediately after the operation ends, so the user always sees the bar complete before it disappears.

Every bar-using operation now explicitly calls `finish()` at completion:
- **NFC (MFRC522 / PN532 I2C / PN532 UART):** detect, dump, dictionary attack, darkside
- **Sub-GHz & RF replay:** `SubGHzScreen`, `RfCaptureScreen`
- **NRF24 & IR detect**
- **TV-B-Gone**
- **Network:** CCTV sniffer, HTTP download, IP scanner, port scanner
- **GPS / Wigle** upload

### How
- `ProgressView.h` — `_finish()` reworked from a one-shot `fillRect` to a stepped sweep to `innerW`, then resets state.
- Call sites across the module / network / GPS screens add the missing `finish()` call at the success path.

### Impact / risk
- **Low, UX-only.** No behavioral change to the underlying operations; purely completes and tears down the progress indicator correctly.
- Adds ~108 ms of animation at the very end of an operation (6 × 18 ms) — negligible next to the operations themselves.

### Files (13)
- `firmware/src/ui/views/ProgressView.h` (core change)
- Module screens: `IRScreen.cpp`, `MFRC522Screen.cpp`, `NRF24Screen.cpp`, `PN532I2cScreen.cpp`, `PN532UartScreen.cpp`, `RfCaptureScreen.cpp`, `SubGHzScreen.cpp`
- Network screens: `CctvSnifferScreen.cpp`, `DownloadScreen.cpp`, `IPScannerScreen.cpp`, `PortScannerScreen.cpp`
- `utils/gps/WigleUtil.cpp`

### Testing
- Built and flashed on M5 Cardputer ADV; bars now animate to 100 % and clear cleanly across the listed operations.
