### PR TITLE
feat: File Manager — Send .ir & Replay .sub on long-press

### DIFF
--- a/firmware/src/screens/module/IRScreen.cpp
+++ b/firmware/src/screens/module/IRScreen.cpp
@@ -33,7 +33,39 @@ IRScreen* IRScreen::_activeInstance = nullptr;
 void IRScreen::onInit() {
   _txPin = (int8_t)PinConfig.getInt(PIN_CONFIG_IR_TX, PIN_CONFIG_IR_TX_DEFAULT);
   _rxPin = (int8_t)PinConfig.getInt(PIN_CONFIG_IR_RX, PIN_CONFIG_IR_RX_DEFAULT);
+  if (_pendingSendFile.length() > 0) {
+    _openPendingSendFile();
+    return;
+  }
   _showMenu();
+}
+
+// Launched from the File Manager: skip the menu and open the Send signal-list
+// for a specific .ir file, ready to fire each command.
+void IRScreen::_openPendingSendFile() {
+  String file = _pendingSendFile;
+  _pendingSendFile = "";
+
+  if (_txPin < 0) {
+    ShowStatusAction::show("Set TX pin first");
+    Screen.goBack();
+    return;
+  }
+  #if defined(DEVICE_M5STICK_S3)
+  if (_txPin == IR_TX_PIN) Uni.Power.setExtOutput(true);
+  _irAmpEnable(true);
+  #endif
+  _ir.beginTx(_txPin);
+
+  // Parent folder so BACK from the send-list returns to a browse of that dir.
+  int slash = file.lastIndexOf('/');
+  _browsePath = (slash > 0) ? file.substring(0, slash) : String(kRootPath);
+
+  _loadAndShowSignals(file);
+  if (_state != STATE_SEND_LIST) {   // read/parse failed — bounce back
+    _ir.end();
+    Screen.goBack();
+  }
 }
 
 void IRScreen::_showMenu() {

--- a/firmware/src/screens/module/IRScreen.h
+++ b/firmware/src/screens/module/IRScreen.h
@@ -11,6 +11,11 @@
 class IRScreen : public ListScreen
 {
 public:
+  IRScreen() = default;
+  // Open straight into the Send signal-list for a specific .ir file (used by the
+  // File Manager "Send" action on a long-pressed .ir file).
+  explicit IRScreen(const String& sendFile) : _pendingSendFile(sendFile) {}
+
   const char* title() override { return _titleBuf; }
 
   void onInit() override;
@@ -69,6 +74,8 @@ private:
   String _sendFilePath;
   bool _sendDirty = false;
   bool _holdFired = false;
+  String _pendingSendFile;  // set via ctor: jump into Send list for this file
+  void _openPendingSendFile();
   void _loadAndShowSignals(const String& filePath);
   void _refreshSendList();
   void _onSendItemAction(uint8_t index);

--- a/firmware/src/screens/module/SubGHzScreen.cpp
+++ b/firmware/src/screens/module/SubGHzScreen.cpp
@@ -40,7 +40,43 @@ void SubGHzScreen::onInit() {
   }
   _rf.end();
 
+  if (_pendingReplayFile.length() > 0) {
+    _replayPendingFile();
+    return;
+  }
+
   _showMenu();
+}
+
+// Launched from the File Manager: transmit a specific .sub file once, then pop
+// back to the caller. Radio presence was already verified in onInit().
+void SubGHzScreen::_replayPendingFile() {
+  String file = _pendingReplayFile;
+  _pendingReplayFile = "";
+
+  String content = Uni.Storage ? Uni.Storage->readFile(file.c_str()) : String();
+  Signal sig;
+  if (content.length() == 0 || !CC1101Util::loadFile(content, sig)) {
+    ShowStatusAction::show("Invalid .sub file");
+    Screen.goBack();
+    return;
+  }
+
+  int slash = file.lastIndexOf('/');
+  String name = (slash >= 0) ? file.substring(slash + 1) : file;
+
+  ProgressView::init();
+  ProgressView::progress(("Replaying " + name).c_str(), 50);
+  if (!_radioSendFromBrowse(sig)) {
+    ShowStatusAction::show("Send failed");
+    Screen.goBack();
+    return;
+  }
+  ProgressView::finish();
+  int n = Achievement.inc("rf_send_first");
+  if (n == 1) Achievement.unlock("rf_send_first");
+  ShowStatusAction::show(("Sent: " + name).c_str(), 1200);
+  Screen.goBack();
 }
 
 // ── Radio adapter (chip lifecycle gated per operation) ──────────────────────

--- a/firmware/src/screens/module/SubGHzScreen.h
+++ b/firmware/src/screens/module/SubGHzScreen.h
@@ -11,6 +11,11 @@
 
 class SubGHzScreen : public RfCaptureScreen {
 public:
+  SubGHzScreen() = default;
+  // Transmit a specific .sub file immediately on entry, then return (used by the
+  // File Manager "Replay" action on a long-pressed .sub file).
+  explicit SubGHzScreen(const String& replayFile) : _pendingReplayFile(replayFile) {}
+
   void onInit() override;
 
 protected:
@@ -52,6 +57,8 @@ private:
   int8_t _csPin   = -1;
   int8_t _gdo0Pin = -1;
   bool   _rfDetectFired = false;  // achievement guard, resets each scan session
+  String _pendingReplayFile;      // set via ctor: transmit this .sub then goBack
+  void _replayPendingFile();
 
   // Menu (8 items: Frequency | Detect Freq | Waterfall | Receive | Record RAW |
   //                Send | Jammer | Mfcodes)

--- a/firmware/src/screens/utility/FileManagerScreen.cpp
+++ b/firmware/src/screens/utility/FileManagerScreen.cpp
@@ -5,6 +5,8 @@
 #include "screens/utility/UtilityMenuScreen.h"
 #include "screens/utility/FileViewerScreen.h"
 #include "screens/utility/FileHexViewerScreen.h"
+#include "screens/module/IRScreen.h"
+#include "screens/module/SubGHzScreen.h"
 #include "ui/actions/InputTextAction.h"
 #include "ui/actions/ShowStatusAction.h"
 
@@ -118,6 +120,14 @@ void FileManagerScreen::_openMenu(uint8_t fileIdx)
   };
 
   if (isFile) {
+    // Protocol files get a transmit shortcut at the top of the menu.
+    String name = _browser.entry(fileIdx).name;
+    name.toLowerCase();
+    if (name.endsWith(".ir")) {
+      addMenu(ACT_IR_SEND, "Send", "Infrared");
+    } else if (name.endsWith(".sub")) {
+      addMenu(ACT_SUB_REPLAY, "Replay", "Sub-GHz");
+    }
     addMenu(ACT_VIEW, "View");
     addMenu(ACT_VIEW_HEX, "View HEX");
   }
@@ -179,6 +189,14 @@ void FileManagerScreen::_handleMenuAction(uint8_t index)
 
     case ACT_VIEW_HEX:
       Screen.push(new FileHexViewerScreen(targetPath));
+      return;
+
+    case ACT_IR_SEND:
+      Screen.push(new IRScreen(targetPath));
+      return;
+
+    case ACT_SUB_REPLAY:
+      Screen.push(new SubGHzScreen(targetPath));
       return;
 
     case ACT_NEW_FOLDER: {

--- a/firmware/src/screens/utility/FileManagerScreen.h
+++ b/firmware/src/screens/utility/FileManagerScreen.h
@@ -20,11 +20,12 @@ private:
   enum State { STATE_FILE, STATE_MENU } _state = STATE_FILE;
 
   enum MenuAction {
-    ACT_VIEW, ACT_VIEW_HEX, ACT_NEW_FOLDER, ACT_RENAME, ACT_DELETE,
+    ACT_VIEW, ACT_VIEW_HEX, ACT_IR_SEND, ACT_SUB_REPLAY,
+    ACT_NEW_FOLDER, ACT_RENAME, ACT_DELETE,
     ACT_COPY, ACT_CUT, ACT_PASTE, ACT_CANCEL_CLIP, ACT_CLOSE_MENU, ACT_EXIT,
   };
 
-  static constexpr uint8_t kMaxMenu      = 11;
+  static constexpr uint8_t kMaxMenu      = 13;
   static constexpr uint8_t kMaxPathDepth = 8;
 
   // File browser


### PR DESCRIPTION
## feat: File Manager — Send `.ir` & Replay `.sub` on long-press

### What
Long-pressing a file in the **File Manager** now offers a transmit shortcut based on the file's extension, so IR and Sub-GHz captures can be fired directly from the file browser without manually re-entering the module and re-selecting the file:

- **`.ir` → "Send"** — opens the IR sender preloaded with the file's command list, ready to fire each command.
- **`.sub` → "Replay"** — transmits the Sub-GHz signal once, then returns to the File Manager.

### How
- New **preloaded-file constructors** on `IRScreen` and `SubGHzScreen` accept a path and jump straight into the existing transmit flow.
- Both paths **reuse the existing `IRScreen` / `SubGHzScreen` transmit code**, so pin configuration checks, hardware detection, and per-board quirks are handled by the module screens themselves — no duplicated RF/IR logic in the File Manager.
- `FileManagerScreen` inspects the extension on long-press and adds the matching context action; unrelated file types are unaffected.

### Impact / risk
- **Additive.** New long-press actions only; existing File Manager navigation and the module screens' normal entry points are unchanged.
- Transmit still goes through the module screens' safety/pin checks, so behavior matches launching a send from the module directly.

### Files (6)
- `firmware/src/screens/utility/FileManagerScreen.cpp` / `.h` — long-press extension routing
- `firmware/src/screens/module/IRScreen.cpp` / `.h` — preloaded-file "Send" constructor
- `firmware/src/screens/module/SubGHzScreen.cpp` / `.h` — preloaded-file "Replay" constructor

### Testing
- Built and flashed on M5 Cardputer ADV; long-press on `.ir` sends the stored commands and long-press on `.sub` replays the capture.
