### PR TITLE
mascot: redesign Robot head + remove home-screen UP/DOWN preview

### DIFF
--- a/firmware/src/screens/CharacterScreen.cpp
+++ b/firmware/src/screens/CharacterScreen.cpp
@@ -199,17 +199,6 @@ void CharacterScreen::onUpdate()
       _enterMainMenu();
       return;
     }
-    // ── debug preview: cycle mascot / level without touching saved state ──
-    if (dir == INavigation::DIR_UP) {
-      _dbgMascot = (int8_t)((_dbgMascot + 1) % Mascot::count());
-      // The head size can change between mascots, which moves the bubble — full
-      // repaint so the bubble reflows and any old frame is cleared.
-      _firstRender = true;
-      _dirtyMask   = 0xFF;
-    } else if (dir == INavigation::DIR_DOWN) {
-      _dbgRank = (int8_t)((_dbgRank + 1) % 5);
-      _dirtyMask |= DIRTY_HEAD | DIRTY_TOP;   // rank changes colours, not size
-    }
   }
 
   unsigned long now = millis();
@@ -300,8 +289,7 @@ void CharacterScreen::onRender()
   const int halfW = (W - PAD * 2 - gap) / 2;
 
   // Mascot head art is configurable (see utils/Mascot.h); hacker is the default.
-  // _dbgMascot (UP key) forces a mascot for preview without changing config.
-  const Mascot& mascot = _dbgMascot >= 0 ? Mascot::at((uint8_t)_dbgMascot) : Mascot::current();
+  const Mascot& mascot = Mascot::current();
   const int headW = mascot.w * ps;
   const int headH = mascot.h * ps;
   const int headX = PAD + scale * 4;
@@ -328,8 +316,7 @@ void CharacterScreen::onRender()
 
   // ── data ─────────────────────────────────────────────────────────────
   int      exp      = Achievement.getExp();
-  // _dbgRank (DOWN key) forces a level for preview without changing exp.
-  RankInfo ri       = _dbgRank >= 0 ? hackerRankByIndex(_dbgRank) : hackerGetRank(exp);
+  RankInfo ri       = hackerGetRank(exp);
   int      hp       = _clampPct(Uni.Power.getBatteryPercentage());
   bool     chg      = Uni.Power.isCharging();
   if (hp == 0 && !chg) hp = 100;

--- a/firmware/src/screens/CharacterScreen.h
+++ b/firmware/src/screens/CharacterScreen.h
@@ -48,10 +48,5 @@ public:
   bool          _firstRender = true;
   uint8_t       _dirtyMask   = 0xFF;
 
-  // debug preview (home screen): UP cycles mascot, DOWN cycles level.
-  // -1 = follow the real config / exp; >=0 = forced override for previewing.
-  int8_t        _dbgMascot   = -1;
-  int8_t        _dbgRank     = -1;
-
   void _enterMainMenu();
 };

--- a/firmware/src/utils/RobotHead.h
+++ b/firmware/src/utils/RobotHead.h
@@ -2,51 +2,57 @@
 #include <Arduino.h>
 
 // ── RobotHead ────────────────────────────────────────────────────────────────
-// Pixel-art robot mascot — a boxy head with an antenna, grille mouth and square
-// eyes. Drawn on the SAME 12×14 art-pixel grid as HackerHead.h, and filling that
-// grid the same way the hacker hood does, so every mascot is the same on-screen
-// size. Single-colour silhouette: the body colour is supplied at draw time
-// (Mascot.h feeds it the theme colour). Eyes are drawn on top of the base art so
-// they can blink and take the rank accent colour.
+// Pixel-art robot mascot — a boxy gray head with two square ears, side bolts and
+// a friendly white smile, recreated from the reference art (Downloads/robot.png)
+// on a 15×14-cell art grid sized to match the other mascots on screen. The body
+// colour is supplied at draw time (Mascot.h feeds it the theme colour); the
+// ears/bolts are a fixed dark charcoal and the mouth is white. The eyes are drawn
+// on top of the base art so they can blink and take the rank accent colour,
+// exactly like the other mascots.
 
-static constexpr int ROBOT_W = 12;
+static constexpr int ROBOT_W = 15;
 static constexpr int ROBOT_H = 14;
 
-// '.' transparent · 'K' black outline / grille · 'B' body (theme-coloured).
+// '.' transparent · 'D' dark charcoal (ears / side bolts) · 'B' body
+// (theme-coloured) · 'W' white mouth. Eyes are painted on top of the 'B' cells.
 static const char* const ROBOT_ART[ROBOT_H] = {
-  ".....KK.....",   // antenna bulb
-  "KKKKKKKKKKKK",   // head top (full width)
-  "KBBBBBBBBBBK",
-  "KBBBBBBBBBBK",
-  "KBBBBBBBBBBK",   // eyes row (drawn on top)
-  "KBBBBBBBBBBK",
-  "KBBBBBBBBBBK",
-  "KBBBBBBBBBBK",
-  "KBBBKKKKBBBK",   // grille mouth
-  "KBBBBBBBBBBK",
-  "KBBBBBBBBBBK",
-  "KBBBBBBBBBBK",
-  "KKKKKKKKKKKK",   // head bottom (full width)
-  "..KK....KK..",   // feet
+  "...............",
+  "...DDD...DDD...",   // ears
+  "...DDD...DDD...",
+  "...DDD...DDD...",
+  "..BBBBBBBBBBB..",   // forehead
+  "..BBBBBBBBBBB..",   // eyes row (drawn on top)
+  "..BBBBBBBBBBB..",
+  "DDBBBBBBBBBBBDD",   // eyes row + side bolts
+  "DDBBBBBBBBBBBDD",   // side bolts
+  "..BBBBBBBBBBB..",
+  "..BWBBBBBBBWB..",   // smile corners
+  "..BBWWWWWWWBB..",   // smile
+  "..BBBBBBBBBBB..",   // chin
+  "...............",
 };
 
-static constexpr uint16_t ROBOT_K = 0x0000;   // black outline / grille
+static constexpr uint16_t ROBOT_DARK  = 0x4A49;   // dark charcoal ears / bolts
+static constexpr uint16_t ROBOT_MOUTH = 0xFFFF;   // white smile
+
+// Eyes: two 2×3 vertical bars (columns 4–5 and 9–10, rows 5–7). Drawn on top of
+// the body so they can blink and take the rank accent colour.
+static constexpr int ROBOT_EYE_COLS[4] = { 4, 5, 9, 10 };
 
 template<typename T>
 void robotDrawEyes(T& dc, int ox, int oy, int ps, bool blink, uint16_t body, uint16_t eye) {
   auto cell = [&](int cx, int cy, uint16_t c) { dc.fillRect(ox + cx * ps, oy + cy * ps, ps, ps, c); };
   // clear the eye cells back to the body colour first (so blink can toggle)
-  for (int y = 4; y <= 5; y++) for (int x = 2; x <= 9; x++) cell(x, y, body);
-  if (blink) {                          // squint — only the lower row
-    cell(2, 5, eye); cell(3, 5, eye); cell(8, 5, eye); cell(9, 5, eye);
-  } else {                              // wide open — 2×2 each
-    cell(2, 4, eye); cell(3, 4, eye); cell(2, 5, eye); cell(3, 5, eye);
-    cell(8, 4, eye); cell(9, 4, eye); cell(8, 5, eye); cell(9, 5, eye);
+  for (int c : ROBOT_EYE_COLS) for (int y = 5; y <= 7; y++) cell(c, y, body);
+  if (blink) {                          // squint — only the lower row of each eye
+    for (int c : ROBOT_EYE_COLS) cell(c, 7, eye);
+  } else {                              // wide open — full 2×3 bar each
+    for (int c : ROBOT_EYE_COLS) for (int y = 5; y <= 7; y++) cell(c, y, eye);
   }
 }
 
-// `accent` is the rank colour, used for the eyes + antenna bulb so the robot
-// "levels up" as the agent ranks.
+// `accent` is the rank colour, used for the eyes so the robot "levels up" as the
+// agent ranks (matches the other mascots).
 template<typename T>
 void robotDrawHead(T& dc, int ox, int oy, int ps, bool blink, uint16_t body, uint16_t accent) {
   auto cell = [&](int cx, int cy, uint16_t c) { dc.fillRect(ox + cx * ps, oy + cy * ps, ps, ps, c); };
@@ -54,13 +60,12 @@ void robotDrawHead(T& dc, int ox, int oy, int ps, bool blink, uint16_t body, uin
     const char* row = ROBOT_ART[y];
     for (int x = 0; x < ROBOT_W; x++) {
       switch (row[x]) {
-        case 'K': cell(x, y, ROBOT_K); break;
-        case 'B': cell(x, y, body);    break;
+        case 'D': cell(x, y, ROBOT_DARK);  break;
+        case 'B': cell(x, y, body);        break;
+        case 'W': cell(x, y, ROBOT_MOUTH); break;
         default: break;   // '.' transparent
       }
     }
   }
-  // antenna bulb glows the rank colour (status-LED style)
-  cell(5, 0, accent); cell(6, 0, accent);
   robotDrawEyes(dc, ox, oy, ps, blink, body, accent);
 }


### PR DESCRIPTION
## mascot: redesign the Robot head + drop the home-screen debug preview

Two related changes to the mascot / home screen.

### 1. Rebuild the Robot mascot from reference art
The Robot mascot previously rendered as a **plain filled block** — just the theme colour with no real features. This recreates it as a proper pixel-art robot, mapped from the reference art onto a **15×14 art grid** so it sits at the same on-screen size as the other mascots (Hacker is 12×14, Cat is 19×17).

Design:
- **Dark-charcoal ears** and **side bolts** (`0x4A49`)
- **White smile** (`0xFFFF`)
- **Body** stays theme-coloured, like the other single-colour mascots
- **Eyes** are two vertical bars drawn on top of the body

The **eyes take the rank accent colour** (black at NOVICE, then the rank colour) and **blink** on the same timer as the other mascots — so the Robot "levels up" and blinks exactly like Hacker and Cat. `Mascot.h` is untouched: the `robotDrawHead(dc, ox, oy, ps, blink, body, accent)` signature is preserved, so no registry/settings changes are needed.

### 2. Remove the UP/DOWN debug preview on the home screen
The Character (home) screen let **UP cycle the mascot** and **DOWN cycle the rank** as a live preview, overriding the real config/exp via `_dbgMascot` / `_dbgRank`. This was a debug affordance that shipped by accident. It's removed:
- UP/DOWN now do nothing on that screen
- The head always reflects the **configured mascot** and the **real rank/exp**
- PRESS/BACK still open the menu
- The unused `_dbgMascot` / `_dbgRank` members and their render-time overrides are deleted

### Impact / risk
- **Low, self-contained.** Touches only `RobotHead.h` and the Character screen; no changes to the mascot registry, settings, or other screens.

### Files
- `firmware/src/utils/RobotHead.h` — new robot art + eye drawing
- `firmware/src/screens/CharacterScreen.cpp` / `.h` — remove UP/DOWN preview + dead members

### Testing
- Built and flashed on **M5 Cardputer ADV**; Robot mascot renders with the new art, eyes recolour by rank and blink, and UP/DOWN no longer change mascot/rank on the home screen.
