### PR TITLE
SubGHz: migrate RF capture/replay to RMT + OOK sensitivity preset & RSSI menu

### DIFF
--- a/firmware/src/screens/module/RfCaptureScreen.cpp
+++ b/firmware/src/screens/module/RfCaptureScreen.cpp
@@ -520,14 +520,18 @@ void RfCaptureScreen::_loadBrowseDir(const String& path) {
 
 void RfCaptureScreen::_sendBrowseFile(uint8_t index) {
   const auto& e = _browser.entry(index);
-  String content = Uni.Storage->readFile(e.path.c_str());
-  if (content.length() == 0) {
+  // Stream the file (parse line-by-line) instead of slurping it into a String —
+  // long RAW captures are tens of KB and two full copies (content + rawData) OOM.
+  fs::File f = Uni.Storage->open(e.path.c_str(), "r");
+  if (!f) {
     ShowStatusAction::show("Failed to read file");
     render();
     return;
   }
   Signal sig;
-  if (!CC1101Util::loadFile(content, sig)) {
+  bool ok = CC1101Util::loadFromStream(f, sig, f.size());
+  f.close();
+  if (!ok) {
     ShowStatusAction::show("Invalid .sub file");
     render();
     return;
@@ -546,9 +550,11 @@ void RfCaptureScreen::_sendBrowseFile(uint8_t index) {
 }
 
 void RfCaptureScreen::_showBrowseFileInfo(uint8_t index) {
-  String content = Uni.Storage->readFile(_browser.entry(index).path.c_str());
+  fs::File f = Uni.Storage->open(_browser.entry(index).path.c_str(), "r");
   Signal sig;
-  if (!CC1101Util::loadFile(content, sig)) {
+  bool ok = f && CC1101Util::loadFromStream(f, sig, f.size());
+  if (f) f.close();
+  if (!ok) {
     ShowStatusAction::show("Invalid .sub file");
     render();
     return;

--- a/firmware/src/screens/module/SubGHzScreen.cpp
+++ b/firmware/src/screens/module/SubGHzScreen.cpp
@@ -91,8 +91,8 @@ void SubGHzScreen::_showMenu() {
 }
 
 void SubGHzScreen::_updateSublabels() {
-  char buf[12];
-  snprintf(buf, sizeof(buf), "%.2f MHz", _rf.getFrequency());
+  char buf[24];
+  snprintf(buf, sizeof(buf), "%.2f MHz / %d dBm", _rf.getFrequency(), _rf.getRssiThreshold());
   _freqSub = buf;
   _menuItems[0].sublabel = _freqSub.c_str();
 
@@ -194,13 +194,17 @@ void SubGHzScreen::_selectFrequency() {
     {"868 MHz",    "868"},
     {"915 MHz",    "915"},
     {"Custom",     "custom"},
+    {"RSSI Threshold", "rssi"},
   };
 
   char curBuf[12];
   snprintf(curBuf, sizeof(curBuf), "%.2f", _rf.getFrequency());
 
-  const char* choice = InputSelectAction::popup("Frequency", freqOpts, 9, curBuf);
+  const char* choice = InputSelectAction::popup("Frequency", freqOpts, 10, curBuf);
   if (!choice) { render(); return; }
+
+  // Carrier-detect sensitivity — governs Record RAW arming + Detect Freq trigger.
+  if (strcmp(choice, "rssi") == 0) { _selectRssiThreshold(); return; }
 
   float mhz;
   if (strcmp(choice, "custom") == 0) {
@@ -214,6 +218,32 @@ void SubGHzScreen::_selectFrequency() {
   if (!_rf.setFrequency(mhz)) {
     ShowStatusAction::show("Invalid frequency");
   }
+  _updateSublabels();
+  render();
+}
+
+// RSSI carrier-detect threshold. Lower (more negative) = more sensitive, so weak
+// / distant signals arm Record RAW and trip Detect Freq. Does not affect the
+// plain Receive path (which decodes whatever reaches GDO0). Mirrors Bruce's
+// scan sensitivity menu (rf_scan.cpp).
+void SubGHzScreen::_selectRssiThreshold() {
+  static constexpr InputSelectAction::Option rssiOpts[] = {
+    {"-55 dBm (closest)", "-55"},
+    {"-60 dBm",           "-60"},
+    {"-65 dBm (default)", "-65"},
+    {"-70 dBm",           "-70"},
+    {"-75 dBm",           "-75"},
+    {"-80 dBm",           "-80"},
+    {"-85 dBm (farthest)","-85"},
+  };
+
+  char curBuf[8];
+  snprintf(curBuf, sizeof(curBuf), "%d", _rf.getRssiThreshold());
+
+  const char* choice = InputSelectAction::popup("RSSI Threshold", rssiOpts, 7, curBuf);
+  if (!choice) { render(); return; }
+
+  _rf.setRssiThreshold(atoi(choice));
   _updateSublabels();
   render();
 }

--- a/firmware/src/screens/module/SubGHzScreen.h
+++ b/firmware/src/screens/module/SubGHzScreen.h
@@ -70,6 +70,7 @@ private:
   String _mfcodesSub;
   void _updateSublabels();
   void _selectFrequency();
+  void _selectRssiThreshold();
   void _startScan();
   void _reloadMfcodes();
 

--- a/firmware/src/utils/rf/CC1101Util.cpp
+++ b/firmware/src/utils/rf/CC1101Util.cpp
@@ -23,7 +23,6 @@ static const float kFreqList[] = {
   906.400f, 915.000f, 925.000f, 928.000f,
 };
 static constexpr uint8_t kFreqCount = sizeof(kFreqList) / sizeof(kFreqList[0]);
-static constexpr int kRssiThreshold = CC1101Util::RSSI_THRESHOLD;
 static constexpr uint8_t kScanHits   = 1;  // lock to first frequency with signal
 
 // ── RAW recorder accumulator ────────────────────────────────────────────────
@@ -64,9 +63,27 @@ bool CC1101Util::begin(ExtSpiClass* spi, int8_t csPin, int8_t gdo0Pin) {
   ELECHOUSE_cc1101.setModulation(2); // ASK/OOK
   ELECHOUSE_cc1101.setDRate(50);
   ELECHOUSE_cc1101.setPktFormat(3);  // async serial
+  _applyOokRxRegs();                 // OOK sensitivity regs — Init() reset them to FSK defaults
   setFrequency(_freq);
 
   return true;
+}
+
+// Sub-GHz OOK RX sensitivity registers, ported from Bruce's
+// cc1101ApplyFixedFreqOokPreset() (src/modules/rf/rf_utils.cpp). The ELECHOUSE
+// Init() defaults are tuned for FSK packet RX and cap the receiver gain
+// (AGCCTRL2=0xC7 disables the 3 highest DVGA gain steps) — that is why weak OOK
+// signals were only decoded with the transmitter right on the antenna. These
+// values free the full gain, enable ADC retention (better sensitivity at narrow
+// RxBW) and select the SmartRF OOK front-end. They must be (re)applied after
+// every ELECHOUSE Init(); setModulation/setRxBW/setDRate/setMHZ never touch them.
+void CC1101Util::_applyOokRxRegs() {
+  ELECHOUSE_cc1101.SpiWriteReg(CC1101_FIFOTHR,  0x47);  // ADC_RETENTION=1
+  ELECHOUSE_cc1101.SpiWriteReg(CC1101_FREND1,   0xB6);  // RX front-end (SmartRF OOK)
+  ELECHOUSE_cc1101.SpiWriteReg(CC1101_FOCCFG,   0x18);  // freq-offset compensation
+  ELECHOUSE_cc1101.SpiWriteReg(CC1101_AGCCTRL2, 0x03);  // full DVGA gain (was 0xC7)
+  ELECHOUSE_cc1101.SpiWriteReg(CC1101_AGCCTRL1, 0x00);
+  ELECHOUSE_cc1101.SpiWriteReg(CC1101_AGCCTRL0, 0x40);  // OOK/ASK decision boundary
 }
 
 void CC1101Util::end() {
@@ -118,7 +135,7 @@ float CC1101Util::_scanForBestFreq(std::function<bool()> cancelCb) {
     int rssi = ELECHOUSE_cc1101.getRssi();
     _scanRssi = rssi;
 
-    if (rssi > kRssiThreshold) {
+    if (rssi > _rssiThreshold) {
       hits[hitCount++] = {f, rssi};
     }
     idx++;
@@ -180,7 +197,7 @@ bool CC1101Util::pollReceive(Signal& out) {
   if (!_initialized) return false;
 
   const int  rssi    = ELECHOUSE_cc1101.getRssi();
-  const bool carrier = rssi > kRssiThreshold;
+  const bool carrier = rssi > _rssiThreshold;
   const uint32_t now = millis();
 
   // Gate: turn the receiver on only once a real carrier persists; while idle the
@@ -409,7 +426,7 @@ bool CC1101Util::stepScan() {
   _scanRssi = rssi;
   uint8_t slot = (_scanIdx - 1) % kFreqCount;
   _scanRssiMap[slot] = rssi;
-  return rssi > kRssiThreshold;
+  return rssi > _rssiThreshold;
 }
 
 uint8_t CC1101Util::getScanCount()           const { return kFreqCount; }
@@ -474,7 +491,7 @@ bool CC1101Util::analyzeStep() {
   // ── Stage 2: fine refine — ±0.3 MHz around the coarse peak in 20 kHz steps to
   // pin the exact carrier (a signal at e.g. 433.66, not on the coarse list, is
   // located here). Recalibrates per point via _tunedRssi() — just a denser sweep.
-  if (coarseRssi > kAnalyzerTrigger) {
+  if (coarseRssi > _rssiThreshold) {
     int   fineRssi = -127;
     float fineFreq = coarseFreq;
     for (float f = coarseFreq - 0.30f; f <= coarseFreq + 0.3001f; f += 0.02f) {
@@ -508,6 +525,13 @@ void CC1101Util::endAnalyze() {
 
 void CC1101Util::_initRx() {
   ELECHOUSE_cc1101.setModulation(2);
+  // Fixed-frequency RX (Receive + Record RAW): narrow the RxBW and drop the data
+  // rate from the 256 kHz / 50 kBaud scan defaults set in begin(). A tighter
+  // channel lowers the noise floor and ~5 kBaud matches typical OOK remote timing
+  // (TE ~300-500 us), both improving weak-signal sensitivity. begin() restores
+  // the wide scan profile on the next mode entry, so this only affects RX.
+  ELECHOUSE_cc1101.setRxBW(135);
+  ELECHOUSE_cc1101.setDRate(5);
   ELECHOUSE_cc1101.setPktFormat(3);
   ELECHOUSE_cc1101.SetRx();
   pinMode(_gdo0Pin, INPUT);

--- a/firmware/src/utils/rf/CC1101Util.cpp
+++ b/firmware/src/utils/rf/CC1101Util.cpp
@@ -142,7 +142,6 @@ bool CC1101Util::beginReceive() {
   _rxCapturing      = false;
   _rxCarrierSinceMs = 0;
   _rxLastCarrierMs  = 0;
-  _captureGate      = _measureNoiseGate();   // adaptive gate (distance-sensitive)
   // The RMT receiver is installed on demand in pollReceive() once a real carrier
   // appears (RSSI gating) and uninstalled when it drops — no noise capture.
   return true;
@@ -181,7 +180,7 @@ bool CC1101Util::pollReceive(Signal& out) {
   if (!_initialized) return false;
 
   const int  rssi    = ELECHOUSE_cc1101.getRssi();
-  const bool carrier = rssi > _captureGate;
+  const bool carrier = rssi > kRssiThreshold;
   const uint32_t now = millis();
 
   // Gate: turn the receiver on only once a real carrier persists; while idle the
@@ -271,7 +270,8 @@ bool CC1101Util::beginRawRecord() {
   _rawLastFrameMs    = 0;
   _rawCarrierSinceMs = 0;
   _rawLastCarrierMs  = 0;
-  _captureGate       = _measureNoiseGate();   // adaptive gate (distance-sensitive)
+  _rawFloor          = _measureNoiseFloor();   // seed the rolling gate
+  _captureGate       = _rawFloor + kCarrierMarginDb;
 
   // Note: the RMT receiver is NOT installed here. pollRawRecord() installs it only
   // once a real carrier appears (RSSI) and uninstalls it when the carrier drops —
@@ -297,15 +297,18 @@ void CC1101Util::pollRawRecord() {
 
   // ── Idle: wait for a real carrier before turning the receiver on. ──────────
   if (!_rawCapturing) {
-    if (carrier) {
+    // Adapt the gate to the noise floor every idle poll (up AND down — no latch).
+    _captureGate = _updateGate(_rawFloor, rssi);
+    if (rssi > _captureGate) {
       if (_rawCarrierSinceMs == 0) _rawCarrierSinceMs = now;
       if (now - _rawCarrierSinceMs >= kRawArmMs && s_rawCount < kRawRecMax) {
         _rawStarted = true;
         // Short idle so per-repeat frames complete and drain (no overflow).
         _rmt.beginRx((gpio_num_t)_gdo0Pin, kRawIdleUs);
-        _rawCapturing     = true;
-        _rawLastCarrierMs = now;
-        _rawLastFrameMs   = now;
+        _rawCapturing      = true;
+        _rawLastCarrierMs  = now;
+        _rawLastFrameMs    = now;
+        _rawCaptureStartMs = now;
       }
     } else {
       _rawCarrierSinceMs = 0;
@@ -329,8 +332,19 @@ void CC1101Util::pollRawRecord() {
         else if (d < -kRawClampUs) d = -kRawClampUs;
         s_rawBuf[s_rawCount++] = d;
       }
-      _rawLastFrameMs = now;
+      _rawLastFrameMs    = now;
+      _rawCaptureStartMs = now;   // frames are landing → not stuck on noise
     }
+  }
+
+  // Safety: no frame drained for this long while "capturing" means the RMT is
+  // sitting on non-idling noise (floor rose above the gate) — tear it down before
+  // it overflows the buffer (→ crash). The idle branch re-adapts the gate next.
+  if (now - _rawCaptureStartMs > kMaxCaptureMs) {
+    _rmt.end();
+    _rawCapturing      = false;
+    _rawCarrierSinceMs = 0;
+    return;
   }
 
   // Carrier gone (or buffer full) → uninstall the receiver so it doesn't sit on
@@ -499,16 +513,24 @@ void CC1101Util::_initRx() {
   pinMode(_gdo0Pin, INPUT);
 }
 
-int CC1101Util::_measureNoiseGate() {
-  // Peak RSSI over a short window with no signal ≈ the noise floor. Gate a few dB
-  // above it so weak/distant carriers still trigger while the floor doesn't.
-  int peak = -120;
-  for (int i = 0; i < 8; i++) {
-    int r = ELECHOUSE_cc1101.getRssi();
-    if (r > peak) peak = r;
+int CC1101Util::_measureNoiseFloor() {
+  // Average RSSI over a short window with no signal ≈ the noise floor. Seeds the
+  // rolling estimate so gating is right from the first poll.
+  long sum = 0;
+  const int samples = 16;
+  for (int i = 0; i < samples; i++) {
+    sum += ELECHOUSE_cc1101.getRssi();
     delayMicroseconds(300);
   }
-  int gate = peak + kCarrierMarginDb;
+  return (int)(sum / samples);
+}
+
+int CC1101Util::_updateGate(int& floor, int rssi) const {
+  // Leaky follower toward the current RSSI (EMA, α≈1/8). Only called while idle,
+  // where RSSI is the noise floor — so `floor` tracks it up AND down and the gate
+  // sits a small margin above it, staying sensitive without latching high.
+  floor = (floor * 7 + rssi) / 8;
+  int gate = floor + kCarrierMarginDb;
   if (gate < kGateMin) gate = kGateMin;
   if (gate > kGateMax) gate = kGateMax;
   return gate;

--- a/firmware/src/utils/rf/CC1101Util.cpp
+++ b/firmware/src/utils/rf/CC1101Util.cpp
@@ -26,13 +26,9 @@ static constexpr uint8_t kFreqCount = sizeof(kFreqList) / sizeof(kFreqList[0]);
 static constexpr int kRssiThreshold = CC1101Util::RSSI_THRESHOLD;
 static constexpr uint8_t kScanHits   = 1;  // lock to first frequency with signal
 
-// ── RAW recorder ISR-shared state ───────────────────────────────────────────
-volatile bool          CC1101Util::s_rawRec    = false;
-volatile bool          CC1101Util::s_rawResync = false;
-volatile uint16_t      CC1101Util::s_rawCount  = 0;
-volatile unsigned long CC1101Util::s_rawLast   = 0;
-int32_t*               CC1101Util::s_rawBuf     = nullptr;
-int                    CC1101Util::s_rawPin     = -1;
+// ── RAW recorder accumulator ────────────────────────────────────────────────
+uint16_t  CC1101Util::s_rawCount = 0;
+int32_t*  CC1101Util::s_rawBuf   = nullptr;
 
 // ── Init / End ───────────────────────────────────────────────────────────────
 
@@ -141,26 +137,41 @@ float CC1101Util::_scanForBestFreq(std::function<bool()> cancelCb) {
 bool CC1101Util::beginReceive() {
   if (!_initialized) return false;
   ELECHOUSE_cc1101.setSidle();
-  _initRx();
-  _sw.enableReceive(_gdo0Pin);
-  _sw.resetAvailable();
+  _initRx();                              // OOK async RX; GDO0 carries the data
+
+  _rxCapturing      = false;
+  _rxCarrierSinceMs = 0;
+  _rxLastCarrierMs  = 0;
+  // The RMT receiver is installed on demand in pollReceive() once a real carrier
+  // appears (RSSI gating) and uninstalled when it drops — no noise capture.
   return true;
 }
 
-void CC1101Util::_fillRcSwitch(Signal& out) {
-  uint64_t val = _sw.getReceivedValue();
+// Serialize the last RMT frame as signed durations (+HIGH / -LOW µs) — the exact
+// format sendSignal() replays and loadFile()/saveToString() use.
+String CC1101Util::_frameToString(uint16_t n) const {
+  String s;
+  s.reserve((size_t)n * 6);
+  for (uint16_t i = 0; i < n; i++) {
+    if (i) s += ' ';
+    s += String((int)_rxFrame[i]);
+  }
+  return s;
+}
+
+void CC1101Util::_fillRcSwitch(const RCSwitchUtil::Decoded& d, Signal& out) {
   out.frequency = _freq;
-  out.key       = val;
-  out.preset    = String(_sw.getReceivedProtocol());
+  out.key       = d.value;
+  out.preset    = String(d.proto);
   out.protocol  = "RcSwitch";
-  out.te        = (int)_sw.getReceivedDelay();
-  out.bit       = (int)_sw.getReceivedBitlength();
+  out.te        = (int)d.delay;
+  out.bit       = (int)d.bits;
   out.rawData   = "";
   // KeeLoq auto-decode: protocol 23 frames carry fix+encrypted+btn+serial packed
   // into a 64-bit value. Unpack the structured fields, then try the manufacturer
   // keystore (no-op if /unigeek/mfcodes is missing).
-  if (_sw.getReceivedProtocol() == 23) {
-    KeeloqUtil::unpack(val, out.fix, out.encrypted, out.btn, out.serial);
+  if (d.proto == 23) {
+    KeeloqUtil::unpack(d.value, out.fix, out.encrypted, out.btn, out.serial);
     KeeloqUtil::identify(out);
   }
 }
@@ -168,96 +179,82 @@ void CC1101Util::_fillRcSwitch(Signal& out) {
 bool CC1101Util::pollReceive(Signal& out) {
   if (!_initialized) return false;
 
-  // KeeLoq (RcSwitch proto 23) stays on the fast path: it's a rolling protocol
-  // that needs the manufacturer keystore and has no brand decoder of its own.
-  // Emitting it here also stops the brand decoders from ever mis-grabbing a
-  // KeeLoq frame.
-  if (_sw.available() && _sw.getReceivedValue() != 0 &&
-      _sw.getReceivedProtocol() == 23) {
-    _fillRcSwitch(out);
-    _sw.resetAvailable();
-    return true;
+  const int  rssi    = ELECHOUSE_cc1101.getRssi();
+  const bool carrier = rssi > kRssiThreshold;
+  const uint32_t now = millis();
+
+  // Gate: turn the receiver on only once a real carrier persists; while idle the
+  // RMT stays paused so squelch noise is never captured (and can't overflow it).
+  if (!_rxCapturing) {
+    if (carrier) {
+      if (_rxCarrierSinceMs == 0) _rxCarrierSinceMs = now;
+      if (now - _rxCarrierSinceMs >= kRxArmMs) {
+        _rmt.beginRx((gpio_num_t)_gdo0Pin);   // default idle (multi-repeat framing)
+        _rxCapturing     = true;
+        _rxLastCarrierMs = now;
+      }
+    } else {
+      _rxCarrierSinceMs = 0;
+    }
+    return false;
   }
 
-  // Everything else is decided on the COMPLETED raw frame so the brand decoders
-  // are AUTHORITATIVE: they identify the real protocol (CAME, Holtek, Linear,
-  // ...) and win over the generic RcSwitch table for overlapping protocols.
-  // RcSwitch is the fallback when no brand decoder matches; generic RAW is last.
-  if (_sw.RAWavailable()) {
-    delay(400); // let the full repeating signal land in the buffer
-    unsigned int* raw = _sw.getRAWReceivedRawdata();
-    uint16_t n = 0;
-    while (raw[n] != 0 && n < 1024) n++;
-
-    String rawStr;
+  // Capturing: pull one completed frame and try to decode it.
+  const uint16_t n = _rmt.readFrame(_rxFrame, kRxFrameMax);
+  if (n >= 8) {
+    // The decoders take unsigned durations; build the magnitude view once.
+    static unsigned int mag[kRxFrameMax];
     for (uint16_t i = 0; i < n; i++) {
-      if (i > 0) rawStr += ' ';
-      int sign = (i % 2 == 0) ? 1 : -1;
-      rawStr += String(sign * (int)raw[i]);
+      const int32_t v = _rxFrame[i];
+      mag[i] = (unsigned int)(v < 0 ? -v : v);
     }
 
-    // 1) Brand/manufacturer decoders — authoritative, both filter modes. The raw
-    //    stream is kept on the Signal so it can still be replayed.
-    if (n >= 8 && SubGhzDecoders::decode(raw, n, out)) {
+    // 1) Brand/manufacturer decoders — AUTHORITATIVE. They self-sync on their own
+    //    headers and win over the generic RcSwitch table (CAME, Holtek, Linear).
+    if (SubGhzDecoders::decode(mag, n, out)) {
       out.frequency = _freq;
-      out.rawData   = rawStr;
-      _sw.resetAvailable();
+      out.rawData   = _frameToString(n);
       return true;
     }
-
-    // 2) RcSwitch table decode (if the ISR recognised one of its 23 protocols).
-    if (_sw.available() && _sw.getReceivedValue() != 0) {
-      _fillRcSwitch(out);
-      _sw.resetAvailable();
+    // 2) RcSwitch table + KeeLoq (proto 23) from the same frame (KeeLoq tried
+    //    first inside decodeStream() so it is never mis-grabbed).
+    RCSwitchUtil::Decoded d;
+    if (RCSwitchUtil::decodeStream(_rxFrame, n, d)) {
+      _fillRcSwitch(d, out);
       return true;
     }
-
     // 3) Generic RAW capture — only when the user enabled raw capture.
-    if (_rxFilter == RX_FILTER_RAW && rawStr.length() > 0) {
+    if (_rxFilter == RX_FILTER_RAW) {
+      out = Signal();
       out.frequency = _freq;
       out.preset    = "0";
       out.protocol  = "RAW";
-      out.rawData   = rawStr;
-      out.key = 0; out.te = 0; out.bit = 0;
-      _sw.resetAvailable();
+      out.rawData   = _frameToString(n);
       return true;
     }
-    _sw.resetAvailable();
   }
 
+  // Carrier gone → uninstall the receiver again (kRxGapMs > RMT idle, so the
+  // burst's final frame has already been drained above before we uninstall).
+  if (carrier) {
+    _rxLastCarrierMs = now;
+  } else if (now - _rxLastCarrierMs > kRxGapMs) {
+    _rmt.end();
+    _rxCapturing      = false;
+    _rxCarrierSinceMs = 0;
+  }
   return false;
 }
 
 void CC1101Util::endReceive() {
-  _sw.disableReceive();
+  _rmt.end();
 }
 
 // ── RAW recorder ─────────────────────────────────────────────────────────────
 
-// GDO0 transition ISR. Mirrors the RCSwitchUtil ISR style (plain static method,
-// non-IRAM, calling micros()/digitalRead() — the proven path on this hardware):
-// stores one signed interval per edge while s_rawRec is set. The sign encodes
-// the level that just ENDED (+HIGH / -LOW), matching sendSignal()'s replay.
-void CC1101Util::_rawIsr() {
-  const unsigned long now = micros();
-  const unsigned long dur = now - s_rawLast;
-  s_rawLast = now;
-
-  if (!s_rawRec) return;
-  if (s_rawResync) { s_rawResync = false; return; }   // first edge: clock only
-  if (s_rawCount >= kRawRecMax) { s_rawRec = false; return; }  // buffer full
-
-  int32_t d = (int32_t)(dur > (unsigned long)kRawClampUs ? (unsigned long)kRawClampUs : dur);
-  // The edge just moved the pin to its NEW level, so the interval that elapsed
-  // was spent at the opposite level: new LOW → ended HIGH (+), new HIGH → (-).
-  if (digitalRead(s_rawPin) == LOW) s_rawBuf[s_rawCount++] = d;
-  else                              s_rawBuf[s_rawCount++] = -d;
-}
-
 bool CC1101Util::beginRawRecord() {
   if (!_initialized) return false;
   if (!s_rawBuf) {
-    // Internal RAM only — an ISR must never touch PSRAM (cache fault).
     s_rawBuf = (int32_t*)malloc((size_t)kRawRecMax * sizeof(int32_t));
     if (!s_rawBuf) return false;
   }
@@ -265,25 +262,22 @@ bool CC1101Util::beginRawRecord() {
   ELECHOUSE_cc1101.setSidle();
   _initRx();                       // OOK async, SetRx, GDO0 INPUT (uses _freq)
 
-  s_rawPin           = _gdo0Pin;
   s_rawCount         = 0;
-  s_rawRec           = false;
-  s_rawResync        = false;
-  s_rawLast          = micros();
   _rawArmed          = true;
   _rawStarted        = false;
-  _rawInGap          = false;
+  _rawCapturing      = false;
   _rawRssi           = -120;
+  _rawLastFrameMs    = 0;
   _rawCarrierSinceMs = 0;
   _rawLastCarrierMs  = 0;
-  _rawGapStartMs     = 0;
 
-  attachInterrupt(digitalPinToInterrupt(_gdo0Pin), _rawIsr, CHANGE);
+  // Note: the RMT receiver is NOT installed here. pollRawRecord() installs it only
+  // once a real carrier appears (RSSI) and uninstalls it when the carrier drops —
+  // so squelch noise is never captured and can never overflow the RMT buffer.
   return true;
 }
 
-// Push one synthetic LOW gap interval into the buffer (main loop only — called
-// while the ISR is paused, so the index write doesn't race).
+// Push one synthetic LOW gap interval into the buffer between two captured frames.
 void CC1101Util::_rawPushGap(uint32_t gapMs) {
   if (s_rawCount >= kRawRecMax) return;
   int32_t us = (gapMs > (uint32_t)(kRawClampUs / 1000)) ? kRawClampUs
@@ -294,23 +288,22 @@ void CC1101Util::_rawPushGap(uint32_t gapMs) {
 void CC1101Util::pollRawRecord() {
   if (!_initialized || !_rawArmed) return;
 
-  const int rssi = ELECHOUSE_cc1101.getRssi();
-  _rawRssi = rssi;
-  const uint32_t now = millis();
+  const int  rssi    = ELECHOUSE_cc1101.getRssi();
+  _rawRssi           = rssi;                    // live bar
   const bool carrier = rssi > kRssiThreshold;
+  const uint32_t now = millis();
 
-  // ── Not started: wait for a real signal on the listened frequency. RSSI must
-  // stay above threshold for kRawArmMs (a single transient sample is ignored).
-  if (!_rawStarted) {
+  // ── Idle: wait for a real carrier before turning the receiver on. ──────────
+  if (!_rawCapturing) {
     if (carrier) {
       if (_rawCarrierSinceMs == 0) _rawCarrierSinceMs = now;
-      if (now - _rawCarrierSinceMs >= kRawArmMs) {
-        _rawStarted       = true;
-        _rawInGap         = false;
+      if (now - _rawCarrierSinceMs >= kRawArmMs && s_rawCount < kRawRecMax) {
+        _rawStarted = true;
+        // Short idle so per-repeat frames complete and drain (no overflow).
+        _rmt.beginRx((gpio_num_t)_gdo0Pin, kRawIdleUs);
+        _rawCapturing     = true;
         _rawLastCarrierMs = now;
-        s_rawResync       = true;     // ISR drops the first edge, syncs the clock
-        s_rawLast         = micros();
-        s_rawRec          = true;
+        _rawLastFrameMs   = now;
       }
     } else {
       _rawCarrierSinceMs = 0;
@@ -318,29 +311,42 @@ void CC1101Util::pollRawRecord() {
     return;
   }
 
-  // ── Recording (continuous until the caller stops). Storing pauses during long
-  // silences so idle noise isn't captured, and the gap is re-inserted as one
-  // compressed LOW interval when the signal comes back. ──────────────────────
-  if (s_rawCount >= kRawRecMax) { s_rawRec = false; return; }  // buffer full
+  // ── Capturing: drain every completed (per-repeat) frame. ───────────────────
+  if (s_rawCount < kRawRecMax) {
+    static int32_t frame[kRxFrameMax];
+    uint16_t n;
+    while ((n = _rmt.readFrame(frame, kRxFrameMax)) > 0) {
+      // Each frame is one repeat, delimited by the RMT idle gap. Re-insert that
+      // silence as a LOW interval so the stream stays HIGH/LOW-alternating and
+      // the inter-repeat spacing survives replay (frames end HIGH, start HIGH —
+      // without this the two would fuse into one bogus long pulse).
+      if (s_rawCount > 0) _rawPushGap(kRawIdleUs / 1000);
+      for (uint16_t i = 0; i < n && s_rawCount < kRawRecMax; i++) {
+        int32_t d = frame[i];
+        if (d >  kRawClampUs) d =  kRawClampUs;
+        else if (d < -kRawClampUs) d = -kRawClampUs;
+        s_rawBuf[s_rawCount++] = d;
+      }
+      _rawLastFrameMs = now;
+    }
+  }
 
+  // Carrier gone (or buffer full) → uninstall the receiver so it doesn't sit on
+  // noise. The final per-repeat frame has already been drained above.
   if (carrier) {
     _rawLastCarrierMs = now;
-    if (_rawInGap) {                          // signal returned → resume
-      _rawPushGap(now - _rawGapStartMs);
-      _rawInGap   = false;
-      s_rawResync = true;
-      s_rawLast   = micros();
-      s_rawRec    = true;
-    }
-  } else if (!_rawInGap && (now - _rawLastCarrierMs) > kRawGapMs) {
-    s_rawRec       = false;                   // carrier gone → pause storing
-    _rawInGap      = true;
-    _rawGapStartMs = _rawLastCarrierMs;
+  } else if (now - _rawLastCarrierMs > kRawGapMs) {
+    _rmt.end();
+    _rawCapturing      = false;
+    _rawCarrierSinceMs = 0;
+  }
+  if (s_rawCount >= kRawRecMax) {
+    _rmt.end();
+    _rawCapturing = false;
   }
 }
 
 void CC1101Util::finishRawRecord(Signal& out) {
-  s_rawRec = false;                 // freeze the buffer before serializing
   out = Signal();
   out.frequency = _freq;
   out.preset    = "0";              // generic OOK — matches the RX_FILTER_RAW path
@@ -357,16 +363,10 @@ void CC1101Util::finishRawRecord(Signal& out) {
 }
 
 void CC1101Util::endRawRecord() {
-  if (s_rawPin >= 0) {
-    detachInterrupt(digitalPinToInterrupt(s_rawPin));
-    s_rawPin = -1;
-  }
-  s_rawRec    = false;
+  _rmt.end();
   s_rawCount  = 0;
   _rawArmed   = false;
   _rawStarted = false;
-  _rawInGap   = false;
-  _rawCarrierSinceMs = 0;
   if (s_rawBuf) { free(s_rawBuf); s_rawBuf = nullptr; }
   if (_initialized) ELECHOUSE_cc1101.setSidle();
 }
@@ -571,26 +571,33 @@ void CC1101Util::sendSignal(const Signal& sig) {
   // Brand-decoded signals (CAME, Holtek, ...) keep their captured raw pulse
   // train and are replayed from it — we decode these protocols but have no
   // dedicated encoder, so RCSwitch re-encoding would transmit the wrong timing.
-  // Only true RcSwitch protocols go through the RCSwitch library.
+  // Only true RcSwitch protocols go through the RCSwitch encoder.
   if (sig.protocol != "RcSwitch" && sig.rawData.length() > 0) {
+    // Parse the signed-duration stream and clock it out over RMT — hardware
+    // timing, immune to WiFi/interrupt jitter (unlike the old digitalWrite +
+    // delayMicroseconds loop). Count tokens first for an exact allocation.
     const String& data = sig.rawData;
-    int start = 0;
-    for (int i = 0; i <= (int)data.length(); i++) {
-      if (i == (int)data.length() || data[i] == ' ') {
-        if (i > start) {
-          int32_t val = data.substring(start, i).toInt();
-          if (val > 0) {
-            digitalWrite(_gdo0Pin, HIGH);
-            delayMicroseconds((uint32_t)val);
-          } else if (val < 0) {
-            digitalWrite(_gdo0Pin, LOW);
-            delayMicroseconds((uint32_t)(-val));
+    uint16_t count = data.length() ? 1 : 0;
+    for (int i = 0; i < (int)data.length(); i++) if (data[i] == ' ') count++;
+
+    int32_t* tx = (int32_t*)malloc((size_t)count * sizeof(int32_t));
+    if (tx) {
+      uint16_t k = 0;
+      int start = 0;
+      for (int i = 0; i <= (int)data.length() && k < count; i++) {
+        if (i == (int)data.length() || data[i] == ' ') {
+          if (i > start) {
+            int32_t val = data.substring(start, i).toInt();
+            if (val != 0) tx[k++] = val;
           }
+          start = i + 1;
         }
-        start = i + 1;
       }
+      _rmt.beginTx((gpio_num_t)_gdo0Pin);
+      _rmt.sendDurations(tx, k);
+      _rmt.end();
+      free(tx);
     }
-    digitalWrite(_gdo0Pin, LOW);
 
   } else {
     _sendRcSwitch(sig);
@@ -617,18 +624,22 @@ void CC1101Util::_sendRcSwitch(const Signal& sig) {
   }
 
   RCSwitchUtil sw;
-  sw.enableTransmit(_gdo0Pin);
   sw.setProtocol(protoNum);
   if (sig.te > 0) sw.setPulseLength(sig.te);
   sw.setRepeatTransmit(10);
-  sw.send(sig.key, (unsigned int)sig.bit);
-  sw.disableTransmit();
+
+  // Encode the waveform to durations, then transmit over RMT (hardware-timed).
+  // Bound: 10 repeats × (~24 preamble + 2×64 bits + trailer) fits comfortably.
+  static int32_t tx[2048];
+  const uint16_t k = sw.encodeToDurations(sig.key, (unsigned int)sig.bit, tx, 2048);
+  _rmt.beginTx((gpio_num_t)_gdo0Pin);
+  _rmt.sendDurations(tx, k);
+  _rmt.end();
 }
 
 void CC1101Util::_initTx() {
   ELECHOUSE_cc1101.setModulation(2);
   ELECHOUSE_cc1101.setPktFormat(3);
-  pinMode(_gdo0Pin, OUTPUT);
   ELECHOUSE_cc1101.setPA(12);
   ELECHOUSE_cc1101.SetTx();
 }
@@ -639,6 +650,10 @@ bool CC1101Util::loadFile(const String& content, Signal& out) {
   out = Signal();
 
   String rawAccum;
+  // Reserve up front: a long RAW capture spans many RAW_Data lines, and letting
+  // rawAccum grow by doubling would spike memory (old buffer + new, ~2×) and can
+  // OOM — leaving rawAccum empty and the whole file wrongly rejected as invalid.
+  rawAccum.reserve(content.length());
   int start = 0;
 
   while (start < (int)content.length()) {

--- a/firmware/src/utils/rf/CC1101Util.cpp
+++ b/firmware/src/utils/rf/CC1101Util.cpp
@@ -142,6 +142,7 @@ bool CC1101Util::beginReceive() {
   _rxCapturing      = false;
   _rxCarrierSinceMs = 0;
   _rxLastCarrierMs  = 0;
+  _captureGate      = _measureNoiseGate();   // adaptive gate (distance-sensitive)
   // The RMT receiver is installed on demand in pollReceive() once a real carrier
   // appears (RSSI gating) and uninstalled when it drops — no noise capture.
   return true;
@@ -180,7 +181,7 @@ bool CC1101Util::pollReceive(Signal& out) {
   if (!_initialized) return false;
 
   const int  rssi    = ELECHOUSE_cc1101.getRssi();
-  const bool carrier = rssi > kRssiThreshold;
+  const bool carrier = rssi > _captureGate;
   const uint32_t now = millis();
 
   // Gate: turn the receiver on only once a real carrier persists; while idle the
@@ -270,6 +271,7 @@ bool CC1101Util::beginRawRecord() {
   _rawLastFrameMs    = 0;
   _rawCarrierSinceMs = 0;
   _rawLastCarrierMs  = 0;
+  _captureGate       = _measureNoiseGate();   // adaptive gate (distance-sensitive)
 
   // Note: the RMT receiver is NOT installed here. pollRawRecord() installs it only
   // once a real carrier appears (RSSI) and uninstalls it when the carrier drops —
@@ -290,7 +292,7 @@ void CC1101Util::pollRawRecord() {
 
   const int  rssi    = ELECHOUSE_cc1101.getRssi();
   _rawRssi           = rssi;                    // live bar
-  const bool carrier = rssi > kRssiThreshold;
+  const bool carrier = rssi > _captureGate;
   const uint32_t now = millis();
 
   // ── Idle: wait for a real carrier before turning the receiver on. ──────────
@@ -497,6 +499,21 @@ void CC1101Util::_initRx() {
   pinMode(_gdo0Pin, INPUT);
 }
 
+int CC1101Util::_measureNoiseGate() {
+  // Peak RSSI over a short window with no signal ≈ the noise floor. Gate a few dB
+  // above it so weak/distant carriers still trigger while the floor doesn't.
+  int peak = -120;
+  for (int i = 0; i < 8; i++) {
+    int r = ELECHOUSE_cc1101.getRssi();
+    if (r > peak) peak = r;
+    delayMicroseconds(300);
+  }
+  int gate = peak + kCarrierMarginDb;
+  if (gate < kGateMin) gate = kGateMin;
+  if (gate > kGateMax) gate = kGateMax;
+  return gate;
+}
+
 // ── Fast RSSI sweep (Waterfall) ──────────────────────────────────────────────
 
 void CC1101Util::beginRssiSweep(float calibMhz) {
@@ -646,75 +663,60 @@ void CC1101Util::_initTx() {
 
 // ── File I/O ─────────────────────────────────────────────────────────────
 
-bool CC1101Util::loadFile(const String& content, Signal& out) {
-  out = Signal();
+// Parse one trimmed .sub line into `out`. RAW_Data is appended straight onto
+// out.rawData (no separate accumulator + final copy — that doubled the peak RAM
+// and OOM'd on long captures, silently emptying rawData → "invalid .sub").
+void CC1101Util::_parseSubLine(const String& line, Signal& out) {
+  if (line.startsWith("Filetype:") || line.startsWith("Version")) return;
 
-  String rawAccum;
-  // Reserve up front: a long RAW capture spans many RAW_Data lines, and letting
-  // rawAccum grow by doubling would spike memory (old buffer + new, ~2×) and can
-  // OOM — leaving rawAccum empty and the whole file wrongly rejected as invalid.
-  rawAccum.reserve(content.length());
-  int start = 0;
+  int colonIdx = line.indexOf(':');
+  if (colonIdx < 0) return;
 
-  while (start < (int)content.length()) {
-    int nl = content.indexOf('\n', start);
-    if (nl < 0) nl = content.length();
-    String line = content.substring(start, nl);
-    line.trim();
-    start = nl + 1;
+  String key = line.substring(0, colonIdx);
+  String val = line.substring(colonIdx + 1);
+  val.trim();
+  if (val.endsWith("\r")) val.remove(val.length() - 1);
 
-    if (line.startsWith("Filetype:") || line.startsWith("Version")) continue;
-
-    int colonIdx = line.indexOf(':');
-    if (colonIdx < 0) continue;
-
-    String key = line.substring(0, colonIdx);
-    String val = line.substring(colonIdx + 1);
-    val.trim();
-    if (val.endsWith("\r")) val.remove(val.length() - 1);
-
-    if (key == "Frequency") {
-      out.frequency = val.toFloat() / 1000000.0f;
-    } else if (key == "Preset") {
-      out.preset = val;
-    } else if (key == "Protocol") {
-      out.protocol = val;
-    } else if (key == "TE") {
-      out.te = val.toInt();
-    } else if (key == "Bit") {
-      out.bit = val.toInt();
-    } else if (key == "Key") {
-      // Accept "0xABCD", space-separated hex bytes "AA BB CC", or decimal
-      String clean = val;
-      clean.replace(" ", "");
-      if (clean.startsWith("0x") || clean.startsWith("0X")) {
-        out.key = strtoull(clean.c_str() + 2, nullptr, 16);
-      } else {
-        // Try hex first (Flipper byte-string without 0x), then decimal
-        bool allHex = true;
-        for (char c : clean) {
-          if (!isxdigit(c)) { allHex = false; break; }
-        }
-        out.key = strtoull(clean.c_str(), nullptr, allHex ? 16 : 10);
+  if (key == "Frequency") {
+    out.frequency = val.toFloat() / 1000000.0f;
+  } else if (key == "Preset") {
+    out.preset = val;
+  } else if (key == "Protocol") {
+    out.protocol = val;
+  } else if (key == "TE") {
+    out.te = val.toInt();
+  } else if (key == "Bit") {
+    out.bit = val.toInt();
+  } else if (key == "Key") {
+    // Accept "0xABCD", space-separated hex bytes "AA BB CC", or decimal
+    String clean = val;
+    clean.replace(" ", "");
+    if (clean.startsWith("0x") || clean.startsWith("0X")) {
+      out.key = strtoull(clean.c_str() + 2, nullptr, 16);
+    } else {
+      bool allHex = true;
+      for (char c : clean) {
+        if (!isxdigit(c)) { allHex = false; break; }
       }
-    } else if (key == "RAW_Data" || key == "Data_RAW") {
-      if (rawAccum.length() > 0) rawAccum += ' ';
-      rawAccum += val;
-    } else if (key == "Manufacturer") {
-      out.mf_name = val;
-    } else if (key == "Serial") {
-      String clean = val;
-      if (clean.startsWith("0x") || clean.startsWith("0X")) clean.remove(0, 2);
-      out.serial = (uint32_t)strtoul(clean.c_str(), nullptr, 16);
-    } else if (key == "Button") {
-      out.btn = (uint8_t)val.toInt();
-    } else if (key == "Counter") {
-      out.cnt = (uint16_t)val.toInt();
+      out.key = strtoull(clean.c_str(), nullptr, allHex ? 16 : 10);
     }
+  } else if (key == "RAW_Data" || key == "Data_RAW") {
+    if (out.rawData.length() > 0) out.rawData += ' ';
+    out.rawData += val;
+  } else if (key == "Manufacturer") {
+    out.mf_name = val;
+  } else if (key == "Serial") {
+    String clean = val;
+    if (clean.startsWith("0x") || clean.startsWith("0X")) clean.remove(0, 2);
+    out.serial = (uint32_t)strtoul(clean.c_str(), nullptr, 16);
+  } else if (key == "Button") {
+    out.btn = (uint8_t)val.toInt();
+  } else if (key == "Counter") {
+    out.cnt = (uint16_t)val.toInt();
   }
+}
 
-  out.rawData = rawAccum;
-
+bool CC1101Util::_finalizeSub(Signal& out) {
   // KeeLoq: always unpack structured fields from the captured Key. If the
   // .sub came from a peer device that already had mf_name resolved, those
   // file-supplied values win; otherwise try the local keystore now.
@@ -732,6 +734,38 @@ bool CC1101Util::loadFile(const String& content, Signal& out) {
   if (out.frequency <= 0) return false;
   if (out.protocol == "RAW") return out.rawData.length() > 0;
   return out.key != 0 || out.bit > 0;
+}
+
+bool CC1101Util::loadFile(const String& content, Signal& out) {
+  out = Signal();
+  out.rawData.reserve(content.length());   // one alloc; no doubling spike
+
+  int start = 0;
+  while (start < (int)content.length()) {
+    int nl = content.indexOf('\n', start);
+    if (nl < 0) nl = content.length();
+    String line = content.substring(start, nl);
+    line.trim();
+    start = nl + 1;
+    if (line.length()) _parseSubLine(line, out);
+  }
+  return _finalizeSub(out);
+}
+
+// Streaming loader: parses the .sub straight off the file, one line at a time,
+// so only rawData (not a second full-file copy) is ever resident. This is what
+// lets large multi-line RAW captures load without OOM. `sizeHint` (file size)
+// pre-reserves rawData to avoid reallocation.
+bool CC1101Util::loadFromStream(Stream& f, Signal& out, size_t sizeHint) {
+  out = Signal();
+  if (sizeHint) out.rawData.reserve(sizeHint);
+
+  while (f.available()) {
+    String line = f.readStringUntil('\n');
+    line.trim();
+    if (line.length()) _parseSubLine(line, out);
+  }
+  return _finalizeSub(out);
 }
 
 String CC1101Util::saveToString(const Signal& sig) {

--- a/firmware/src/utils/rf/CC1101Util.h
+++ b/firmware/src/utils/rf/CC1101Util.h
@@ -179,12 +179,16 @@ private:
   static constexpr uint32_t kRxArmMs = 6;    // carrier must persist to start
   static constexpr uint32_t kRxGapMs = 80;   // carrier-gone hold (> RMT idle) so
                                              // the final frame is drained first
-  // The carrier gate is adaptive: measured a few dB above the noise floor at
-  // begin, so a weak/distant transmitter still triggers (a fixed threshold
-  // needed the remote almost touching the antenna).
-  static constexpr int kCarrierMarginDb = 8;   // gate = measured floor + this
-  static constexpr int kGateMin         = -98; // clamp (never gate on pure noise)
-  static constexpr int kGateMax         = -55;
+  // The carrier gate is adaptive: measured just above the average noise floor at
+  // begin, so a weak/distant transmitter still triggers — nearly as sensitive as
+  // the raw data slicer the old RCSwitch ISR read directly (it had no RSSI gate).
+  static constexpr int      kCarrierMarginDb = 4;   // gate = avg floor + this
+  static constexpr int      kGateMin         = -100;// clamp (never gate on floor)
+  static constexpr int      kGateMax         = -55;
+  static constexpr uint32_t kMaxCaptureMs    = 600; // safety: no frame drained for
+                                                    // this long → stuck on noise;
+                                                    // tear down (idle poll re-adapts
+                                                    // the gate) before RMT overflow
   int      _captureGate      = RSSI_THRESHOLD;
   bool     _rxCapturing      = false;
   uint32_t _rxCarrierSinceMs = 0;
@@ -199,7 +203,9 @@ private:
                                                    // (keeps the .sub + its String
                                                    // reassembly within RAM budget)
   static constexpr int32_t  kRawClampUs = 300000;  // clamp a single interval
-  static constexpr uint16_t kRawIdleUs  = 5000;    // RMT idle → close per-repeat frames
+  static constexpr uint16_t kRawIdleUs  = 6000;    // RMT idle → close per-repeat
+                                                   // frames (> KeeLoq's 4 ms intra
+                                                   // sync, < inter-repeat gaps)
   static constexpr uint32_t kRawArmMs   = 6;       // carrier must persist to start
   static constexpr uint32_t kRawGapMs   = 30;      // carrier-gone → pause + gap mark
 
@@ -210,6 +216,8 @@ private:
   uint32_t _rawLastFrameMs    = 0;     // millis() of the last appended frame
   uint32_t _rawCarrierSinceMs = 0;     // when RSSI first crossed (0 = below)
   uint32_t _rawLastCarrierMs  = 0;     // last time carrier was present
+  uint32_t _rawCaptureStartMs = 0;     // when the current RMT capture opened
+  int      _rawFloor          = -100;  // rolling noise-floor estimate (RAW record)
 
   void _rawPushGap(uint32_t gapMs);    // insert one compressed LOW gap interval
 
@@ -253,7 +261,11 @@ private:
   static void _parseSubLine(const String& line, Signal& out);
   static bool _finalizeSub(Signal& out);   // KeeLoq unpack + validity check
 
-  // Sample the RSSI noise floor and return the adaptive carrier gate (floor +
-  // margin, clamped). Call once the chip is in RX and no signal is expected.
-  int _measureNoiseGate();
+  // Average RSSI over a short window ≈ the noise floor (seed for the rolling
+  // estimate). Call once the chip is in RX and no signal is expected.
+  int _measureNoiseFloor();
+  // Advance a rolling noise-floor estimate by one RSSI sample and return the
+  // resulting carrier gate (floor + margin, clamped). Adapts up and down, so a
+  // rising floor can't latch the gate high and kill sensitivity.
+  int _updateGate(int& floor, int rssi) const;
 };

--- a/firmware/src/utils/rf/CC1101Util.h
+++ b/firmware/src/utils/rf/CC1101Util.h
@@ -146,6 +146,10 @@ public:
 
   // File I/O — Bruce SubGhz .sub format
   static bool loadFile(const String& content, Signal& out);
+  // Streaming parse straight off an open file — use for on-SD .sub files so a
+  // large RAW capture doesn't need the whole file resident (avoids OOM). Pass
+  // the file size as `sizeHint` to pre-reserve rawData.
+  static bool loadFromStream(Stream& f, Signal& out, size_t sizeHint = 0);
   static String saveToString(const Signal& sig);
 
   // Display helpers
@@ -175,6 +179,13 @@ private:
   static constexpr uint32_t kRxArmMs = 6;    // carrier must persist to start
   static constexpr uint32_t kRxGapMs = 80;   // carrier-gone hold (> RMT idle) so
                                              // the final frame is drained first
+  // The carrier gate is adaptive: measured a few dB above the noise floor at
+  // begin, so a weak/distant transmitter still triggers (a fixed threshold
+  // needed the remote almost touching the antenna).
+  static constexpr int kCarrierMarginDb = 8;   // gate = measured floor + this
+  static constexpr int kGateMin         = -98; // clamp (never gate on pure noise)
+  static constexpr int kGateMax         = -55;
+  int      _captureGate      = RSSI_THRESHOLD;
   bool     _rxCapturing      = false;
   uint32_t _rxCarrierSinceMs = 0;
   uint32_t _rxLastCarrierMs  = 0;
@@ -237,4 +248,12 @@ private:
   void  _fillRcSwitch(const RCSwitchUtil::Decoded& d, Signal& out);
   // Serialize the last captured RMT frame (_rxFrame) as signed-duration text.
   String _frameToString(uint16_t n) const;
+
+  // .sub parsing shared by loadFile() and loadFromStream().
+  static void _parseSubLine(const String& line, Signal& out);
+  static bool _finalizeSub(Signal& out);   // KeeLoq unpack + validity check
+
+  // Sample the RSSI noise floor and return the adaptive carrier gate (floor +
+  // margin, clamped). Call once the chip is in RX and no signal is expected.
+  int _measureNoiseGate();
 };

--- a/firmware/src/utils/rf/CC1101Util.h
+++ b/firmware/src/utils/rf/CC1101Util.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include "core/ExtSpiClass.h"
 #include "RCSwitchUtil.h"
+#include "RmtRf.h"
 
 class CC1101Util {
 public:
@@ -162,37 +163,48 @@ private:
   float  _freq = DEFAULT_FREQ;
   bool   _initialized = false;
 
-  RCSwitchUtil _sw;  // persistent receiver state for non-blocking polling
+  RmtRf        _rmt;  // hardware RMT capture/replay (replaces the GDO0 ISRs)
   RxFilter     _rxFilter = RX_FILTER_CODE;
 
-  // ── RAW recorder state ─────────────────────────────────────────────────
-  // Tuning: recording opens after the carrier persists kRawArmMs; once started
-  // it runs until the caller stops it. A carrier gap longer than kRawGapMs
-  // pauses storing (so idle noise isn't recorded) and is re-inserted as one
-  // compressed LOW interval when the signal returns.
-  static constexpr uint16_t kRawRecMax  = 8192;    // max transitions / capture
-  static constexpr uint32_t kRawArmMs   = 8;       // carrier must persist to start
-  static constexpr uint32_t kRawGapMs   = 25;      // carrier-gone → pause + gap mark
-  static constexpr int32_t  kRawClampUs = 300000;  // clamp a single interval
+  // Scratch for one RMT frame, read out of the ring buffer each pollReceive().
+  static constexpr uint16_t kRxFrameMax = 1024;
+  int32_t _rxFrame[kRxFrameMax];
 
-  bool     _rawArmed         = false;  // begin/end lifecycle
-  bool     _rawStarted       = false;  // first carrier seen (recording live)
-  bool     _rawInGap         = false;  // storing paused, waiting for carrier
-  int      _rawRssi          = -120;
+  // Receive carrier gating (RSSI) — the RMT receiver stays paused until a real
+  // carrier appears, so squelch noise is never captured (and can't overflow it).
+  static constexpr uint32_t kRxArmMs = 6;    // carrier must persist to start
+  static constexpr uint32_t kRxGapMs = 80;   // carrier-gone hold (> RMT idle) so
+                                             // the final frame is drained first
+  bool     _rxCapturing      = false;
+  uint32_t _rxCarrierSinceMs = 0;
+  uint32_t _rxLastCarrierMs  = 0;
+
+  // ── RAW recorder state ─────────────────────────────────────────────────
+  // Continuous capture over RMT: each completed frame (burst) is appended to one
+  // accumulating buffer, and the real silence between frames — measured by wall
+  // clock — is re-inserted as a single compressed LOW gap so the buffer holds
+  // signal content, not idle noise. Runs until the caller stops it or fills up.
+  static constexpr uint16_t kRawRecMax  = 4096;    // max transitions / capture
+                                                   // (keeps the .sub + its String
+                                                   // reassembly within RAM budget)
+  static constexpr int32_t  kRawClampUs = 300000;  // clamp a single interval
+  static constexpr uint16_t kRawIdleUs  = 5000;    // RMT idle → close per-repeat frames
+  static constexpr uint32_t kRawArmMs   = 6;       // carrier must persist to start
+  static constexpr uint32_t kRawGapMs   = 30;      // carrier-gone → pause + gap mark
+
+  bool     _rawArmed          = false; // begin/end lifecycle
+  bool     _rawStarted        = false; // first frame captured (recording live)
+  bool     _rawCapturing      = false; // RMT actively receiving (carrier present)
+  int      _rawRssi           = -120;  // last RSSI (live bar)
+  uint32_t _rawLastFrameMs    = 0;     // millis() of the last appended frame
   uint32_t _rawCarrierSinceMs = 0;     // when RSSI first crossed (0 = below)
-  uint32_t _rawLastCarrierMs = 0;
-  uint32_t _rawGapStartMs    = 0;
+  uint32_t _rawLastCarrierMs  = 0;     // last time carrier was present
 
   void _rawPushGap(uint32_t gapMs);    // insert one compressed LOW gap interval
 
-  // ISR-shared state (single active CC1101Util at a time — static like RCSwitch).
-  static void              _rawIsr();
-  static volatile bool          s_rawRec;     // ISR storing transitions
-  static volatile bool          s_rawResync;  // drop next edge, just resync clock
-  static volatile uint16_t      s_rawCount;
-  static volatile unsigned long s_rawLast;
-  static int32_t*               s_rawBuf;     // signed durations (internal RAM)
-  static int                    s_rawPin;
+  // Accumulator (main-loop only now — RMT does the timing, no ISR).
+  static uint16_t  s_rawCount;
+  static int32_t*  s_rawBuf;           // signed durations (internal RAM)
 
   // Scan status (updated during receive/scan)
   bool    _scanning = false;
@@ -221,6 +233,8 @@ private:
   void  _initTx();
   void  _initRx();
   void  _sendRcSwitch(const Signal& sig);
-  // Fill `out` from the current RCSwitch decode (incl. KeeLoq proto-23 unpack).
-  void  _fillRcSwitch(Signal& out);
+  // Fill `out` from a decoded RcSwitch/KeeLoq frame (incl. KeeLoq proto-23 unpack).
+  void  _fillRcSwitch(const RCSwitchUtil::Decoded& d, Signal& out);
+  // Serialize the last captured RMT frame (_rxFrame) as signed-duration text.
+  String _frameToString(uint16_t n) const;
 };

--- a/firmware/src/utils/rf/CC1101Util.h
+++ b/firmware/src/utils/rf/CC1101Util.h
@@ -59,6 +59,13 @@ public:
   bool setFrequency(float mhz);
   float getFrequency() const { return _freq; }
 
+  // RSSI carrier-detect threshold (dBm). Gates the Receive capture arming and the
+  // Detect Freq peak trigger — lower = more sensitive (weaker/farther signals).
+  // Record RAW does NOT use this: it runs an adaptive noise-floor gate instead.
+  // Defaults to RSSI_THRESHOLD; set at runtime and persists across begin()/end().
+  void setRssiThreshold(int dbm) { _rssiThreshold = dbm; }
+  int  getRssiThreshold() const  { return _rssiThreshold; }
+
   // Check if CC1101 is connected
   bool isConnected();
 
@@ -115,7 +122,7 @@ public:
   // ── Frequency analyzer (Flipper-style "peaky" peak detect) ────────────────
   // Call analyzeStep() once per frame. Each call runs a full coarse sweep
   // across the whole band (wide RxBW — also fills the RSSI map that drives the
-  // bar chart) then, if the strongest channel passes kAnalyzerTrigger, a fine
+  // bar chart) then, if the strongest channel passes _rssiThreshold, a fine
   // refine (narrow RxBW, ±0.3 MHz @ 20 kHz) to pin the exact frequency. The
   // last peak is held for kAnalyzerHold frames after the signal disappears so
   // it stays on screen instead of vanishing the instant the carrier drops.
@@ -169,6 +176,7 @@ private:
 
   RmtRf        _rmt;  // hardware RMT capture/replay (replaces the GDO0 ISRs)
   RxFilter     _rxFilter = RX_FILTER_CODE;
+  int          _rssiThreshold = RSSI_THRESHOLD;  // Receive gate + Detect trigger (runtime)
 
   // Scratch for one RMT frame, read out of the ring buffer each pollReceive().
   static constexpr uint16_t kRxFrameMax = 1024;
@@ -232,8 +240,8 @@ private:
   uint8_t _scanIdx  = 0;
   int     _scanRssiMap[kScanFreqCount];
 
-  // Frequency analyzer (peak detect + sample-hold)
-  static constexpr int      kAnalyzerTrigger = -75;   // dBm; coarse peak must exceed
+  // Frequency analyzer (peak detect + sample-hold). Coarse peak must exceed the
+  // runtime _rssiThreshold (shared with the Receive capture gate).
   static constexpr uint8_t  kAnalyzerHold    = 16;    // frames to hold after signal stops
   static constexpr uint16_t kSweepSettleUs   = 1500;  // µs RSSI settle after re-entering RX
   float   _peakFreq = 0;
@@ -251,6 +259,9 @@ private:
   float _scanForBestFreq(std::function<bool()> cancelCb);
   void  _initTx();
   void  _initRx();
+  // Write the OOK RX sensitivity registers (AGC full gain, ADC retention, SmartRF
+  // front-end) after ELECHOUSE Init(), whose FSK-packet defaults cap the gain.
+  void  _applyOokRxRegs();
   void  _sendRcSwitch(const Signal& sig);
   // Fill `out` from a decoded RcSwitch/KeeLoq frame (incl. KeeLoq proto-23 unpack).
   void  _fillRcSwitch(const RCSwitchUtil::Decoded& d, Signal& out);

--- a/firmware/src/utils/rf/M5RF433Util.cpp
+++ b/firmware/src/utils/rf/M5RF433Util.cpp
@@ -30,60 +30,53 @@ void M5RF433Util::end() {
 
 bool M5RF433Util::beginReceive() {
   if (!_initialized || _rxPin < 0) return false;
-  _sw.enableReceive(_rxPin);
-  _sw.resetAvailable();
-  return true;
+  return _rmt.beginRx((gpio_num_t)_rxPin);
 }
 
 bool M5RF433Util::pollReceive(Signal& out) {
   if (!_initialized) return false;
 
-  if (_sw.available()) {
-    uint64_t val = _sw.getReceivedValue();
-    if (val != 0) {
-      out.frequency = FIXED_FREQ;
-      out.key       = val;
-      out.preset    = String(_sw.getReceivedProtocol());
-      out.protocol  = "RcSwitch";
-      out.te        = (int)_sw.getReceivedDelay();
-      out.bit       = (int)_sw.getReceivedBitlength();
-      out.rawData   = "";
-      if (_sw.getReceivedProtocol() == 23) {
-        KeeloqUtil::unpack(val, out.fix, out.encrypted, out.btn, out.serial);
-        KeeloqUtil::identify(out);
-      }
-      _sw.resetAvailable();
-      return true;
+  static int32_t frame[1024];
+  const uint16_t n = _rmt.readFrame(frame, 1024);
+  if (n < 8) return false;
+
+  // RcSwitch table + KeeLoq (proto 23) decoded from the captured frame.
+  RCSwitchUtil::Decoded d;
+  if (RCSwitchUtil::decodeStream(frame, n, d)) {
+    out.frequency = FIXED_FREQ;
+    out.key       = d.value;
+    out.preset    = String(d.proto);
+    out.protocol  = "RcSwitch";
+    out.te        = (int)d.delay;
+    out.bit       = (int)d.bits;
+    out.rawData   = "";
+    if (d.proto == 23) {
+      KeeloqUtil::unpack(d.value, out.fix, out.encrypted, out.btn, out.serial);
+      KeeloqUtil::identify(out);
     }
-    _sw.resetAvailable();
+    return true;
   }
 
-  if (_rxFilter == RX_FILTER_RAW && _sw.RAWavailable()) {
-    delay(400);  // let trailing pulses settle
-    unsigned int* raw = _sw.getRAWReceivedRawdata();
-    String rawStr;
-    for (int i = 0; raw[i] != 0; i++) {
-      if (i > 0) rawStr += ' ';
-      int sign = (i % 2 == 0) ? 1 : -1;
-      rawStr += String(sign * (int)raw[i]);
+  if (_rxFilter == RX_FILTER_RAW) {
+    out = Signal();
+    out.frequency = FIXED_FREQ;
+    out.preset    = "0";
+    out.protocol  = "RAW";
+    String s;
+    s.reserve((size_t)n * 6);
+    for (uint16_t i = 0; i < n; i++) {
+      if (i) s += ' ';
+      s += String((int)frame[i]);
     }
-    if (rawStr.length() > 0) {
-      out.frequency = FIXED_FREQ;
-      out.preset    = "0";
-      out.protocol  = "RAW";
-      out.rawData   = rawStr;
-      out.key = 0; out.te = 0; out.bit = 0;
-      _sw.resetAvailable();
-      return true;
-    }
-    _sw.resetAvailable();
+    out.rawData = s;
+    return true;
   }
 
   return false;
 }
 
 void M5RF433Util::endReceive() {
-  _sw.disableReceive();
+  _rmt.end();
 }
 
 // ── Send ─────────────────────────────────────────────────────────────────────
@@ -91,15 +84,8 @@ void M5RF433Util::endReceive() {
 void M5RF433Util::sendSignal(const Signal& sig) {
   if (!_initialized || _txPin < 0) return;
 
-  // Detaching RX while transmitting prevents the ISR firing on our own pulses.
-  bool rxWasActive = false;
-  if (_rxPin >= 0) {
-    _sw.disableReceive();
-    rxWasActive = true;
-  }
-
-  pinMode(_txPin, OUTPUT);
-  digitalWrite(_txPin, LOW);
+  const bool rxWasActive = _rmt.active();   // RX installed → restore it after TX
+  _rmt.beginTx((gpio_num_t)_txPin);          // (ends RX first if it was active)
 
   if (sig.protocol == "RAW") {
     _sendRaw(sig.rawData);
@@ -107,31 +93,31 @@ void M5RF433Util::sendSignal(const Signal& sig) {
     _sendRcSwitch(sig);
   }
 
+  _rmt.end();
   digitalWrite(_txPin, LOW);
-
-  if (rxWasActive) {
-    _sw.enableReceive(_rxPin);
-    _sw.resetAvailable();
-  }
+  if (rxWasActive) beginReceive();
 }
 
 void M5RF433Util::_sendRaw(const String& data) {
+  // Parse the signed-duration stream and clock it out over RMT.
+  uint16_t count = data.length() ? 1 : 0;
+  for (int i = 0; i < (int)data.length(); i++) if (data[i] == ' ') count++;
+
+  int32_t* tx = (int32_t*)malloc((size_t)count * sizeof(int32_t));
+  if (!tx) return;
+  uint16_t k = 0;
   int start = 0;
-  for (int i = 0; i <= (int)data.length(); i++) {
+  for (int i = 0; i <= (int)data.length() && k < count; i++) {
     if (i == (int)data.length() || data[i] == ' ') {
       if (i > start) {
         int32_t val = data.substring(start, i).toInt();
-        if (val > 0) {
-          digitalWrite(_txPin, HIGH);
-          delayMicroseconds((uint32_t)val);
-        } else if (val < 0) {
-          digitalWrite(_txPin, LOW);
-          delayMicroseconds((uint32_t)(-val));
-        }
+        if (val != 0) tx[k++] = val;
       }
       start = i + 1;
     }
   }
+  _rmt.sendDurations(tx, k);
+  free(tx);
 }
 
 void M5RF433Util::_sendRcSwitch(const Signal& sig) {
@@ -148,12 +134,13 @@ void M5RF433Util::_sendRcSwitch(const Signal& sig) {
   }
 
   RCSwitchUtil sw;
-  sw.enableTransmit(_txPin);
   sw.setProtocol(protoNum);
   if (sig.te > 0) sw.setPulseLength(sig.te);
   sw.setRepeatTransmit(10);
-  sw.send(sig.key, (unsigned int)sig.bit);
-  sw.disableTransmit();
+
+  static int32_t tx[2048];
+  const uint16_t k = sw.encodeToDurations(sig.key, (unsigned int)sig.bit, tx, 2048);
+  _rmt.sendDurations(tx, k);
 }
 
 // ── Jammer ───────────────────────────────────────────────────────────────────

--- a/firmware/src/utils/rf/M5RF433Util.h
+++ b/firmware/src/utils/rf/M5RF433Util.h
@@ -1,6 +1,6 @@
 //
 // M5 RF433 Utility — send/receive raw RF signals on M5 RF433T/R
-// (single-pin OOK TX + ISR-based RX, fixed 433.92 MHz).
+// (OOK TX + RX over the RMT peripheral, fixed 433.92 MHz).
 //
 // Mirrors CC1101Util's surface so screens can reuse the same Signal type
 // and the same .sub file format. Hardware is purely GPIO bit-bang:
@@ -45,7 +45,7 @@ private:
   int8_t _txPin = -1;
   int8_t _rxPin = -1;
   bool   _initialized = false;
-  RCSwitchUtil _sw;
+  RmtRf    _rmt;   // hardware RMT capture/replay (separate TX + RX GPIOs)
   RxFilter _rxFilter = RX_FILTER_RAW;
 
   void _sendRaw(const String& rawData);

--- a/firmware/src/utils/rf/RCSwitchUtil.cpp
+++ b/firmware/src/utils/rf/RCSwitchUtil.cpp
@@ -37,16 +37,7 @@ static constexpr int kNumProto = sizeof(kProto) / sizeof(kProto[0]);
 
 // ── Static storage ────────────────────────────────────────────────────────
 
-volatile unsigned long long RCSwitchUtil::_rxValue      = 0;
-volatile unsigned int       RCSwitchUtil::_rxBits        = 0;
-volatile unsigned int       RCSwitchUtil::_rxDelay       = 0;
-volatile unsigned int       RCSwitchUtil::_rxProto       = 0;
-int                         RCSwitchUtil::_rxTolerance   = 60;
-int                         RCSwitchUtil::_rxPin         = -1;
-unsigned int  RCSwitchUtil::_timings[RCSwitchUtil::kMaxChanges]  = {};
-unsigned int  RCSwitchUtil::_rawTimings[RCSwitchUtil::kRawMax]   = {};
-unsigned long RCSwitchUtil::_lastMicros    = 0;
-unsigned int  RCSwitchUtil::_rawTransitions= 0;
+int RCSwitchUtil::_rxTolerance = 60;
 
 // ── Constructor ───────────────────────────────────────────────────────────
 
@@ -61,11 +52,6 @@ void RCSwitchUtil::setProtocol(int n) {
   _proto = kProto[n - 1];
 }
 
-void RCSwitchUtil::setProtocol(int n, int pulseLength) {
-  setProtocol(n);
-  _proto.pulseLength = (uint16_t)pulseLength;
-}
-
 void RCSwitchUtil::setPulseLength(int us) {
   _proto.pulseLength = (uint16_t)us;
 }
@@ -74,198 +60,119 @@ void RCSwitchUtil::setRepeatTransmit(int n) {
   _nRepeat = n;
 }
 
-// ── Transmit ──────────────────────────────────────────────────────────────
+// ── Transmit (encode only) ──────────────────────────────────────────────────
 
-void RCSwitchUtil::enableTransmit(int pin) {
-  _txPin = pin;
-  pinMode(pin, OUTPUT);
-}
+// Encode the RcSwitch waveform as a signed-duration stream (+HIGH / -LOW µs) for
+// hardware-timed RMT transmit. Returns the number of durations written.
+uint16_t RCSwitchUtil::encodeToDurations(unsigned long long code, unsigned int bits,
+                                         int32_t* out, uint16_t maxLen) {
+  const bool     keeloq = (_proto.syncFactor.high == 0);
+  const uint32_t pl     = _proto.pulseLength;
+  const int32_t  sHi    = _proto.invertedSignal ? -1 : 1;   // level of the 'high' part
+  const int32_t  sLo    = _proto.invertedSignal ?  1 : -1;  // level of the 'low' part
 
-void RCSwitchUtil::disableTransmit() {
-  _txPin = -1;
-}
+  uint16_t k = 0;
+  auto emit = [&](uint8_t high, uint8_t low) {
+    if (high && k < maxLen) out[k++] = sHi * (int32_t)(pl * high);
+    if (low  && k < maxLen) out[k++] = sLo * (int32_t)(pl * low);
+  };
 
-void RCSwitchUtil::_transmit(HighLow pulses) {
-  uint8_t hi = _proto.invertedSignal ? LOW : HIGH;
-  uint8_t lo = _proto.invertedSignal ? HIGH : LOW;
-
-  if (pulses.high) {
-    digitalWrite(_txPin, hi);
-    uint32_t us = (uint32_t)_proto.pulseLength * pulses.high;
-    delay(us / 1000);
-    delayMicroseconds(us % 1000);
-  }
-  if (pulses.low) {
-    digitalWrite(_txPin, lo);
-    uint32_t us = (uint32_t)_proto.pulseLength * pulses.low;
-    delay(us / 1000);
-    delayMicroseconds(us % 1000);
-  }
-}
-
-void RCSwitchUtil::send(unsigned long long code, unsigned int bits) {
-  if (_txPin < 0) return;
-
-  bool keeloq = (_proto.syncFactor.high == 0);
-
-  for (int rep = 0; rep < _nRepeat; rep++) {
+  for (int rep = 0; rep < _nRepeat && k < maxLen; rep++) {
     if (keeloq) {
-      for (int i = 0; i < 11; i++) _transmit({ 1, 1 });
-      _transmit({ 1, 10 });
+      for (int i = 0; i < 11; i++) emit(1, 1);
+      emit(1, 10);
     }
-
     for (int i = (int)bits - 1; i >= 0; i--) {
-      if (code & (1ULL << i))
-        _transmit(_proto.one);
-      else
-        _transmit(_proto.zero);
+      if (code & (1ULL << i)) emit(_proto.one.high,  _proto.one.low);
+      else                    emit(_proto.zero.high, _proto.zero.low);
     }
-
     if (!keeloq) {
-      _transmit(_proto.syncFactor);
+      emit(_proto.syncFactor.high, _proto.syncFactor.low);
     } else {
-      _transmit(_proto.one);
-      _transmit({ 1, 0 });
-      _transmit({ 0, 40 });
+      emit(_proto.one.high, _proto.one.low);
+      emit(1, 0);
+      emit(0, 40);
     }
   }
-
-  digitalWrite(_txPin, LOW);
+  return k;
 }
 
-// ── Receive ───────────────────────────────────────────────────────────────
+// ── Pure decode (from an RMT-captured frame) ───────────────────────────────
 
-void RCSwitchUtil::enableReceive(int pin) {
-  _rxPin = pin;
-  _rxValue = 0;
-  _rxBits  = 0;
-  attachInterrupt(digitalPinToInterrupt(pin), _isr, CHANGE);
-}
-
-void RCSwitchUtil::disableReceive() {
-  if (_rxPin >= 0) {
-    detachInterrupt(digitalPinToInterrupt(_rxPin));
-    _rxPin = -1;
-  }
-}
-
-void RCSwitchUtil::resetAvailable() {
-  _rawTransitions = 0;
-  _rxValue = 0;
-  memset(_rawTimings, 0, sizeof(_rawTimings));
-  _lastMicros = micros() + 10000; // 10ms settle
-}
-
-bool RCSwitchUtil::available() {
-  return _rxValue != 0;
-}
-
-bool RCSwitchUtil::RAWavailable() {
-  return _rawTransitions > 10 && (micros() - _lastMicros) > 100000;
-}
-
-// ── Protocol decoder (called from ISR) ────────────────────────────────────
-
-bool RCSwitchUtil::_receiveProtocol(int p, unsigned int changeCount) {
+// Matches one protocol `p` against a caller-supplied `timings` buffer
+// (magnitudes; timings[0] = leading separator gap) and writes into `out`.
+// Requires a real bit count so RMT noise bursts don't match with zero payload.
+bool RCSwitchUtil::_matchProtocol(int p, const unsigned int* timings,
+                                  unsigned int changeCount, Decoded& out) {
   const Protocol& pro = kProto[p - 1];
 
   unsigned long long code = 0;
   const unsigned int syncLen = (pro.syncFactor.low > pro.syncFactor.high)
                                ? pro.syncFactor.low : pro.syncFactor.high;
-  unsigned int te  = _timings[0] / syncLen;
+  unsigned int te  = syncLen ? timings[0] / syncLen : 0;
   unsigned int tol = te * _rxTolerance / 100;
 
-  // Protocol 23 (KeeLoq): fixed timing
-  if (p == 23) { te = 400; tol = 400 * _rxTolerance / 100; }
+  if (p == 23) { te = 400; tol = 400 * _rxTolerance / 100; }   // KeeLoq fixed te
+  if (te == 0) return false;
 
   unsigned int firstData = pro.invertedSignal ? 2u : 1u;
   if (p == 23) firstData = 25;
+  if (changeCount <= firstData + 1) return false;
 
   unsigned int numBits = 0;
   for (unsigned int i = firstData; i < changeCount - 1 && numBits < 64; i += 2, numBits++) {
     code <<= 1ULL;
-    if (abs((int)_timings[i]     - (int)(te * pro.zero.high)) < (int)tol &&
-        abs((int)_timings[i + 1] - (int)(te * pro.zero.low))  < (int)tol) {
+    if (abs((int)timings[i]     - (int)(te * pro.zero.high)) < (int)tol &&
+        abs((int)timings[i + 1] - (int)(te * pro.zero.low))  < (int)tol) {
       // zero — no change
-    } else if (abs((int)_timings[i]     - (int)(te * pro.one.high)) < (int)tol &&
-               abs((int)_timings[i + 1] - (int)(te * pro.one.low))  < (int)tol) {
+    } else if (abs((int)timings[i]     - (int)(te * pro.one.high)) < (int)tol &&
+               abs((int)timings[i + 1] - (int)(te * pro.one.low))  < (int)tol) {
       code |= 1ULL;
     } else {
       return false;
     }
   }
 
-  if (changeCount > 7) {
-    _rxValue = code;
-    _rxBits  = numBits;
-    _rxDelay = te;
-    _rxProto = (unsigned int)p;
+  if (numBits >= 8) {
+    out.value = code;
+    out.bits  = numBits;
+    out.delay = te;
+    out.proto = (unsigned int)p;
     return true;
   }
   return false;
 }
 
-// ── ISR ───────────────────────────────────────────────────────────────────
+bool RCSwitchUtil::decodeStream(const int32_t* dur, uint16_t n, Decoded& out) {
+  if (n < 8) return false;
 
-void RCSwitchUtil::_isr() {
-  static unsigned int changeCount    = 0;
-  static unsigned int changeRAWCount = 0;
-  static unsigned long lastTime      = 0;
-  static unsigned int repeatCount    = 0;
+  static unsigned int timings[kMaxChanges];
 
-  static unsigned long rawPreBuff[kRawPreSize] = {};
-  static unsigned int  rawPreCount = 0;
+  // Protocol try-order: KeeLoq (23) first so it is labelled correctly and never
+  // stolen by an earlier generic protocol; then 1..22.
+  auto tryAll = [&](unsigned int cc) -> bool {
+    if (_matchProtocol(23, timings, cc, out)) return true;
+    for (int p = 1; p < kNumProto; p++)
+      if (_matchProtocol(p, timings, cc, out)) return true;
+    return false;
+  };
 
-  const unsigned long now      = micros();
-  const unsigned int  duration = (unsigned int)(now - lastTime);
+  int prevSep = -1;
+  for (uint16_t i = 0; i < n; i++) {
+    const unsigned int mag = (unsigned int)(dur[i] < 0 ? -dur[i] : dur[i]);
+    if (mag <= kSepLimit) continue;            // not a separator
 
-  if (duration > kSepLimit) {
-    if (repeatCount == 0 ||
-        (unsigned int)abs((int)duration - (int)_timings[0]) < 200) {
-      repeatCount++;
-      if (repeatCount == 2) {
-        for (int i = 1; i <= kNumProto; i++) {
-          if (_receiveProtocol(i, changeCount)) break;
+    if (prevSep >= 0) {
+      unsigned int cc = (unsigned int)(i - prevSep);   // timings[0] = separator
+      if (cc >= 6 && cc <= kMaxChanges) {
+        for (unsigned int j = 0; j < cc; j++) {
+          const int32_t v = dur[prevSep + j];
+          timings[j] = (unsigned int)(v < 0 ? -v : v);
         }
-        repeatCount = 0;
+        if (tryAll(cc)) return true;
       }
     }
-    changeCount = 0;
+    prevSep = i;
   }
-
-  if (changeCount >= kMaxChanges) {
-    changeCount  = 0;
-    repeatCount  = 0;
-  }
-  _timings[changeCount++] = duration;
-
-  // RAW capture — reset on very long gaps (>400ms)
-  if (duration > 400000) {
-    changeRAWCount = 0;
-    memset(_rawTimings, 0, sizeof(_rawTimings));
-    memset(rawPreBuff,  0, sizeof(rawPreBuff));
-    rawPreCount = 0;
-    lastTime = now;
-    return;
-  }
-
-  // Sliding-window noise filter: require sum of last kRawPreSize durations >= threshold
-  rawPreCount = rawPreCount + duration - rawPreBuff[0];
-  for (unsigned int i = 0; i < kRawPreSize - 1; i++) rawPreBuff[i] = rawPreBuff[i + 1];
-  rawPreBuff[kRawPreSize - 1] = duration;
-
-  if (rawPreCount >= kRawPreSize * kNoiseThresh) {
-    if (changeRAWCount >= kRawMax) changeRAWCount = 0;
-    if (duration > kNoiseThresh) {
-      _rawTimings[changeRAWCount++] = duration;
-      if (changeRAWCount == 15) {
-        _rawTransitions = 15;
-        _lastMicros     = now;
-      }
-    }
-  } else {
-    changeRAWCount = 0;
-  }
-
-  lastTime = now;
+  return false;
 }

--- a/firmware/src/utils/rf/RCSwitchUtil.h
+++ b/firmware/src/utils/rf/RCSwitchUtil.h
@@ -1,7 +1,10 @@
 //
-// RCSwitchUtil — RC switch encode/decode for CC1101
-// Derived from RCSwitch by Suat Özgür (LGPL v2.1)
-// Stripped to send + interrupt-based receive only.
+// RCSwitchUtil — RC switch protocol table + encode/decode.
+// Derived from RCSwitch by Suat Özgür (LGPL v2.1).
+//
+// Timing now comes from the RMT peripheral (see RmtRf): transmit encodes a
+// waveform to signed durations for hardware-timed replay, and receive decodes a
+// captured frame with decodeStream(). No interrupt-driven capture or bit-bang.
 //
 
 #pragma once
@@ -21,55 +24,41 @@ public:
 
   RCSwitchUtil();
 
-  // ── Transmit ──────────────────────────────────────────────────────────────
-  void enableTransmit(int pin);
-  void disableTransmit();
+  // ── Transmit (encode only — RmtRf clocks it out) ───────────────────────────
   void setProtocol(int n);
-  void setProtocol(int n, int pulseLength);
   void setPulseLength(int us);
   void setRepeatTransmit(int n);
-  void send(unsigned long long code, unsigned int bits);
+  // Encode the RcSwitch waveform as signed durations (+HIGH / -LOW µs) for RMT TX.
+  uint16_t encodeToDurations(unsigned long long code, unsigned int bits,
+                             int32_t* out, uint16_t maxLen);
 
-  // ── Receive ───────────────────────────────────────────────────────────────
-  void enableReceive(int pin);
-  void disableReceive();
-  void resetAvailable();
+  // ── Decode (pure — from an RMT-captured frame) ─────────────────────────────
+  // Result of decoding one of the kProto protocols out of a raw pulse train.
+  struct Decoded {
+    unsigned long long value = 0;
+    unsigned int       bits  = 0;
+    unsigned int       delay = 0;   // te (µs)
+    unsigned int       proto = 0;   // 1..kNumProto, 0 = no match
+  };
 
-  bool available();
-  bool RAWavailable();
-
-  unsigned long long getReceivedValue()    { return _rxValue; }
-  unsigned int       getReceivedBitlength(){ return _rxBits;  }
-  unsigned int       getReceivedDelay()    { return _rxDelay; }
-  unsigned int       getReceivedProtocol() { return _rxProto; }
-  unsigned int*      getRAWReceivedRawdata(){ return _rawTimings; }
+  // Decode a completed frame captured by RMT: `dur` holds signed durations
+  // (+HIGH / -LOW µs) alternating. The frame is split on separator gaps
+  // (> kSepLimit) into per-repeat segments; each segment is matched against the
+  // protocol table (KeeLoq/proto-23 first so it is never mis-grabbed). Returns
+  // true and fills `out` on the first match. Pure/reentrant — no ISR state.
+  static bool decodeStream(const int32_t* dur, uint16_t n, Decoded& out);
 
 private:
-  int      _txPin    = -1;
   int      _nRepeat  = 10;
   Protocol _proto;
 
-  void _transmit(HighLow pulses);
+  // Pure protocol matcher used by decodeStream(): matches one protocol `p`
+  // against `timings` (magnitudes, timings[0] = leading separator gap).
+  static bool _matchProtocol(int p, const unsigned int* timings,
+                             unsigned int changeCount, Decoded& out);
 
-  static void _isr();
-  static bool           _receiveProtocol(int p, unsigned int changeCount);
+  static int _rxTolerance;   // % timing tolerance for decode
 
-  // shared ISR state
-  static volatile unsigned long long _rxValue;
-  static volatile unsigned int       _rxBits;
-  static volatile unsigned int       _rxDelay;
-  static volatile unsigned int       _rxProto;
-  static int                         _rxTolerance;
-  static int                         _rxPin;
-
-  static constexpr unsigned int kSepLimit    = 4300;
-  static constexpr unsigned int kMaxChanges  = 157;
-  static constexpr unsigned int kRawMax      = 512;
-  static constexpr unsigned int kNoiseThresh = 50;
-  static constexpr unsigned int kRawPreSize  = 5;
-
-  static unsigned int  _timings[kMaxChanges];
-  static unsigned int  _rawTimings[kRawMax];
-  static unsigned long _lastMicros;
-  static unsigned int  _rawTransitions;
+  static constexpr unsigned int kSepLimit   = 4300;   // gap that separates repeats
+  static constexpr unsigned int kMaxChanges = 157;    // max edges per segment
 };

--- a/firmware/src/utils/rf/RmtRf.cpp
+++ b/firmware/src/utils/rf/RmtRf.cpp
@@ -1,0 +1,151 @@
+//
+// RmtRf — see RmtRf.h. Legacy RMT driver (IDF 4.4).
+//
+
+#include "RmtRf.h"
+
+// ── RX ────────────────────────────────────────────────────────────────────
+
+bool RmtRf::beginRx(gpio_num_t gpio, uint16_t idleUs) {
+  end();
+
+  rmt_config_t c = RMT_DEFAULT_CONFIG_RX(gpio, RX_CH);
+  c.clk_div                       = CLK_DIV;
+  c.mem_block_num                 = 4;          // long frames (KeeLoq / brand)
+  c.rx_config.filter_en           = true;
+  c.rx_config.filter_ticks_thresh = FILTER_TK;  // drop sub-~3 µs noise glitches
+  c.rx_config.idle_threshold      = idleUs;     // end-of-frame in hardware
+
+  if (rmt_config(&c) != ESP_OK) return false;
+  // Ring buffer sized for a good backlog of frames so a burst can't overrun it.
+  if (rmt_driver_install(c.channel, 4096 * sizeof(rmt_item32_t), 0) != ESP_OK)
+    return false;
+
+  _ch = c.channel;
+  rmt_get_ringbuf_handle(_ch, &_rb);
+  rmt_rx_start(_ch, true);
+
+  _installed = true;
+  _isRx      = true;
+  return true;
+}
+
+void RmtRf::pauseRx() {
+  if (_installed && _isRx) rmt_rx_stop(_ch);
+}
+
+void RmtRf::resumeRx() {
+  if (!_installed || !_isRx || !_rb) return;
+  // Drop any stale frames captured just before the pause, then restart clean.
+  size_t bytes;
+  void* it;
+  while ((it = xRingbufferReceive(_rb, &bytes, 0)) != nullptr)
+    vRingbufferReturnItem(_rb, it);
+  rmt_rx_start(_ch, true);
+}
+
+uint16_t RmtRf::readFrame(int32_t* out, uint16_t maxLen) {
+  if (!_installed || !_isRx || !_rb) return 0;
+
+  size_t bytes = 0;
+  rmt_item32_t* items =
+      (rmt_item32_t*)xRingbufferReceive(_rb, &bytes, 0);  // 0 = non-blocking
+  if (!items) return 0;
+
+  // Defensive: never trust the reported size to walk past maxLen entries.
+  size_t nItems = bytes / sizeof(rmt_item32_t);
+  if (nItems > (size_t)maxLen) nItems = maxLen;
+  uint16_t k = 0;
+  for (size_t i = 0; i < nItems && k < maxLen; i++) {
+    // Each item packs two half-symbols. A zero duration marks the frame end.
+    if (items[i].duration0 == 0) break;
+    out[k++] = items[i].level0 ? (int32_t)items[i].duration0
+                               : -(int32_t)items[i].duration0;
+    if (k >= maxLen) break;
+    if (items[i].duration1 == 0) break;
+    out[k++] = items[i].level1 ? (int32_t)items[i].duration1
+                               : -(int32_t)items[i].duration1;
+  }
+
+  vRingbufferReturnItem(_rb, (void*)items);
+  return k;
+}
+
+// ── TX ────────────────────────────────────────────────────────────────────
+
+bool RmtRf::beginTx(gpio_num_t gpio) {
+  end();
+
+  rmt_config_t c = RMT_DEFAULT_CONFIG_TX(gpio, TX_CH);
+  c.clk_div                   = CLK_DIV;
+  c.tx_config.carrier_en      = false;             // CC1101 supplies the carrier
+  c.tx_config.idle_output_en  = true;
+  c.tx_config.idle_level      = RMT_IDLE_LEVEL_LOW;
+
+  if (rmt_config(&c) != ESP_OK) return false;
+  if (rmt_driver_install(c.channel, 0, 0) != ESP_OK) return false;
+
+  _ch        = c.channel;
+  _installed = true;
+  _isRx      = false;
+  return true;
+}
+
+void RmtRf::sendDurations(const int32_t* dur, uint16_t n) {
+  if (!_installed || _isRx || n == 0) return;
+
+  // Each interval becomes one or more half-symbols (an interval > MAX_TICK is
+  // split). Size the item buffer exactly, then heap-allocate it — TX is
+  // infrequent, so this avoids a large permanently-resident static buffer.
+  size_t halves = 0;
+  for (uint16_t i = 0; i < n; i++) {
+    uint32_t us = (uint32_t)(dur[i] < 0 ? -dur[i] : dur[i]);
+    if (us == 0) us = 1;
+    halves += (us + MAX_TICK - 1) / MAX_TICK;
+  }
+  const size_t items = halves / 2 + 2;   // 2 half-symbols per item, + slack/terminator
+  rmt_item32_t* buf = (rmt_item32_t*)calloc(items, sizeof(rmt_item32_t));
+  if (!buf) return;
+
+  int  idx       = 0;
+  bool fillFirst = true;   // next half-symbol goes into slot 0 of the item
+  for (uint16_t i = 0; i < n; i++) {
+    const uint8_t lvl = dur[i] > 0 ? 1 : 0;
+    uint32_t      us  = (uint32_t)(dur[i] > 0 ? dur[i] : -dur[i]);
+    if (us == 0) us = 1;
+
+    while (us > 0) {
+      const uint16_t chunk = us > MAX_TICK ? MAX_TICK : (uint16_t)us;
+      if (fillFirst) {
+        buf[idx].level0    = lvl;
+        buf[idx].duration0 = chunk;
+        buf[idx].level1    = lvl;   // provisional; overwritten if a second half comes
+        buf[idx].duration1 = 0;
+      } else {
+        buf[idx].level1    = lvl;
+        buf[idx].duration1 = chunk;
+        idx++;
+      }
+      fillFirst = !fillFirst;
+      us -= chunk;
+    }
+  }
+  if (!fillFirst) idx++;  // include the trailing half-filled item (duration1 = 0 ends TX)
+
+  if (idx > 0) {
+    rmt_write_items(_ch, buf, idx, true);   // true = block until sent
+    rmt_wait_tx_done(_ch, portMAX_DELAY);
+  }
+  free(buf);
+}
+
+// ── Lifecycle ───────────────────────────────────────────────────────────────
+
+void RmtRf::end() {
+  if (!_installed) return;
+  if (_isRx) rmt_rx_stop(_ch);
+  rmt_driver_uninstall(_ch);
+  _installed = false;
+  _ch        = RMT_CHANNEL_MAX;
+  _rb        = nullptr;
+}

--- a/firmware/src/utils/rf/RmtRf.h
+++ b/firmware/src/utils/rf/RmtRf.h
@@ -1,0 +1,70 @@
+//
+// RmtRf — Sub-GHz OOK capture/replay over the ESP32 RMT peripheral (legacy
+// IDF 4.4 driver: driver/rmt.h, rmt_item32_t, ring buffer).
+//
+// Replaces the attachInterrupt() edge timing used by RCSwitchUtil / CC1101Util
+// with hardware-timed capture (RX) and hardware-timed transmit (TX). The chip's
+// OOK carrier still comes from the CC1101; GDO0 carries the async data only, so
+// TX runs with carrier_en = false and RX reads raw pulse durations.
+//
+// One RMT clock tick = 1 µs (clk_div = 80 on the 80 MHz APB). A single interval
+// is capped at MAX_TICK µs (15-bit duration field); longer gaps are split across
+// items on TX and clamped by the caller on RX.
+//
+// Channels: RX on a receive-capable channel, TX on a transmit-capable one.
+// ESP32 (8 bidirectional) and ESP32-S3 (TX 0-3 / RX 4-7) both satisfy CH4/CH0.
+//
+
+#pragma once
+#include <Arduino.h>
+#include "driver/rmt.h"
+
+class RmtRf {
+public:
+  static constexpr uint32_t CLK_DIV   = 80;      // 1 tick = 1 µs
+  static constexpr uint16_t MAX_TICK  = 32767;   // 15-bit duration ceiling (µs)
+  static constexpr uint16_t IDLE_US   = 20000;   // default RX gap that closes a frame
+  static constexpr uint8_t  FILTER_TK = 255;     // RX glitch filter (APB ticks, ~3 µs)
+
+#if CONFIG_IDF_TARGET_ESP32C3 || CONFIG_IDF_TARGET_ESP32C6
+  static constexpr rmt_channel_t RX_CH = RMT_CHANNEL_2;
+  static constexpr rmt_channel_t TX_CH = RMT_CHANNEL_0;
+#else
+  static constexpr rmt_channel_t RX_CH = RMT_CHANNEL_4;
+  static constexpr rmt_channel_t TX_CH = RMT_CHANNEL_0;
+#endif
+
+  // ── RX ──────────────────────────────────────────────────────────────────
+  // Install the RX channel + ring buffer on `gpio` and start receiving. `idleUs`
+  // is the silence that closes a frame — keep it short (a few ms) when capturing
+  // continuously so per-repeat frames drain and RMT memory never overflows.
+  bool beginRx(gpio_num_t gpio, uint16_t idleUs = IDLE_US);
+  // Non-blocking: pull one completed frame from the ring buffer into `out` as
+  // signed durations (+HIGH / -LOW) in µs. Returns the number of entries, or 0
+  // when no frame is ready. `out` must hold at least `maxLen` int32_t.
+  uint16_t readFrame(int32_t* out, uint16_t maxLen);
+
+  // Gate capture without uninstalling: pauseRx() stops the receiver (so squelch
+  // noise isn't captured and can't overflow the buffer); resumeRx() flushes any
+  // stale frames and restarts. Use RSSI to drive these around a real carrier.
+  void pauseRx();
+  void resumeRx();
+
+  // ── TX ──────────────────────────────────────────────────────────────────
+  // Install the TX channel on `gpio` (carrier off — the CC1101 supplies it).
+  bool beginTx(gpio_num_t gpio);
+  // Blocking: transmit the signed-duration stream (+HIGH / -LOW µs), splitting
+  // any interval longer than MAX_TICK across multiple RMT items.
+  void sendDurations(const int32_t* dur, uint16_t n);
+
+  // Stop + uninstall whichever channel is active. Safe to call when idle.
+  void end();
+
+  bool active() const { return _installed; }
+
+private:
+  bool            _installed = false;
+  bool            _isRx      = false;
+  rmt_channel_t   _ch        = RMT_CHANNEL_MAX;
+  RingbufHandle_t _rb        = nullptr;
+};


### PR DESCRIPTION
## Summary
Migrates the Sub-GHz RF path from interrupt/RCSwitch + bit-bang to the ESP32 **RMT** peripheral for capture and replay, and adds an **OOK receive-sensitivity preset** plus a runtime **RSSI threshold** menu.

### RMT migration
- New `RmtRf` class (legacy IDF 4.4 `driver/rmt.h`): hardware-timed RX capture and TX replay on GDO0 — no more `attachInterrupt`/`micros()` edge timing or `digitalWrite`+`delayMicroseconds` bit-bang (immune to WiFi/interrupt jitter, no missed edges).
- `pollReceive` / Record RAW feed the existing `SubGhzDecoders` (Flipper decoders) from RMT frames, RSSI-gated so squelch noise is never captured.
- Record RAW uses an adaptive noise-floor gate; `.sub` files load via a streaming parser to avoid OOM on long RAW captures.
- `RCSwitchUtil` refactored to `decodeStream`/`encodeToDurations`; `M5RF433Util` migrated too.

### OOK sensitivity + RSSI menu
- Port Bruce's `cc1101ApplyFixedFreqOokPreset()` AGC/front-end registers (AGCCTRL2=0x03 full DVGA gain, FIFOTHR ADC retention, FREND1 SmartRF OOK), re-applied after every `Init()` — the ELECHOUSE FSK defaults capped the gain, so weak OOK signals only decoded with the transmitter right on the antenna.
- Narrow the fixed-freq RX to RxBW 135 kHz / 5 kBaud.
- Runtime `RSSI_THRESHOLD` with an "RSSI Threshold" entry in the Frequency menu (-55..-85 dBm) gating Receive arming + Detect Freq.

## Testing
Built and flashed to `m5_cardputer_adv`; verified on hardware.

