### PR TITLE
partitions(8mb): grow app0 3MB -> 4MB (shrink LittleFS)

### DIFF
--- a/firmware/partitions_8mb.csv
+++ b/firmware/partitions_8mb.csv
@@ -1,6 +1,6 @@
 # Name,     Type, SubType,  Offset,   Size,    Flags
 nvs,        data, nvs,      0x9000,   0x4000,
 otadata,    data, ota,      0xD000,   0x2000,
-app0,       app,  ota_0,    0x10000,  0x300000,
-spiffs,     data, spiffs,   0x310000, 0x4E0000,
+app0,       app,  ota_0,    0x10000,  0x400000,
+spiffs,     data, spiffs,   0x410000, 0x3E0000,
 coredump,   data, coredump, 0x7F0000, 0x10000,


### PR DESCRIPTION
## What changes

Grows the application partition (`app0`) from **3 MB → 4 MB** in the 8 MB layout, shrinking the LittleFS/spiffs partition from ~4.9 MB → ~3.9 MB.

```
app0    0x10000  0x300000 -> 0x400000   (3MB -> 4MB)
spiffs  0x310000 0x4E0000 -> 0x410000 0x3E0000
```

## Why

- The build ships no filesystem image (there is no `data/`); LittleFS is only a runtime fallback store (SD is primary), so ~4.9 MB sat essentially idle.
- Feature-rich boards were butting against the 3 MB app ceiling (e.g. `m5_cardputer_adv` reached 99%+ of `app0`). With 4 MB there is ~1 MB of headroom.

## Impact

- Shared by the 4 M5 8 MB boards (`m5_cardputer`, `m5_cardputer_adv`, `m5sticks3`, `m5stickcplus_2`) — all gain the headroom.
- Because the partition table changes, this requires a **full flash** (not OTA-only over the old layout). LittleFS is reformatted on the next boot (it was empty).
- `nvs`, `otadata` and `coredump` offsets are left intact.