### PR TITLE
tvbgone: universal multi-device power-off codes (port of Bruce #2614)

### DIFF
--- a/firmware/src/utils/ir/IRUtil.cpp
+++ b/firmware/src/utils/ir/IRUtil.cpp
@@ -301,40 +301,39 @@ String IRUtil::signalLabel(const Signal& sig) {
 
 #include "TVBGoneData.h"
 
-void IRUtil::startTvBGone(uint8_t region, void (*progressCb)(uint8_t, uint8_t),
-                           bool (*cancelCb)()) {
-  if (!_sender) return;
+namespace {
 
-  const IrCode* const* codes;
-  uint8_t numCodes;
+// Gap between codes: long enough for an IR receiver to register each burst,
+// short enough to keep the full sweep brisk.
+constexpr uint32_t kTvbGap = 200;
 
-  if (region == 1) { // NA
-    codes = NApowerCodes;
-    numCodes = sizeof(NApowerCodes) / sizeof(NApowerCodes[0]);
-  } else { // EU
-    codes = EUpowerCodes;
-    numCodes = sizeof(EUpowerCodes) / sizeof(EUpowerCodes[0]);
+// Report cumulative progress across the whole sweep, throttled to keep UI
+// overhead down. `overall`/`total` stay < 255 (≈200 codes worst case).
+inline void tvbProgress(void (*progressCb)(uint8_t, uint8_t), uint16_t overall,
+                        uint16_t total) {
+  if (progressCb && (overall % 3 == 0 || overall == total)) {
+    progressCb((uint8_t)overall, (uint8_t)total);
   }
+}
 
+// Send a batch of parsed (bit-compressed) codes — times are stored /10, so
+// each pair is multiplied back by 10 before transmit. Returns false if the
+// user cancelled mid-batch.
+bool tvbSendParsedBatch(IRsend* sender, const IrCode* const* codes, uint8_t count,
+                        uint16_t doneBefore, uint16_t total,
+                        void (*progressCb)(uint8_t, uint8_t), bool (*cancelCb)()) {
   uint16_t rawData[300];
-
-  for (uint8_t i = 0; i < numCodes; i++) {
-    if (cancelCb && cancelCb()) break;
+  for (uint8_t i = 0; i < count; i++) {
+    if (cancelCb && cancelCb()) return false;
 
     const IrCode* powerCode = codes[i];
     uint8_t freq = powerCode->timer_val;
     uint8_t numpairs = powerCode->numpairs;
     uint8_t bitcompression = powerCode->bitcompression;
 
-    // Decode compressed data
-    uint8_t bitsleft = 0;
-    uint8_t bits = 0;
-    uint8_t codePtr = 0;
-
+    uint8_t bitsleft = 0, bits = 0, codePtr = 0;
     for (uint8_t k = 0; k < numpairs; k++) {
-      // Read bits
-      uint8_t tmp = 0;
-      uint8_t remaining = bitcompression;
+      uint8_t tmp = 0, remaining = bitcompression;
       while (remaining--) {
         if (bitsleft == 0) {
           bits = powerCode->codes[codePtr++];
@@ -347,15 +346,72 @@ void IRUtil::startTvBGone(uint8_t region, void (*progressCb)(uint8_t, uint8_t),
       rawData[k * 2 + 1] = powerCode->times[ti + 1] * 10;
     }
 
-    _sender->sendRaw(rawData, numpairs * 2, freq);
+    sender->sendRaw(rawData, numpairs * 2, freq);
+    tvbProgress(progressCb, doneBefore + i + 1, total);
+    delay(kTvbGap);
+  }
+  return true;
+}
 
-    if (progressCb && (i % 3 == 0 || i == numCodes - 1)) {
-      progressCb(i + 1, numCodes);
+// Send a batch of raw codes — times are 32-bit microseconds, sent as-is (no
+// ×10). Values > 65535 truncate to uint16_t, matching Bruce's custom loader.
+bool tvbSendRawBatch(IRsend* sender, const RawIrCode* const* codes, uint8_t count,
+                     uint16_t doneBefore, uint16_t total,
+                     void (*progressCb)(uint8_t, uint8_t), bool (*cancelCb)()) {
+  uint16_t rawData[300];
+  for (uint8_t i = 0; i < count; i++) {
+    if (cancelCb && cancelCb()) return false;
+
+    const RawIrCode* powerCode = codes[i];
+    uint8_t freq = powerCode->timer_val;
+    uint8_t numpairs = powerCode->numpairs;
+
+    for (uint8_t k = 0; k < numpairs; k++) {
+      rawData[k * 2] = (uint16_t)powerCode->times[k * 2];
+      rawData[k * 2 + 1] = (uint16_t)powerCode->times[k * 2 + 1];
     }
 
-    delay(200);
+    sender->sendRaw(rawData, numpairs * 2, freq);
+    tvbProgress(progressCb, doneBefore + i + 1, total);
+    delay(kTvbGap);
+  }
+  return true;
+}
+
+}  // namespace
+
+void IRUtil::startTvBGone(uint8_t region, void (*progressCb)(uint8_t, uint8_t),
+                           bool (*cancelCb)()) {
+  if (!_sender) return;
+
+  const IrCode* const* regionCodes;
+  uint8_t numRegion;
+  if (region == 1) { // NA
+    regionCodes = NApowerCodes;
+    numRegion = sizeof(NApowerCodes) / sizeof(NApowerCodes[0]);
+  } else { // EU
+    regionCodes = EUpowerCodes;
+    numRegion = sizeof(EUpowerCodes) / sizeof(EUpowerCodes[0]);
   }
 
-  if (progressCb) progressCb(numCodes, numCodes);
+  // Three sequential sweeps: region-specific first, then the universal parsed
+  // codes, then the universal raw codes (projectors / streaming sticks / etc).
+  // Progress runs cumulatively across all three so the bar fills 0 -> total.
+  const uint16_t total =
+      (uint16_t)numRegion + num_UniversalParsedCodes + num_UniversalRawCodes;
+
+  bool ok = tvbSendParsedBatch(_sender, regionCodes, numRegion,
+                               0, total, progressCb, cancelCb);
+  if (ok) {
+    ok = tvbSendParsedBatch(_sender, UniversalParsedCodes, num_UniversalParsedCodes,
+                            numRegion, total, progressCb, cancelCb);
+  }
+  if (ok) {
+    ok = tvbSendRawBatch(_sender, UniversalRawCodes, num_UniversalRawCodes,
+                         (uint16_t)numRegion + num_UniversalParsedCodes,
+                         total, progressCb, cancelCb);
+  }
+
+  if (progressCb) progressCb((uint8_t)total, (uint8_t)total);
   digitalWrite(_txPin, LOW);
 }

--- a/firmware/src/utils/ir/TVBGoneData.h
+++ b/firmware/src/utils/ir/TVBGoneData.h
@@ -8521,3 +8521,933 @@ const IrCode *const EUpowerCodes[] = {
     &code_eu138Code,
     &code_eu139Code,
 };
+
+////////////////////////////////////////////////////////////////
+// Universal multi-device power-off codes
+// Sent after the region-specific NA/EU sweep for projectors, set-top
+// boxes, streaming sticks (Roku/Amazon/Android TV) and generic gear.
+////////////////////////////////////////////////////////////////
+
+// Raw IR code entry with 32-bit timing values (for values > 65535).
+struct RawIrCode {
+    uint8_t timer_val;
+    uint8_t numpairs;
+    uint8_t bitcompression;
+    uint32_t const *times;
+    uint8_t const *codes;
+};
+// ===== UNIVERSAL POWER CODES =====
+
+// ----- PARSED PROTOCOLS -----
+
+// Samsung universal power code
+const uint16_t code_universal_samsungTimes[] = {
+    50, 100, 50, 200, 50, 800, 400, 400,
+};
+const uint8_t code_universal_samsungCodes[] = {
+    0xD5, 0x41, 0x11, 0x00, 0x14, 0x44, 0x6D, 0x54, 0x11, 0x10, 0x01, 0x44, 0x45,
+};
+const struct IrCode code_universal_samsungCode = {
+    freq_to_timerval(57143), 52, 2, code_universal_samsungTimes, code_universal_samsungCodes
+};
+
+// Grundig universal power code
+const uint16_t code_universal_grundigTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_grundigCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_grundigCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_grundigTimes, code_universal_grundigCodes
+};
+
+// LG universal power code
+const uint16_t code_universal_lgTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_lgCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_lgCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_lgTimes, code_universal_lgCodes
+};
+
+// Sony universal power code
+const uint16_t code_universal_sonyTimes[] = {
+    88, 90, 88, 91, 88, 181, 88, 8976, 177, 91,
+};
+const uint8_t code_universal_sonyCodes[] = {
+    0x10, 0x92, 0x49, 0x46, 0x33, 0x09, 0x24, 0x94, 0x60,
+};
+const struct IrCode code_universal_sonyCode = {
+    freq_to_timerval(35714), 24, 3, code_universal_sonyTimes, code_universal_sonyCodes
+};
+
+// Telefunken universal power code
+const uint16_t code_universal_telefunkenTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_telefunkenCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_telefunkenCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_telefunkenTimes, code_universal_telefunkenCodes
+};
+
+// Vizio universal power code
+const uint16_t code_universal_vizioTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_vizioCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_vizioCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_vizioTimes, code_universal_vizioCodes
+};
+
+// Phillips universal power code
+const uint16_t code_universal_phillipsTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_phillipsCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_phillipsCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_phillipsTimes, code_universal_phillipsCodes
+};
+
+// Medion universal power code
+const uint16_t code_universal_medionTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_medionCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_medionCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_medionTimes, code_universal_medionCodes
+};
+
+// Oppo universal power code
+const uint16_t code_universal_oppoTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_oppoCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_oppoCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_oppoTimes, code_universal_oppoCodes
+};
+
+// Fetch universal power code
+const uint16_t code_universal_fetchTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_fetchCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_fetchCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_fetchTimes, code_universal_fetchCodes
+};
+
+// Denver universal power code
+const uint16_t code_universal_denverTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_denverCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_denverCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_denverTimes, code_universal_denverCodes
+};
+
+// Xbox universal power code
+const uint16_t code_universal_xboxTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_xboxCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_xboxCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_xboxTimes, code_universal_xboxCodes
+};
+
+// Platinum universal power code
+const uint16_t code_universal_platinumTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_platinumCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_platinumCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_platinumTimes, code_universal_platinumCodes
+};
+
+// Hisense universal power code
+const uint16_t code_universal_hisenseTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_hisenseCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_hisenseCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_hisenseTimes, code_universal_hisenseCodes
+};
+
+// Elitelux universal power code
+const uint16_t code_universal_eliteluxTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_eliteluxCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_eliteluxCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_eliteluxTimes, code_universal_eliteluxCodes
+};
+
+// Android TV universal power code
+const uint16_t code_universal_androidTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_androidCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_androidCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_androidTimes, code_universal_androidCodes
+};
+
+// Sanyo universal power code
+const uint16_t code_universal_sanyoTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_sanyoCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_sanyoCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_sanyoTimes, code_universal_sanyoCodes
+};
+
+// Smart Board MX universal power code
+const uint16_t code_universal_smartboardTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_smartboardCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_smartboardCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_smartboardTimes, code_universal_smartboardCodes
+};
+
+// Remotes Replaced universal power code
+const uint16_t code_universal_remotesTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_remotesCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_remotesCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_remotesTimes, code_universal_remotesCodes
+};
+
+// Bush universal power code
+const uint16_t code_universal_bushTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_bushCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_bushCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_bushTimes, code_universal_bushCodes
+};
+
+// TCL Roku universal power code
+const uint16_t code_universal_tlc_rokuTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_tlc_rokuCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_tlc_rokuCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_tlc_rokuTimes, code_universal_tlc_rokuCodes
+};
+
+// LG Projector universal power code
+const uint16_t code_universal_lg_projectorTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_lg_projectorCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_lg_projectorCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_lg_projectorTimes, code_universal_lg_projectorCodes
+};
+
+// POWER_On universal power code
+const uint16_t code_universal_power_onTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_power_onCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_power_onCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_power_onTimes, code_universal_power_onCodes
+};
+
+// POWER_Off universal power code
+const uint16_t code_universal_power_offTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_power_offCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_power_offCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_power_offTimes, code_universal_power_offCodes
+};
+
+// Szxlcom universal power code
+const uint16_t code_universal_szxlcomTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_szxlcomCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_szxlcomCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_szxlcomTimes, code_universal_szxlcomCodes
+};
+
+// Digi Days universal power code
+const uint16_t code_universal_digi_daysTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_digi_daysCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_digi_daysCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_digi_daysTimes, code_universal_digi_daysCodes
+};
+
+// Amazon TV universal power code
+const uint16_t code_universal_amazonTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_amazonCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_amazonCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_amazonTimes, code_universal_amazonCodes
+};
+
+// NECext 01 72 00 00 / 1E E1 00 00
+const uint16_t code_universal_nec01Times[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec01Codes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec01Code = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec01Times, code_universal_nec01Codes
+};
+
+// NECext 01 3E 00 00 / 0A F5 00 00
+const uint16_t code_universal_nec013eTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec013eCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec013eCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec013eTimes, code_universal_nec013eCodes
+};
+
+// NECext 04 F4 00 00 / 08 F7 00 00
+const uint16_t code_universal_nec04f4Times[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec04f4Codes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec04f4Code = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec04f4Times, code_universal_nec04f4Codes
+};
+
+// NECext 85 7C 00 00 / 80 7F 00 00
+const uint16_t code_universal_nec857cTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec857cCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec857cCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec857cTimes, code_universal_nec857cCodes
+};
+
+// NECext 83 7A 00 00 / 08 00 00 00
+const uint16_t code_universal_nec837aTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec837aCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec837aCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec837aTimes, code_universal_nec837aCodes
+};
+
+// NECext 00 F7 00 00 / 0C F3 00 00
+const uint16_t code_universal_nec00f7Times[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec00f7Codes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec00f7Code = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec00f7Times, code_universal_nec00f7Codes
+};
+
+// NECext 72 DD 00 00 / 0E F1 00 00
+const uint16_t code_universal_nec72ddTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec72ddCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec72ddCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec72ddTimes, code_universal_nec72ddCodes
+};
+
+// NECext 72 DD 00 00 / 10 EF 00 00
+const uint16_t code_universal_nec72dd2Times[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec72dd2Codes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec72dd2Code = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec72dd2Times, code_universal_nec72dd2Codes
+};
+
+// NECext 04 B9 00 00 / 00 FF 00 00
+const uint16_t code_universal_nec04b9Times[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec04b9Codes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec04b9Code = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec04b9Times, code_universal_nec04b9Codes
+};
+
+// NECext 00 DF 00 00 / 1C E3 00 00
+const uint16_t code_universal_nec00dfTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec00dfCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec00dfCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec00dfTimes, code_universal_nec00dfCodes
+};
+
+// NECext 00 BF 00 00 / 03 FC 00 00
+const uint16_t code_universal_nec00bfTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec00bfCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec00bfCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec00bfTimes, code_universal_nec00bfCodes
+};
+
+// NECext A0 B7 00 00 / E9 16 00 00
+const uint16_t code_universal_necA0b7Times[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_necA0b7Codes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_necA0b7Code = {
+    freq_to_timerval(35714), 40, 3, code_universal_necA0b7Times, code_universal_necA0b7Codes
+};
+
+// NECext 00 BF 00 00 / 00 FF 00 00
+const uint16_t code_universal_nec00bf00Times[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec00bf00Codes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec00bf00Code = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec00bf00Times, code_universal_nec00bf00Codes
+};
+
+// NECext 00 FB 00 00 / 0A F5 00 00
+const uint16_t code_universal_nec00fbTimes[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec00fbCodes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec00fbCode = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec00fbTimes, code_universal_nec00fbCodes
+};
+
+// NECext 84 E0 00 00 / 20 DF 00 00
+const uint16_t code_universal_nec84e0Times[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec84e0Codes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec84e0Code = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec84e0Times, code_universal_nec84e0Codes
+};
+
+// NECext 86 05 00 00 / 0F F0 00 00
+const uint16_t code_universal_nec8605Times[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec8605Codes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec8605Code = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec8605Times, code_universal_nec8605Codes
+};
+
+// NECext 40 40 00 00 / 0A F5 00 00
+const uint16_t code_universal_nec4040Times[] = {
+    43, 47, 43, 91, 43, 8324, 88, 47, 133, 133, 264, 90, 264, 91,
+};
+const uint8_t code_universal_nec4040Codes[] = {
+    0xA4, 0x08, 0x00, 0x00, 0x00, 0x00, 0x64, 0x2C, 0x40, 0x80, 0x00, 0x00, 0x00, 0x06, 0x41,
+};
+const struct IrCode code_universal_nec4040Code = {
+    freq_to_timerval(35714), 40, 3, code_universal_nec4040Times, code_universal_nec4040Codes
+};
+
+// Samsung32 3E 00 00 00 / 0C 00 00 00
+const uint16_t code_universal_samsung3eTimes[] = {
+    50, 100, 50, 200, 50, 800, 400, 400,
+};
+const uint8_t code_universal_samsung3eCodes[] = {
+    0xD5, 0x41, 0x11, 0x00, 0x14, 0x44, 0x6D, 0x54, 0x11, 0x10, 0x01, 0x44, 0x45,
+};
+const struct IrCode code_universal_samsung3eCode = {
+    freq_to_timerval(57143), 52, 2, code_universal_samsung3eTimes, code_universal_samsung3eCodes
+};
+
+// Samsung32 0E 00 00 00 / 0C 00 00 00
+const uint16_t code_universal_samsung0eTimes[] = {
+    50, 100, 50, 200, 50, 800, 400, 400,
+};
+const uint8_t code_universal_samsung0eCodes[] = {
+    0xD5, 0x41, 0x11, 0x00, 0x14, 0x44, 0x6D, 0x54, 0x11, 0x10, 0x01, 0x44, 0x45,
+};
+const struct IrCode code_universal_samsung0eCode = {
+    freq_to_timerval(57143), 52, 2, code_universal_samsung0eTimes, code_universal_samsung0eCodes
+};
+
+// Pioneer
+const uint16_t code_universal_pioneerTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_pioneerCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_pioneerCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_pioneerTimes, code_universal_pioneerCodes
+};
+
+// RCA
+const uint16_t code_universal_rcaTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_rcaCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_rcaCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_rcaTimes, code_universal_rcaCodes
+};
+
+// RCA alt (0F 00 00 00 / 54 00 00 00)
+const uint16_t code_universal_rca_altTimes[] = {
+    44, 815, 45, 528, 45, 815, 45, 5000,
+};
+const uint8_t code_universal_rca_altCodes[] = {
+    0x29, 0x9A, 0x9B, 0xA9, 0x9A, 0x9A,
+};
+const struct IrCode code_universal_rca_altCode = {
+    freq_to_timerval(34483), 24, 2, code_universal_rca_altTimes, code_universal_rca_altCodes
+};
+
+// ===== RAW CODES (32-bit) =====
+
+// MOST TV'S - raw universal power code
+const uint32_t code_universal_most_tvsTimes[] = {
+    2762, 793, 534, 358, 530, 358, 530, 794, 534, 794, 981, 379, 533, 354, 532, 356,
+    530, 357, 505, 383, 505, 382, 506, 382, 506, 383, 505, 383, 505, 384, 503, 385,
+    502, 386, 501, 388, 499, 389, 498, 390, 497, 391, 943, 389, 495, 834, 495, 394,
+    494, 122265, 2760, 796, 529, 384, 503, 385, 502, 825, 502, 826, 947, 385, 498,
+    391, 496, 392, 496, 392, 496, 392, 496, 393, 495, 393, 495, 393, 495, 393, 495,
+    393, 495, 393, 495, 393, 495, 393, 495, 393, 495, 393, 495, 393, 942, 389, 495,
+    834, 495, 394, 494,
+};
+const uint8_t code_universal_most_tvsCodes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_most_tvsCode = {
+    freq_to_timerval(38000), 20, 3, code_universal_most_tvsTimes, code_universal_most_tvsCodes
+};
+
+// Panasonic raw
+const uint32_t code_universal_panasonicTimes[] = {
+    3481, 1715, 457, 442, 428, 1284, 457, 442, 428, 443, 427, 443, 427, 443, 427, 442,
+    428, 442, 428, 442, 453, 417, 453, 417, 453, 417, 452, 418, 451, 1289, 451, 422,
+    448, 447, 422, 424, 447, 447, 423, 448, 422, 424, 446, 448, 422, 448, 422, 448,
+    422, 1319, 422, 448, 422, 448, 422, 448, 422, 448, 422, 448, 423, 448, 422, 448,
+    422, 1319, 422, 448, 422, 1319, 422, 1319, 422, 1319, 422, 1319, 422, 448, 422,
+    449, 421, 1319, 422, 448, 422, 1320, 421, 1319, 422, 1320, 421, 1319, 422, 449,
+    422, 1319, 422, 74732, 3475, 1750, 422, 448, 422, 1319, 422, 448, 422, 448, 422,
+    448, 422, 448, 422, 448, 422, 448, 422, 448, 422, 448, 422, 448, 422, 448, 422,
+    449, 422, 1319, 422, 449, 421, 449, 421, 448, 422, 449, 421, 449, 421, 449, 421,
+    449, 421, 449, 421, 449, 421, 1320, 421, 449, 421, 449, 421, 449, 421, 449, 421,
+    449, 422, 449, 421, 449, 421, 449, 422, 449, 421, 1320, 421, 449, 421, 1320, 421,
+    1320, 421, 1320, 421, 1320, 421, 449, 421, 449, 421, 1320, 421, 449, 421, 1320,
+    421, 1320, 421, 1320, 421, 1320, 421, 450, 420, 1321, 420, 74732, 3475, 1750,
+    422, 448, 422, 1319, 422, 448, 422, 448, 423, 448, 422, 448, 422, 448, 422, 448,
+    422, 448, 422, 448, 422, 448, 422, 448, 422, 448, 422, 1319, 422, 448, 422, 448,
+    422, 448, 422, 448, 422, 448, 422, 449, 421, 449, 421, 449, 421, 448, 422, 1320,
+    421, 449, 421, 449, 421, 449, 422, 449, 421, 449, 421, 449, 422, 449, 421, 449,
+    421, 1320, 421, 449, 421, 1320, 421, 1320, 421, 1320, 421, 1320, 421, 449, 421,
+    449, 421, 1320, 421, 449, 421, 1320, 421, 1320, 421, 1320, 421, 1320, 421, 449, 421, 1320, 421,
+};
+const uint8_t code_universal_panasonicCodes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_panasonicCode = {
+    freq_to_timerval(38000), 38, 3, code_universal_panasonicTimes, code_universal_panasonicCodes
+};
+
+// EHP raw
+const uint32_t code_universal_ehpTimes[] = {
+    528, 1870, 433, 380, 432, 386, 426, 392, 431, 780, 428, 390, 433, 386, 426, 392,
+    431, 387, 425, 392, 431, 95569, 536, 1862, 430, 382, 431, 389, 423, 421, 402,
+    783, 425, 394, 429, 389, 434, 386, 426, 418, 405, 387, 425, 95574, 531, 1868,
+    424, 389, 434, 386, 426, 392, 431, 781, 427, 392, 431, 388, 424, 395, 428, 416,
+    407, 411, 402, 95573, 532, 1867, 425, 388, 424, 395, 428, 391, 432, 779, 430,
+    390, 433, 412, 400, 418, 405, 389, 423, 419, 404, 95571, 533, 1866, 426, 387,
+    425, 394, 429, 415, 408, 804, 404, 390, 423, 421, 402, 392, 431, 388, 424, 419,
+    404, 95571, 534, 1864, 428, 385, 427, 392, 431, 388, 424, 787, 432, 388, 424,
+    395, 428, 392, 431, 388, 424, 394, 429,
+};
+const uint8_t code_universal_ehpCodes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_ehpCode = {
+    freq_to_timerval(38000), 10, 3, code_universal_ehpTimes, code_universal_ehpCodes
+};
+
+// Generic fan raw
+const uint32_t code_universal_generic_fanTimes[] = {
+    1370, 314, 1375, 320, 519, 1167, 1370, 322, 1339, 350, 465, 1221, 467, 1222, 467,
+    1222, 466, 1221, 467, 1221, 467, 1221, 1317, 7067, 1317, 372, 1341, 349, 491,
+    1198, 1340, 352, 1337, 353, 486, 1202, 486, 1226, 462, 1226, 462, 1227, 461,
+    1227, 462, 1227, 1311, 7073, 1312, 378, 1311, 378, 462, 1227, 1311, 378, 1312,
+    378, 462, 1227, 462, 1227, 461, 1227, 462, 1227, 461, 1227, 461, 1227, 1311,
+    7074, 1311, 378, 1311, 378, 462, 1227, 1311, 379, 1310, 379, 461, 1228, 461,
+    1228, 460, 1228, 460, 1228, 460, 1229, 459, 1228, 1310, 7076, 1309, 381, 1309,
+    380, 460, 1229, 1310, 381, 1309, 381, 458, 1230, 458, 1230, 459, 1230, 459, 1230,
+    459, 1230, 458, 1230, 1309, 7077, 1309, 380, 1310, 380, 460, 1229, 1310, 380,
+    1310, 380, 459, 1229, 460, 1229, 459, 1229, 460, 1229, 459, 1229, 459, 1229,
+    1310, 7075, 1310, 379, 1310, 380, 459, 1229, 1310, 380, 1310, 379, 460, 1229,
+    460, 1229, 459, 1229, 460, 1228, 460, 1229, 459, 1229, 1310, 7074, 1310, 380,
+    1310, 379, 460, 1229, 1310, 379, 1310, 379, 460, 1229, 459, 1229, 459, 1229,
+    460, 1229, 460, 1229, 460, 1228, 1311,
+};
+const uint8_t code_universal_generic_fanCodes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_generic_fanCode = {
+    freq_to_timerval(38000), 10, 3, code_universal_generic_fanTimes, code_universal_generic_fanCodes
+};
+
+// Projector Freeze raw
+const uint32_t code_universal_projector_freeTimes[] = {
+    151, 56105, 9037, 4437, 585, 525, 564, 519, 616, 498, 594, 1673, 586, 1619, 613,
+    459, 652, 524, 587, 529, 587, 1645, 586, 525, 587, 528, 587, 1646, 586, 529, 587,
+    1649, 587, 1650, 586, 1645, 585, 527, 586, 529, 586, 1650, 586, 1645, 563, 518,
+    593, 525, 590, 1668, 564, 553, 563, 1672, 564, 1668, 563, 549, 562, 521, 595,
+    1643, 593, 1668, 563, 552, 564, 1669, 563, 548, 563, 520, 591, 548, 563, 548,
+    563, 548, 563, 548, 697, 414, 697, 419, 695, 1541, 563, 1673, 563, 1673, 563,
+    1673, 563, 1673, 563, 1673, 563, 1673, 563, 1682, 587, 14405, 9030, 2182, 587,
+};
+const uint8_t code_universal_projector_freeCodes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_projector_freeCode = {
+    freq_to_timerval(38000), 10, 3, code_universal_projector_freeTimes, code_universal_projector_freeCodes
+};
+
+// Projector On raw
+const uint32_t code_universal_projector_onTimes[] = {
+    9096, 4436, 620, 505, 647, 478, 648, 501, 623, 1599, 647, 1624, 623, 502, 623,
+    503, 621, 504, 619, 1628, 618, 507, 617, 507, 617, 1630, 617, 508, 616, 1630,
+    617, 1630, 617, 1631, 616, 508, 616, 508, 617, 508, 616, 1631, 616, 508, 617,
+    508, 617, 508, 616, 508, 616, 1630, 616, 1630, 616, 1631, 616, 508, 616, 1630,
+    617, 1630, 617, 1630, 617, 1631, 617, 509, 616, 508, 616, 509, 616, 509, 616,
+    509, 616, 509, 615, 509, 616, 508, 617, 1631, 616, 1631, 615, 1631, 616, 1631,
+    616, 1631, 616, 1631, 615, 1631, 616, 14435, 9093, 2186, 615, 96359, 9095, 2184, 617,
+};
+const uint8_t code_universal_projector_onCodes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_projector_onCode = {
+    freq_to_timerval(38000), 10, 3, code_universal_projector_onTimes, code_universal_projector_onCodes
+};
+
+// Projector Off raw
+const uint32_t code_universal_projector_offTimes[] = {
+    9075, 4307, 677, 433, 675, 456, 651, 461, 651, 1579, 650, 1576, 649, 459, 649,
+    460, 648, 465, 648, 1578, 647, 461, 622, 491, 622, 1604, 647, 465, 647, 1583,
+    622, 1608, 647, 1579, 647, 461, 647, 466, 622, 1604, 647, 465, 647, 1579, 647,
+    461, 645, 463, 648, 465, 648, 1583, 646, 1580, 646, 466, 647, 1579, 622, 491,
+    647, 1583, 622, 1608, 647, 1579, 647, 461, 647, 461, 622, 486, 622, 486, 647,
+    461, 647, 462, 646, 462, 622, 491, 646, 1584, 622, 1608, 647, 1584, 621, 1608,
+    647, 1583, 646, 1584, 647, 1584, 646, 1592, 622, 14330, 9047, 2137, 621,
+};
+const uint8_t code_universal_projector_offCodes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_projector_offCode = {
+    freq_to_timerval(38000), 10, 3, code_universal_projector_offTimes, code_universal_projector_offCodes
+};
+
+// Projector Menu raw
+const uint32_t code_universal_projector_menuTimes[] = {
+    9036, 4477, 598, 557, 565, 565, 567, 562, 570, 1690, 564, 1668, 597, 559, 563,
+    567, 565, 564, 568, 1692, 562, 541, 591, 565, 567, 1666, 588, 541, 591, 1695,
+    570, 1663, 591, 1694, 571, 559, 563, 1671, 594, 1691, 563, 540, 592, 564, 568,
+    535, 597, 1663, 591, 564, 568, 1691, 563, 540, 592, 537, 595, 1691, 563, 1696,
+    569, 1665, 589, 566, 566, 1667, 598, 558, 564, 566, 566, 563, 569, 534, 598, 558,
+    564, 540, 592, 564, 568, 561, 571, 1689, 565, 1694, 571, 1662, 592, 1667, 597,
+    1688, 566, 1667, 597, 1687, 567, 1692, 562, 13990, 9030, 2221, 589, 96232, 9031,
+    2219, 591, 96227, 9026, 2223, 597, 96223, 9030, 2220, 590,
+};
+const uint8_t code_universal_projector_menuCodes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_projector_menuCode = {
+    freq_to_timerval(38000), 10, 3, code_universal_projector_menuTimes, code_universal_projector_menuCodes
+};
+
+// Roku raw
+const uint32_t code_universal_rokuTimes[] = {
+    8885, 4455, 573, 573, 573, 1641, 573, 573, 573, 1641, 573, 573, 573, 1641, 573,
+    1641, 573, 1641, 573, 573, 573, 1641, 573, 573, 573, 573, 573, 573, 573, 573,
+    573, 1641, 573, 1641, 573, 1641, 573, 1641, 573, 573, 573, 573, 573, 573, 573,
+    573, 573, 573, 573, 573, 573, 573, 573, 573, 573, 1641, 573, 1641, 573, 1641,
+    573, 1641, 573, 1641, 573, 1641, 573, 38196, 8885, 4507, 573, 573, 573, 1641,
+    573, 573, 573, 1641, 573, 573, 573, 1641, 573, 1641, 573, 1641, 573, 573, 573,
+    1641, 573, 573, 573, 573, 573, 573, 573, 573, 573, 1641, 573, 1641, 573, 1641,
+    573, 1641, 573, 573, 573, 573, 573, 573, 573, 573, 573, 573, 573, 1641, 573,
+    573, 573, 573, 573, 1641, 573, 1641, 573, 1641, 573, 1641, 573, 1641, 573, 573, 573, 38196,
+};
+const uint8_t code_universal_rokuCodes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_rokuCode = {
+    freq_to_timerval(38381), 10, 3, code_universal_rokuTimes, code_universal_rokuCodes
+};
+
+// Xiaomi raw
+const uint32_t code_universal_xiomiTimes[] = {
+    985, 605, 587, 589, 587, 1470, 587, 1472, 586, 589, 587, 1471, 586, 589, 586,
+    1470, 587, 589, 586, 1472, 586, 1472, 585, 10765, 987, 610, 585, 589, 587, 1472,
+    585, 1471, 587, 589, 587, 1470, 588, 588, 587, 1471, 586, 589, 586, 1471, 587,
+    1472, 585, 10765, 987, 609, 586, 590, 585, 1471, 586, 1473, 585, 589, 587, 1471,
+    587, 589, 587, 1471, 586, 589, 587, 1472, 586, 1471, 586, 10765, 987, 609, 587,
+    589, 586, 1471, 586, 1472, 586, 589, 587, 1471, 586, 589, 587, 1472, 585, 589,
+    586, 1472, 586, 1471, 587, 10764, 988, 609, 586, 589, 587, 1471, 586, 1471, 587,
+    588, 588, 1471, 586, 588, 587, 1470, 587, 588, 587, 1471, 587, 1471, 586, 10765,
+    987, 609, 586, 589, 587, 1470, 587, 1471, 587, 589, 587, 1470, 587, 590, 586,
+    1471, 586, 589, 587, 1470, 588, 1472, 585, 10764, 988, 608, 587, 588, 587, 1471,
+    587, 1472, 586, 590, 585, 1470, 587, 589, 587, 1471, 586, 589, 587, 1472, 586,
+    1471, 586, 10765, 987, 609, 586, 589, 587, 1470, 587, 1472, 586, 589, 586, 1471,
+    586, 589, 587, 1472, 585, 590, 585, 1472, 586, 1470, 587, 10765, 987, 609, 586,
+    589, 586, 1471, 586, 1471, 587, 589, 587, 1471, 586, 589, 586, 1471, 587, 588,
+    587, 1470, 588, 1472, 586, 10765, 987, 609, 586, 589, 587, 1470, 587, 1471, 587,
+    589, 586, 1471, 586, 589, 586, 1471, 586, 589, 586, 1471, 587, 1471, 586, 10764,
+    987, 609, 587, 590, 585, 1470, 587, 1472, 586, 589, 587, 1470, 587, 590, 586,
+    1471, 586, 589, 586, 1472, 586, 1471, 586, 10764, 988, 609, 586, 588, 588, 1471,
+    586, 1471, 587, 589, 586, 1471, 586, 589, 587, 1471, 586, 589, 587, 1471, 587,
+    1471, 586, 10764, 988, 609, 586, 589, 587, 1470, 587, 1471, 587, 589, 587, 1471,
+    587, 589, 586, 1470, 587, 589, 587, 1472, 586, 1471, 586, 10764, 988, 609, 586,
+    589, 586, 1471, 586, 1471, 587, 589, 587, 1472, 585, 589, 587, 1472, 585, 588,
+    587, 1472, 586, 1470, 587, 10764, 988, 609, 586, 588, 588, 1471, 586, 1471, 587,
+    589, 586, 1470, 587, 589, 587, 1469, 588, 588, 587, 1471, 587, 1471, 586, 10764,
+    988, 608, 587, 589, 587, 1470, 587, 1471, 587, 588, 587, 1471, 586, 588, 587,
+    1471, 587, 589, 586, 1471, 587, 1471, 586, 10765, 987, 608, 587, 588, 588, 1470,
+    587, 1474, 584, 590, 585, 1471, 586, 588, 588, 1471, 586, 587, 589, 1470, 588,
+    1471, 586, 10764, 988, 609, 586, 588, 588, 1471, 587, 1470, 588, 588, 588, 1470,
+    587, 588, 587, 1471, 586, 587, 588, 1471, 587, 1471, 586,
+};
+const uint8_t code_universal_xiomiCodes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_xiomiCode = {
+    freq_to_timerval(38000), 10, 3, code_universal_xiomiTimes, code_universal_xiomiCodes
+};
+
+// Power raw
+const uint32_t code_universal_power_rawTimes[] = {
+    3523, 1701, 472, 426, 444, 1269, 472, 426, 444, 426, 442, 429, 443, 427, 443,
+    426, 444, 426, 444, 426, 443, 427, 442, 429, 440, 430, 439, 432, 438, 1304, 437,
+    433, 437, 432, 438, 432, 438, 433, 437, 433, 437, 433, 437, 433, 437, 433, 437,
+    433, 437, 1304, 437, 433, 437, 433, 437, 433, 437, 1304, 437, 433, 437, 433,
+    437, 1304, 437, 433, 437, 434, 436, 433, 437, 434, 436, 434, 436, 434, 436, 433,
+    437, 433, 437, 434, 436, 1304, 437, 1305, 436, 1305, 436, 1305, 436, 1305, 436,
+    1305, 436, 434, 436, 434, 436, 1305, 436, 1305, 436, 1305, 436, 434, 436, 1305,
+    436, 1305, 436, 1306, 435, 1306, 435, 74393, 3515, 1736, 437, 433, 437, 1304,
+    437, 433, 437, 433, 437, 433, 437, 433, 437, 433, 437, 433, 437, 433, 437, 434,
+    436, 433, 437, 434, 436, 434, 436, 1304, 437, 434, 436, 434, 436, 434, 436, 434,
+    436, 434, 436, 434, 436, 434, 436, 434, 436, 434, 436, 1305, 436, 434, 436, 434,
+    436, 434, 436, 1305, 436, 434, 436, 434, 436, 1306, 435, 435, 435, 435, 435,
+    435, 435, 435, 435, 435, 435, 435, 435, 435, 435, 436, 434, 435, 435, 1307, 434,
+    1331, 410, 1307, 434, 1307, 434, 1330, 411, 1307, 434, 460, 410, 460, 410, 1331,
+    410, 1331, 410, 1331, 410, 460, 410, 1331, 410, 1331, 410, 1331, 410, 1331, 410,
+    74393, 3515, 1736, 437, 433, 437, 1304, 437, 433, 437, 433, 437, 433, 437, 433,
+    437, 433, 437, 433, 437, 433, 437, 434, 436, 434, 436, 433, 437, 433, 437, 1304,
+    437, 434, 436, 434, 436, 434, 437, 434, 436, 434, 436, 434, 436, 434, 436, 434,
+    436, 434, 436, 1305, 436, 434, 436, 434, 436, 434, 436, 1305, 436, 435, 435,
+    434, 436, 1305, 436, 434, 436, 435, 435, 435, 435, 435, 435, 435, 435, 435, 435,
+    435, 435, 435, 435, 435, 435, 1307, 434, 1306, 435, 1307, 434, 1307, 434, 1307,
+    434, 1331, 410, 460, 410, 460, 410, 1331, 410, 1331, 410, 1331, 410, 460, 410,
+    1331, 410, 1331, 410, 1331, 410, 1331, 410,
+};
+const uint8_t code_universal_power_rawCodes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_power_rawCode = {
+    freq_to_timerval(38000), 10, 3, code_universal_power_rawTimes, code_universal_power_rawCodes
+};
+
+// Off raw
+const uint32_t code_universal_off_rawTimes[] = {
+    3523, 1701, 472, 426, 444, 1269, 472, 426, 444, 426, 442, 429, 443, 427, 443,
+    426, 444, 426, 444, 426, 443, 427, 442, 429, 440, 430, 439, 432, 438, 1304, 437,
+    433, 437, 432, 438, 432, 438, 433, 437, 433, 437, 433, 437, 433, 437, 433, 437,
+    433, 437, 1304, 437, 433, 437, 433, 437, 433, 437, 1304, 437, 433, 437, 433,
+    437, 1304, 437, 433, 437, 434, 436, 433, 437, 434, 436, 434, 436, 434, 436, 433,
+    437, 433, 437, 434, 436, 1304, 437, 1305, 436, 1305, 436, 1305, 436, 1305, 436,
+    1305, 436, 434, 436, 434, 436, 1305, 436, 1305, 436, 1305, 436, 434, 436, 1305,
+    436, 1305, 436, 1306, 435, 1306, 435, 74393, 3515, 1736, 437, 433, 437, 1304,
+    437, 433, 437, 433, 437, 433, 437, 433, 437, 433, 437, 433, 437, 433, 437, 434,
+    436, 433, 437, 434, 436, 434, 436, 1304, 437, 434, 436, 434, 436, 434, 436, 434,
+    436, 434, 436, 434, 436, 434, 436, 434, 436, 434, 436, 1305, 436, 434, 436, 434,
+    436, 434, 436, 1305, 436, 434, 436, 434, 436, 1306, 435, 435, 435, 435, 435,
+    435, 435, 435, 435, 435, 435, 435, 435, 435, 435, 436, 434, 435, 435, 1307, 434,
+    1331, 410, 1307, 434, 1307, 434, 1330, 411, 1307, 434, 460, 410, 460, 410, 1331,
+    410, 1331, 410, 1331, 410, 460, 410, 1331, 410, 1331, 410, 1331, 410, 1331, 410,
+    74393, 3515, 1736, 437, 433, 437, 1304, 437, 433, 437, 433, 437, 433, 437, 433,
+    437, 433, 437, 433, 437, 433, 437, 434, 436, 434, 436, 433, 437, 433, 437, 1304,
+    437, 434, 436, 434, 436, 434, 437, 434, 436, 434, 436, 434, 436, 434, 436, 434,
+    436, 434, 436, 1305, 436, 434, 436, 434, 436, 434, 436, 1305, 436, 435, 435,
+    434, 436, 1305, 436, 434, 436, 435, 435, 435, 435, 435, 435, 435, 435, 435, 435,
+    435, 435, 435, 435, 435, 435, 1307, 434, 1306, 435, 1307, 434, 1307, 434, 1307,
+    434, 1331, 410, 460, 410, 460, 410, 1331, 410, 1331, 410, 1331, 410, 460, 410,
+    1331, 410, 1331, 410, 1331, 410, 1331, 410,
+};
+const uint8_t code_universal_off_rawCodes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_off_rawCode = {
+    freq_to_timerval(38000), 10, 3, code_universal_off_rawTimes, code_universal_off_rawCodes
+};
+
+// Power raw 2
+const uint32_t code_universal_power_raw2Times[] = {
+    1221, 1171, 433, 566, 433, 881, 433, 2381, 433, 1486, 434, 565, 434, 1486, 433,
+    1776, 433, 2380, 433, 565, 434, 2381, 433, 1170, 434, 87358, 1220, 1171, 433,
+    566, 433, 883, 431, 2381, 433, 1486, 433, 567, 432, 1487, 432, 1775, 434, 2381,
+    432, 566, 433, 2380, 434, 1171, 433, 86252, 1221, 1172, 432, 565, 434, 880, 435,
+    2381, 433, 1486, 433, 565, 434, 1487, 432, 1776, 433, 2380, 434, 566, 433, 2379, 434, 1170, 434,
+};
+const uint8_t code_universal_power_raw2Codes[] = {
+    0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+};
+const struct RawIrCode code_universal_power_raw2Code = {
+    freq_to_timerval(38000), 10, 3, code_universal_power_raw2Times, code_universal_power_raw2Codes
+};
+
+// Universal codes arrays for IrCode and RawIrCode
+const IrCode *const UniversalParsedCodes[] = {
+    &code_universal_samsungCode,
+    &code_universal_grundigCode,
+    &code_universal_lgCode,
+    &code_universal_sonyCode,
+    &code_universal_telefunkenCode,
+    &code_universal_vizioCode,
+    &code_universal_phillipsCode,
+    &code_universal_medionCode,
+    &code_universal_oppoCode,
+    &code_universal_fetchCode,
+    &code_universal_denverCode,
+    &code_universal_xboxCode,
+    &code_universal_platinumCode,
+    &code_universal_hisenseCode,
+    &code_universal_eliteluxCode,
+    &code_universal_androidCode,
+    &code_universal_sanyoCode,
+    &code_universal_smartboardCode,
+    &code_universal_remotesCode,
+    &code_universal_bushCode,
+    &code_universal_tlc_rokuCode,
+    &code_universal_lg_projectorCode,
+    &code_universal_power_onCode,
+    &code_universal_power_offCode,
+    &code_universal_szxlcomCode,
+    &code_universal_digi_daysCode,
+    &code_universal_amazonCode,
+    &code_universal_nec01Code,
+    &code_universal_nec013eCode,
+    &code_universal_nec04f4Code,
+    &code_universal_nec857cCode,
+    &code_universal_nec837aCode,
+    &code_universal_nec00f7Code,
+    &code_universal_nec72ddCode,
+    &code_universal_nec72dd2Code,
+    &code_universal_nec04b9Code,
+    &code_universal_nec00dfCode,
+    &code_universal_nec00bfCode,
+    &code_universal_necA0b7Code,
+    &code_universal_nec00bf00Code,
+    &code_universal_nec00fbCode,
+    &code_universal_nec84e0Code,
+    &code_universal_nec8605Code,
+    &code_universal_nec4040Code,
+    &code_universal_samsung3eCode,
+    &code_universal_samsung0eCode,
+    &code_universal_pioneerCode,
+    &code_universal_rcaCode,
+    &code_universal_rca_altCode,
+};
+const uint8_t num_UniversalParsedCodes = sizeof(UniversalParsedCodes) / sizeof(UniversalParsedCodes[0]);
+
+const RawIrCode *const UniversalRawCodes[] = {
+    &code_universal_most_tvsCode,
+    &code_universal_panasonicCode,
+    &code_universal_ehpCode,
+    &code_universal_generic_fanCode,
+    &code_universal_projector_freeCode,
+    &code_universal_projector_onCode,
+    &code_universal_projector_offCode,
+    &code_universal_projector_menuCode,
+    &code_universal_rokuCode,
+    &code_universal_xiomiCode,
+    &code_universal_power_rawCode,
+    &code_universal_off_rawCode,
+    &code_universal_power_raw2Code,
+};
+const uint8_t num_UniversalRawCodes = sizeof(UniversalRawCodes) / sizeof(UniversalRawCodes[0]);


### PR DESCRIPTION
## What this does
Turns TV-B-Gone into a universal power-off tool: after the region-specific NA/EU sweep, it now also fires a set of **universal power-off codes** covering projectors, set-top boxes and streaming sticks (Roku / Amazon / Android TV), not just TVs.

## Changes

**`TVBGoneData.h`**
- New `RawIrCode` struct (32-bit timings, for values above the 16-bit range).
- **49 universal parsed codes** + **13 raw codes**, exposed via `UniversalParsedCodes[]` / `UniversalRawCodes[]`. Data lifted verbatim from the Bruce PR; all 62 referenced codes are defined.

**`IRUtil.cpp`**
- `startTvBGone` refactored into `tvbSendParsedBatch` (bit-compressed, times ×10) and `tvbSendRawBatch` (raw microseconds, cast to `uint16_t` — values > 65535 truncate, matching Bruce's custom-IR loader).
- The three sweeps (region → universal parsed → universal raw) run in sequence behind a **single cumulative progress bar**, with mid-sweep cancel preserved.

## Notes

- **No behaviour change** for the existing NA/EU codes.
- Flash cost ≈ **+13 KB**.
- Kept the existing 200 ms inter-code gap (this branch is cut from `main`, so it does not pull in the separate TV-B-Gone timing tweak).
- Fidelity: some raw codes carry a `numpairs` smaller than their timing array, so only the first `2×numpairs` pulses are sent — identical to the upstream Bruce PR, intentionally not "fixed" here.