### PR TITLE
wifi-analyzer: list connected clients per AP

### DIFF
--- a/firmware/src/screens/wifi/WifiAnalyzerScreen.cpp
+++ b/firmware/src/screens/wifi/WifiAnalyzerScreen.cpp
@@ -1,11 +1,80 @@
 #include "WifiAnalyzerScreen.h"
 #include "core/Device.h"
 #include "core/ScreenManager.h"
+#include "core/ConfigManager.h"
 #include "core/AchievementManager.h"
 #include "screens/wifi/WifiMenuScreen.h"
 #include "ui/actions/ShowStatusAction.h"
 
 #include <WiFi.h>
+#include <esp_wifi.h>
+#include <string.h>
+
+// ── Client sniffer (promiscuous) ─────────────────────────────────────────────
+//
+// When an AP is selected we lock the radio to its channel, turn on promiscuous
+// mode and record the unique station MACs seen talking to/from that BSSID.
+// The callback runs in the WiFi task, so the shared store is guarded with a
+// portMUX spinlock; the screen copies it out and renders on the main loop.
+
+static constexpr uint8_t kMaxClients = 32;  // must match MAX_CLIENTS in the header
+
+static portMUX_TYPE _cliMux = portMUX_INITIALIZER_UNLOCKED;
+static uint8_t      _cliMacs[kMaxClients][6];
+static volatile uint8_t _cliCount = 0;
+static uint8_t      _targetBssid[6];
+
+// Multicast/broadcast group bit (LSB of the first octet). Group-addressed
+// frames never identify a real station, so they are ignored.
+static inline bool _isGroupAddr(const uint8_t* m) { return (m[0] & 0x01) != 0; }
+
+static void _addClient(const uint8_t* mac)
+{
+  portENTER_CRITICAL(&_cliMux);
+  bool found = false;
+  for (uint8_t i = 0; i < _cliCount; i++) {
+    if (memcmp(_cliMacs[i], mac, 6) == 0) { found = true; break; }
+  }
+  if (!found && _cliCount < kMaxClients) {
+    memcpy(_cliMacs[_cliCount], mac, 6);
+    _cliCount++;
+  }
+  portEXIT_CRITICAL(&_cliMux);
+}
+
+static void _clientSnifferCb(void* buf, wifi_promiscuous_pkt_type_t type)
+{
+  if (type != WIFI_PKT_DATA && type != WIFI_PKT_MGMT) return;
+
+  const auto* pkt = (const wifi_promiscuous_pkt_t*)buf;
+  if (pkt->rx_ctrl.sig_len < 24) return;  // need a full 3-address MAC header
+
+  const uint8_t* pl    = pkt->payload;
+  const uint8_t  flags = pl[1];
+  const bool     toDS   = flags & 0x01;
+  const bool     fromDS = flags & 0x02;
+
+  const uint8_t* a1 = pl + 4;    // addr1
+  const uint8_t* a2 = pl + 10;   // addr2
+  const uint8_t* a3 = pl + 16;   // addr3
+
+  // Resolve which address is the BSSID and which is the station from the
+  // toDS/fromDS flags. WDS (both set) uses a 4-address header — skip it.
+  const uint8_t* bssid;
+  const uint8_t* sta;
+  if (toDS && !fromDS)        { bssid = a1; sta = a2; }  // STA -> AP
+  else if (!toDS && fromDS)   { bssid = a2; sta = a1; }  // AP  -> STA
+  else if (!toDS && !fromDS)  { bssid = a3; sta = a2; }  // mgmt / IBSS
+  else                        return;
+
+  if (memcmp(bssid, _targetBssid, 6) != 0) return;
+  if (_isGroupAddr(sta)) return;
+  if (memcmp(sta, _targetBssid, 6) == 0) return;  // the AP itself, not a client
+
+  _addClient(sta);
+}
+
+// ── Lifecycle ────────────────────────────────────────────────────────────────
 
 void WifiAnalyzerScreen::onInit()
 {
@@ -14,14 +83,18 @@ void WifiAnalyzerScreen::onInit()
 
 void WifiAnalyzerScreen::onUpdate()
 {
-  if (_state == STATE_INFO) {
+  if (_state == STATE_CLIENTS) {
     if (Uni.Nav->wasPressed()) {
       auto dir = Uni.Nav->readDirection();
-      if (dir == INavigation::DIR_BACK) { _showScan(); return; }
+      if (dir == INavigation::DIR_BACK) { _stopClients(); _showScan(); return; }
 #ifndef DEVICE_HAS_KEYBOARD
-      if (dir == INavigation::DIR_PRESS) { _showScan(); return; }
+      if (dir == INavigation::DIR_PRESS) { _stopClients(); _showScan(); return; }
 #endif
       _scrollView.onNav(dir);
+    }
+    if (millis() - _lastClientRefresh >= 700) {
+      _lastClientRefresh = millis();
+      _refreshClients(false);
     }
     return;
   }
@@ -31,13 +104,13 @@ void WifiAnalyzerScreen::onUpdate()
 void WifiAnalyzerScreen::onItemSelected(uint8_t index)
 {
   if (_state == STATE_SCAN && index < _entryCount) {
-    _showInfo(index);
+    _showClients(index);
   }
 }
 
 void WifiAnalyzerScreen::onRender()
 {
-  if (_state == STATE_INFO) {
+  if (_state == STATE_CLIENTS) {
     _scrollView.render(bodyX(), bodyY(), bodyW(), bodyH());
     return;
   }
@@ -46,7 +119,8 @@ void WifiAnalyzerScreen::onRender()
 
 void WifiAnalyzerScreen::onBack()
 {
-  if (_state == STATE_INFO) {
+  if (_state == STATE_CLIENTS) {
+    _stopClients();
     _showScan();
   } else {
     WiFi.scanDelete();
@@ -113,21 +187,79 @@ void WifiAnalyzerScreen::_showScan()
   setItems(_scanItems, _entryCount);
 }
 
-void WifiAnalyzerScreen::_showInfo(int index)
+void WifiAnalyzerScreen::_showClients(int index)
 {
-  _state = STATE_INFO;
-  strncpy(_title, "WiFi Info", sizeof(_title));
+  _selectedAp = index;
+  _state      = STATE_CLIENTS;
 
-  _infoRows[0] = {"SSID",       _entries[index].ssid};
-  _infoRows[1] = {"BSSID",      _entries[index].bssid};
-  _infoRows[2] = {"RSSI",       _entries[index].rssi};
-  _infoRows[3] = {"Channel",    _entries[index].channel};
-  _infoRows[4] = {"Encryption", _entries[index].encryption};
+  // Parse the selected AP's BSSID + channel and reset the shared store.
+  unsigned v[6] = {0};
+  sscanf(_entries[index].bssid, "%02x:%02x:%02x:%02x:%02x:%02x",
+         &v[0], &v[1], &v[2], &v[3], &v[4], &v[5]);
+  portENTER_CRITICAL(&_cliMux);
+  for (int i = 0; i < 6; i++) _targetBssid[i] = (uint8_t)v[i];
+  _cliCount = 0;
+  portEXIT_CRITICAL(&_cliMux);
 
-  int nd = Achievement.inc("wifi_analyzer_detail");
-  if (nd == 1) Achievement.unlock("wifi_analyzer_detail");
+  _lastClientCount   = -1;
+  _lastClientRefresh = millis();
+  _scrollView.resetScroll();
 
-  setItems(nullptr, 0);
-  _scrollView.setRows(_infoRows, 5);
+  int ch = atoi(_entries[index].channel);
+  if (ch < 1) ch = 1;
+
+  WiFi.mode(WIFI_MODE_STA);
+  esp_wifi_set_promiscuous(true);
+  esp_wifi_set_promiscuous_rx_cb(&_clientSnifferCb);
+  esp_wifi_set_channel((uint8_t)ch, WIFI_SECOND_CHAN_NONE);
+
+  setItems(nullptr, 0);     // hand the body over to the scroll view
+  _refreshClients(true);    // build the info rows + "Listening..." and render
+}
+
+void WifiAnalyzerScreen::_stopClients()
+{
+  esp_wifi_set_promiscuous_rx_cb(nullptr);
+  delay(10);
+  esp_wifi_set_promiscuous(false);
+}
+
+void WifiAnalyzerScreen::_refreshClients(bool force)
+{
+  // Snapshot the shared MAC store under the lock, then format outside it
+  // (String allocation must not happen inside a critical section).
+  uint8_t macs[kMaxClients][6];
+  uint8_t n;
+  portENTER_CRITICAL(&_cliMux);
+  n = _cliCount;
+  for (uint8_t i = 0; i < n; i++) memcpy(macs[i], _cliMacs[i], 6);
+  portEXIT_CRITICAL(&_cliMux);
+
+  if (!force && (int)n == _lastClientCount) return;  // nothing new to show
+  _lastClientCount = n;
+
+  // Row 0..4: the AP details (kept visible regardless of client count).
+  _rows[0] = {"SSID",       _entries[_selectedAp].ssid};
+  _rows[1] = {"BSSID",      _entries[_selectedAp].bssid};
+  _rows[2] = {"RSSI",       _entries[_selectedAp].rssi};
+  _rows[3] = {"Channel",    _entries[_selectedAp].channel};
+  _rows[4] = {"Encryption", _entries[_selectedAp].encryption};
+
+  // Clients section header, then one row per captured MAC below it.
+  _rows[INFO_ROWS] = {"Clients", n > 0 ? String((unsigned)n)
+                                       : String("Listening...")};
+  uint8_t r = INFO_ROWS + 1;
+  for (uint8_t i = 0; i < n; i++) {
+    snprintf(_clientLabels[i], sizeof(_clientLabels[i]), "#%u", (unsigned)(i + 1));
+    char m[18];
+    snprintf(m, sizeof(m), "%02X:%02X:%02X:%02X:%02X:%02X",
+             macs[i][0], macs[i][1], macs[i][2], macs[i][3], macs[i][4], macs[i][5]);
+    _rows[r].label = _clientLabels[i];
+    _rows[r].value = m;
+    r++;
+  }
+  _scrollView.setRows(_rows, r);
+
+  snprintf(_title, sizeof(_title), "Clients (%u)", (unsigned)n);
   render();
 }

--- a/firmware/src/screens/wifi/WifiAnalyzerScreen.h
+++ b/firmware/src/screens/wifi/WifiAnalyzerScreen.h
@@ -8,6 +8,9 @@ class WifiAnalyzerScreen : public ListScreen
 public:
   const char* title() override { return _title; }
 
+  // Keep WiFi awake while sniffing clients (promiscuous mode).
+  bool inhibitPowerSave() override { return _state == STATE_CLIENTS; }
+
   void onInit() override;
   void onUpdate() override;
   void onRender() override;
@@ -15,9 +18,10 @@ public:
   void onBack() override;
 
 private:
-  static constexpr int MAX_SCAN = 20;
+  static constexpr int MAX_SCAN    = 20;
+  static constexpr int MAX_CLIENTS = 32;  // keep in sync with kMaxClients in .cpp
 
-  enum State { STATE_SCAN, STATE_INFO };
+  enum State { STATE_SCAN, STATE_CLIENTS };
   State _state = STATE_SCAN;
 
   struct WifiEntry {
@@ -32,11 +36,21 @@ private:
   WifiEntry _entries[MAX_SCAN];
   int       _entryCount        = 0;
 
-  ListItem         _scanItems[MAX_SCAN];
-  ScrollListView   _scrollView;
-  ScrollListView::Row _infoRows[5];
+  ListItem       _scanItems[MAX_SCAN];
+  ScrollListView _scrollView;
+
+  // Client sniffer (per-AP) state. The detail view is one scrollable list:
+  // the AP info rows on top, then a "Clients" header, then the live MACs.
+  static constexpr int INFO_ROWS = 5;  // SSID, BSSID, RSSI, Channel, Encryption
+  int                 _selectedAp        = -1;
+  ScrollListView::Row _rows[INFO_ROWS + 1 + MAX_CLIENTS];
+  char                _clientLabels[MAX_CLIENTS][6];
+  int                 _lastClientCount   = -1;
+  uint32_t            _lastClientRefresh = 0;
 
   void _scan();
   void _showScan();
-  void _showInfo(int index);
+  void _showClients(int index);
+  void _stopClients();
+  void _refreshClients(bool force);
 };


### PR DESCRIPTION
## What this does

Adds a per-AP client list to the WiFi Analyzer. Selecting a network now locks the radio to that AP's channel, turns on promiscuous mode, and shows the stations communicating with it — useful for auditing your own network.

## UI

The detail view is a single scrollable list:

```
SSID         MyNetwork
BSSID        AA:BB:CC:DD:EE:FF
RSSI         [-52] Good
Channel      6
Encryption   WPA2_PSK
Clients      Listening...      <- becomes the count once traffic appears
#1           11:22:33:44:55:66
#2           77:88:99:AA:BB:CC
```

The AP info rows stay pinned on top regardless of client count; MAC rows grow live as devices are seen. Up/Down scroll, Back returns to the AP list.

## How it works

- Station MACs are resolved from the 802.11 MAC header using the `toDS`/`fromDS` flags (STA→AP, AP→STA, IBSS/mgmt), filtering out group (broadcast/multicast) addresses and the AP's own BSSID.
- Up to 32 clients tracked per AP. The shared store is guarded with a `portMUX` spinlock — the RX callback runs in the WiFi task while the screen renders on the main loop (same safety model as the Packet Monitor).
- Promiscuous mode is torn down on Back; `inhibitPowerSave()` is active only while sniffing.

## Notes

- **Passive only**: a client shows up once it transmits; a silent associated device won't appear until it sends/receives traffic.
- No behaviour change to the AP scan itself. Flash cost is negligible (~1 KB).