### PR TITLE
firmware(lua): show script titles instead of filenames

### DIFF
--- a/firmware/src/screens/LuaScreen.cpp
+++ b/firmware/src/screens/LuaScreen.cpp
@@ -11,7 +11,7 @@ void LuaScreen::_loadDir(const String& path) {
   // _browser.root confines the picker to ROOT_DIR — ".." appears below but
   // never resolves above /unigeek/lua.
   _browser.root = ROOT_DIR;
-  _browser.load(this, path, ".lua");
+  _browser.load(this, path, ".lua", nullptr, BrowseFileView::TITLE);
   setItems(_browser.items(), _browser.count());
 }
 

--- a/firmware/src/screens/wifi/network/DownloadScreen.cpp
+++ b/firmware/src/screens/wifi/network/DownloadScreen.cpp
@@ -6,6 +6,7 @@
 #include "utils/network/WebFileManager.h"
 #include "ui/actions/ShowStatusAction.h"
 #include "ui/views/ProgressView.h"
+#include "ui/views/BrowseFileView.h"
 #include <WiFi.h>
 #include <HTTPClient.h>
 #include <WiFiClientSecure.h>
@@ -810,8 +811,8 @@ bool DownloadScreen::_populateLuaLevel(const String& path) {
     if (rest.length() == 0) continue;
 
     _luaIsFolder[_luaCount] = false;
-    _luaNames[_luaCount]    = rest;
-    _luaLabels[_luaCount]   = rest;
+    _luaNames[_luaCount]    = rest;                              // raw name → download path
+    _luaLabels[_luaCount]   = BrowseFileView::prettifyTitle(rest); // display title only
     _luaItems[_luaCount]    = {_luaLabels[_luaCount].c_str()};
     _luaCount++;
   }

--- a/firmware/src/ui/views/BrowseFileView.cpp
+++ b/firmware/src/ui/views/BrowseFileView.cpp
@@ -7,8 +7,32 @@ void BrowseFileView::showLoading()
   ShowStatusAction::show("Loading...", 0);
 }
 
+String BrowseFileView::prettifyTitle(const String& filename)
+{
+  // Strip the last extension (".lua", ".ir", …).
+  int dot = filename.lastIndexOf('.');
+  String base = (dot > 0) ? filename.substring(0, dot) : filename;
+
+  // Split on '-'/'_'/space; Title-Case each word; join with single spaces.
+  String out;
+  bool   startWord = true;
+  for (uint16_t i = 0; i < base.length(); i++) {
+    char c = base[i];
+    if (c == '-' || c == '_' || c == ' ') {
+      if (out.length() > 0 && !out.endsWith(" ")) out += ' ';
+      startWord = true;
+      continue;
+    }
+    if (startWord) { c = toupper((unsigned char)c); startWord = false; }
+    out += c;
+  }
+  out.trim();
+  return out.length() > 0 ? out : filename;
+}
+
 uint8_t BrowseFileView::load(BaseScreen* host, String dir,
-                              Mode mode, const char* fileSublabel)
+                              Mode mode, const char* fileSublabel,
+                              LabelStyle style)
 {
   _count = 0;
   showLoading();
@@ -24,9 +48,10 @@ uint8_t BrowseFileView::load(BaseScreen* host, String dir,
     String parent = (slash > 0) ? dir.substring(0, slash) : root;
     if (root.length() > 1 && !parent.startsWith(root)) parent = root;
     _entries[_count].name  = "..";
+    _entries[_count].label = "..";
     _entries[_count].path  = parent;
     _entries[_count].isDir = true;
-    _listItems[_count]     = { "..", "Up" };
+    _listItems[_count]     = { _entries[_count].label.c_str(), "Up" };
     _count++;
   }
 
@@ -55,9 +80,12 @@ uint8_t BrowseFileView::load(BaseScreen* host, String dir,
     if (mode.kind == Mode::DIRECTORY && !raw[i].isDir) continue;
     if (mode.ext && !raw[i].isDir && !raw[i].name.endsWith(mode.ext)) continue;
     _entries[_count].name  = raw[i].name;
+    _entries[_count].label = (style == TITLE && !raw[i].isDir)
+                               ? prettifyTitle(raw[i].name)
+                               : raw[i].name;
     _entries[_count].path  = base + "/" + raw[i].name;
     _entries[_count].isDir = raw[i].isDir;
-    _listItems[_count]     = { _entries[_count].name.c_str(),
+    _listItems[_count]     = { _entries[_count].label.c_str(),
                                 raw[i].isDir ? "DIR" : fileSublabel };
     _count++;
   }

--- a/firmware/src/ui/views/BrowseFileView.h
+++ b/firmware/src/ui/views/BrowseFileView.h
@@ -51,10 +51,22 @@ struct BrowseFileView {
   };
 
   struct Entry {
-    String name;
+    String name;   // raw filename — used to build path / selection
+    String label;  // display label — defaults to name; TITLE style prettifies files
     String path;
     bool   isDir = false;
   };
+
+  // Display label style for file rows (directories always show their name).
+  //   NAME  — show the raw filename (default; unchanged behavior)
+  //   TITLE — show prettifyTitle(name): strip extension, dashes/underscores to
+  //           spaces, Title Case. e.g. "hacker-news.lua" -> "Hacker News".
+  enum LabelStyle { NAME, TITLE };
+
+  // Filename -> friendly title. Static so other screens (e.g. the remote Lua
+  // browser) can reuse the exact same mapping. Keep in sync with the website
+  // catalog generator's prettify().
+  static String prettifyTitle(const String& filename);
 
   // Subtree the picker is confined to. ".." inserts only below this path and
   // never resolves above it. Default "/" = no confinement (filesystem root).
@@ -75,7 +87,8 @@ struct BrowseFileView {
   // the selected dir's path). The copy keeps the input stable.
   uint8_t load(BaseScreen* host, String dir,
                Mode        mode         = {},
-               const char* fileSublabel = nullptr);
+               const char* fileSublabel = nullptr,
+               LabelStyle  style        = NAME);
 
   uint8_t        count()          const { return _count; }
   const Entry&   entry(uint8_t i) const { return _entries[i]; }


### PR DESCRIPTION
The on-device Lua list now shows a friendly **title** instead of the raw filename — e.g. `hacker-news.lua` renders as **Hacker News**.

### Changes
- **`BrowseFileView`** gains a per-entry display **`label`** (kept separate from the raw `name`, which still builds the path / drives selection), a **`LabelStyle{NAME,TITLE}`** option on `load()`, and a static **`prettifyTitle()`** (strip the extension, `-`/`_` → spaces, Title-Case each word). Default is `NAME`, so **every existing caller is unchanged**.
- **`LuaScreen`** (the Lua Runner) opts into `TITLE`.
- **`DownloadScreen`** — the remote Lua download browser shows titles too. The **download path is unchanged** (it still uses the raw filename); only the label is prettified.

Directories and the `..` row keep their names. `prettifyTitle()` uses the same rule as the website catalog generator, so on-device and web titles match.

Companion PRs add the App Store web page and the `lshaf/unigeek-lua` app catalog.