### PR TITLE
feat(subghz): selectable jammer modes (Full Power, Intermittent, Noise Storm, Freq Sweep)

### DIFF
--- a/firmware/src/screens/module/RfCaptureScreen.cpp
+++ b/firmware/src/screens/module/RfCaptureScreen.cpp
@@ -99,7 +99,7 @@ void RfCaptureScreen::onUpdate() {
       auto dir = Uni.Nav->readDirection();
       if (dir == INavigation::DIR_BACK || dir == INavigation::DIR_PRESS) {
         _radioStopJam();
-        _showMenu();
+        if (!_onJamStopped()) _showMenu();
         return;
       }
     }
@@ -167,8 +167,19 @@ void RfCaptureScreen::onRender() {
 
     char freqStr[24];
     _radioFreqLabel(freqStr, sizeof(freqStr));
-    lcd.drawString(freqStr, bodyX() + bodyW() / 2, bodyY() + bodyH() / 2 - 20);
-    lcd.drawString("Jamming...", bodyX() + bodyW() / 2, bodyY() + bodyH() / 2);
+
+    const char* modeName = _radioJamModeName();
+    int cy = bodyY() + bodyH() / 2;
+    if (modeName) {
+      lcd.drawString(freqStr, bodyX() + bodyW() / 2, cy - 30);
+      lcd.setTextColor(Config.getThemeColor(), TFT_BLACK);
+      lcd.drawString(modeName, bodyX() + bodyW() / 2, cy - 12);
+      lcd.setTextColor(TFT_WHITE, TFT_BLACK);
+      lcd.drawString("Jamming...", bodyX() + bodyW() / 2, cy + 8);
+    } else {
+      lcd.drawString(freqStr, bodyX() + bodyW() / 2, cy - 20);
+      lcd.drawString("Jamming...", bodyX() + bodyW() / 2, cy);
+    }
 
     #ifdef DEVICE_HAS_KEYBOARD
       lcd.drawString("BACK: Stop", bodyX() + bodyW() / 2, bodyY() + bodyH() - 10);
@@ -208,7 +219,7 @@ void RfCaptureScreen::onBack() {
     _showMenu();
   } else if (_state == STATE_JAMMING) {
     _radioStopJam();
-    _showMenu();
+    if (!_onJamStopped()) _showMenu();
   } else if (_state == STATE_SEND_BROWSE) {
     if (_browsePath == kRootPath) {
       _showMenu();

--- a/firmware/src/screens/module/RfCaptureScreen.h
+++ b/firmware/src/screens/module/RfCaptureScreen.h
@@ -98,6 +98,12 @@ protected:
   virtual bool _onBackExtra()               { return false; }
   virtual bool _onItemSelectedExtra(uint8_t /*idx*/) { return false; }
   virtual bool _inhibitExtra() const        { return false; }
+  // Active jammer mode name, shown under "Jamming..." — nullptr hides the line.
+  virtual const char* _radioJamModeName()   { return nullptr; }
+  // Called after the jam is stopped by BACK. Return true if the derived screen
+  // took over navigation (e.g. reopened its mode menu); false lets the base fall
+  // back to the main menu. Radio is already stopped when this runs.
+  virtual bool _onJamStopped()              { return false; }
 
   // ── Shared helpers (called by base + reusable by derived) ──────────────
   void   _enterReceiveMode();

--- a/firmware/src/screens/module/SubGHzScreen.cpp
+++ b/firmware/src/screens/module/SubGHzScreen.cpp
@@ -130,22 +130,17 @@ void SubGHzScreen::_radioSendCaptured(const Signal& sig) {
 
 bool SubGHzScreen::_radioStartJam() {
   if (!_rf.begin(Uni.Spi, _csPin, _gdo0Pin)) return false;
-  _rf.startTx();
+  _rf.startJam(_jamMode);
   return true;
 }
 
 void SubGHzScreen::_radioStopJam() {
-  digitalWrite(_gdo0Pin, LOW);
+  _rf.stopJam();
   _rf.end();
 }
 
 void SubGHzScreen::_radioJamBurst() {
-  for (int i = 0; i < 50; i++) {
-    uint32_t pw  = 5 + (micros() % 46);
-    uint32_t gap = 5 + (micros() % 96);
-    digitalWrite(_gdo0Pin, HIGH); delayMicroseconds(pw);
-    digitalWrite(_gdo0Pin, LOW);  delayMicroseconds(gap);
-  }
+  _rf.jamTick();
 }
 
 // ── Menu ────────────────────────────────────────────────────────────────────
@@ -240,12 +235,7 @@ void SubGHzScreen::_onMenuSelected(uint8_t index) {
         render();
         return;
       }
-      if (!_radioStartJam()) {
-        ShowStatusAction::show("CC1101 not found");
-        render();
-        return;
-      }
-      _enterJammingMode();
+      if (!_beginJammer()) render();  // cancelled → back to Sub-GHz menu
       return;
     }
     case 6: { // Brute Force
@@ -253,6 +243,33 @@ void SubGHzScreen::_onMenuSelected(uint8_t index) {
       return;
     }
   }
+}
+
+bool SubGHzScreen::_beginJammer() {
+  int mode = _selectJammerMode();
+  if (mode < 0) return false;  // cancelled
+  _jamMode = (CC1101Util::JamMode)mode;
+  if (!_radioStartJam()) {
+    ShowStatusAction::show("CC1101 not found");
+    return false;
+  }
+  _enterJammingMode();
+  return true;
+}
+
+int SubGHzScreen::_selectJammerMode() {
+  static constexpr InputSelectAction::Option modeOpts[] = {
+    {"Full Power",   "0"},  // max duty-cycle continuous TX
+    {"Intermittent", "1"},  // varied pulse patterns + bursts
+    {"Noise Storm",  "2"},  // CC1101 PN9 hardware random noise
+    {"Freq Sweep",   "3"},  // sweep +/-5 MHz around target
+  };
+  char curBuf[4];
+  snprintf(curBuf, sizeof(curBuf), "%d", (int)_jamMode);
+  const char* choice = InputSelectAction::popup("Jammer Mode", modeOpts,
+                                                CC1101Util::JAM_MODE_COUNT, curBuf);
+  if (!choice) return -1;
+  return atoi(choice);
 }
 
 void SubGHzScreen::_selectFrequency() {

--- a/firmware/src/screens/module/SubGHzScreen.h
+++ b/firmware/src/screens/module/SubGHzScreen.h
@@ -32,6 +32,9 @@ protected:
   bool        _radioStartJam()                    override;
   void        _radioStopJam()                     override;
   void        _radioJamBurst()                    override;
+  const char* _radioJamModeName()                 override { return CC1101Util::jamModeName(_jamMode); }
+  // BACK from jamming reopens the mode menu instead of the Sub-GHz menu.
+  bool        _onJamStopped()                      override { return _beginJammer(); }
   RxFilter    _radioGetRxFilter()                 override { return _rf.getRxFilter(); }
   void        _radioSetRxFilter(RxFilter f)       override { _rf.setRxFilter(f); }
   void        _radioFreqLabel(char* buf, size_t n) override {
@@ -56,6 +59,12 @@ private:
   CC1101Util _rf;
   int8_t _csPin   = -1;
   int8_t _gdo0Pin = -1;
+  CC1101Util::JamMode _jamMode = CC1101Util::JAM_FULL;
+  // Mode-select popup shown when entering Jammer; returns -1 on cancel.
+  int  _selectJammerMode();
+  // Show the mode popup then start jamming; true if jamming began, false on
+  // cancel / no radio. Shared by the menu entry and the BACK-from-jam path.
+  bool _beginJammer();
   bool   _rfDetectFired = false;  // achievement guard, resets each scan session
   String _pendingReplayFile;      // set via ctor: transmit this .sub then goBack
   void _replayPendingFile();

--- a/firmware/src/utils/rf/CC1101Util.cpp
+++ b/firmware/src/utils/rf/CC1101Util.cpp
@@ -596,6 +596,191 @@ void CC1101Util::startTx() {
   pinMode(_gdo0Pin, OUTPUT);
 }
 
+// ── Multi-mode jammer ───────────────────────────────────────────────────────
+
+const char* CC1101Util::jamModeName(JamMode m) {
+  switch (m) {
+    case JAM_FULL:  return "Full Power";
+    case JAM_ITMT:  return "Intermittent";
+    case JAM_NOISE: return "Noise Storm";
+    case JAM_SWEEP: return "Freq Sweep";
+    default:        return "Jammer";
+  }
+}
+
+void CC1101Util::startJam(JamMode mode) {
+  if (!_initialized) return;
+  _jamMode    = mode;
+  _jamPulses  = 0;
+  _jamSweeps  = 0;
+  _jamStartMs = millis();
+
+  switch (mode) {
+    case JAM_NOISE:
+      // CC1101 PN9 pseudo-random TX — the chip generates continuous modulated
+      // noise. High data rate widens the occupied bandwidth; PA at max.
+      ELECHOUSE_cc1101.setSidle();
+      ELECHOUSE_cc1101.setPktFormat(2);    // PN9 random TX mode
+      ELECHOUSE_cc1101.setDRate(800);      // wider occupied bandwidth
+      ELECHOUSE_cc1101.setModulation(2);   // start on ASK/OOK
+      ELECHOUSE_cc1101.setDeviation(47.6); // max deviation for the FSK legs
+      ELECHOUSE_cc1101.setRxBW(812);
+      ELECHOUSE_cc1101.setPA(12);
+      ELECHOUSE_cc1101.SetTx();
+      _jamNoiseMod = 0;
+      break;
+
+    case JAM_SWEEP:
+      // OOK carrier keyed over GDO0, retuned +/-5 MHz each tick.
+      _jamBaseFreq  = _freq;
+      _jamSweepFreq = _freq - 5.0f;
+      _jamSweepFwd  = true;
+      ELECHOUSE_cc1101.setModulation(2);
+      ELECHOUSE_cc1101.setPktFormat(3);
+      ELECHOUSE_cc1101.setPA(12);
+      ELECHOUSE_cc1101.setMHZ(_jamSweepFreq);
+      ELECHOUSE_cc1101.SetTx();
+      pinMode(_gdo0Pin, OUTPUT);
+      break;
+
+    default:  // JAM_FULL, JAM_ITMT — carrier keyed over GDO0 at the fixed freq
+      ELECHOUSE_cc1101.setPA(12);
+      ELECHOUSE_cc1101.setModulation(2);
+      ELECHOUSE_cc1101.setPktFormat(3);
+      ELECHOUSE_cc1101.SetTx();
+      pinMode(_gdo0Pin, OUTPUT);
+      break;
+  }
+}
+
+void CC1101Util::jamTick() {
+  if (!_initialized) return;
+
+  switch (_jamMode) {
+    case JAM_FULL: {
+      // Max duty-cycle carrier keying — rotate through three attack phases every
+      // 100 ms for the widest spectral pollution around the centre frequency.
+      uint8_t phase = ((millis() - _jamStartMs) / 100) % 3;
+      if (phase == 0) {
+        // Ultra-rapid micro-glitches (3 us HIGH / 1 us LOW).
+        for (int i = 0; i < 100; i++) {
+          digitalWrite(_gdo0Pin, HIGH); delayMicroseconds(3);
+          digitalWrite(_gdo0Pin, LOW);  delayMicroseconds(1);
+          _jamPulses++;
+        }
+      } else if (phase == 1) {
+        // Variable-width bursts (2-20 us).
+        for (int i = 0; i < 50; i++) {
+          uint32_t w = 2 + (micros() % 18);
+          digitalWrite(_gdo0Pin, HIGH); delayMicroseconds(w);
+          digitalWrite(_gdo0Pin, LOW);  delayMicroseconds(1);
+          _jamPulses++;
+        }
+      } else {
+        // Sustained carrier with periodic hard cuts.
+        digitalWrite(_gdo0Pin, HIGH); delayMicroseconds(80);
+        digitalWrite(_gdo0Pin, LOW);  delayMicroseconds(2);
+        digitalWrite(_gdo0Pin, HIGH); delayMicroseconds(80);
+        digitalWrite(_gdo0Pin, LOW);
+        _jamPulses += 2;
+      }
+      break;
+    }
+
+    case JAM_ITMT: {
+      // One forward sweep of pulse widths (10 -> 500 us) plus a random noise
+      // burst, for a chirp-like intermittent disruption.
+      for (uint32_t seq = 0; seq < 50; seq++) {
+        _jamSendPulse(10 * (seq + 1));
+        _jamPulses++;
+      }
+      _jamRandomBurst(120);
+      _jamPulses += 120;
+      break;
+    }
+
+    case JAM_NOISE: {
+      // Hardware drives the PN9 TX on its own; here we just cycle the modulation
+      // scheme every 3 s (ASK -> 2-FSK -> MSK) for spectral diversity.
+      uint32_t now = millis();
+      uint8_t newMod = ((now - _jamStartMs) / 3000) % 3;
+      if (newMod != _jamNoiseMod) {
+        static const uint8_t schemes[] = {2, 0, 1}; // ASK/OOK, 2-FSK, MSK
+        _jamNoiseMod = newMod;
+        ELECHOUSE_cc1101.setSidle();
+        ELECHOUSE_cc1101.setModulation(schemes[newMod]);
+        ELECHOUSE_cc1101.SetTx();
+      }
+      _jamPulses = (now - _jamStartMs) / 1000;  // seconds on air
+      delay(20);  // hardware handles TX — keep CPU cool but stay responsive
+      break;
+    }
+
+    case JAM_SWEEP: {
+      ELECHOUSE_cc1101.setMHZ(_jamSweepFreq);
+      // Tight TX burst at the current step.
+      for (int b = 0; b < 40; b++) {
+        digitalWrite(_gdo0Pin, HIGH); delayMicroseconds(30);
+        digitalWrite(_gdo0Pin, LOW);  delayMicroseconds(5);
+        _jamPulses++;
+      }
+      // Bidirectional sweep across +/-5 MHz in 50 kHz steps.
+      const float lo = _jamBaseFreq - 5.0f;
+      const float hi = _jamBaseFreq + 5.0f;
+      if (_jamSweepFwd) {
+        _jamSweepFreq += 0.05f;
+        if (_jamSweepFreq > hi) { _jamSweepFreq = hi; _jamSweepFwd = false; _jamSweeps++; }
+      } else {
+        _jamSweepFreq -= 0.05f;
+        if (_jamSweepFreq < lo) { _jamSweepFreq = lo; _jamSweepFwd = true; _jamSweeps++; }
+      }
+      break;
+    }
+
+    default: break;
+  }
+}
+
+void CC1101Util::stopJam() {
+  if (!_initialized) return;
+  digitalWrite(_gdo0Pin, LOW);
+
+  if (_jamMode == JAM_NOISE) {
+    // Restore the async-serial defaults the rest of the driver expects.
+    ELECHOUSE_cc1101.setSidle();
+    ELECHOUSE_cc1101.setPktFormat(3);
+    ELECHOUSE_cc1101.setDRate(50);
+  } else if (_jamMode == JAM_SWEEP) {
+    ELECHOUSE_cc1101.setMHZ(_jamBaseFreq);
+  }
+  ELECHOUSE_cc1101.setSidle();
+}
+
+void CC1101Util::_jamSendPulse(uint32_t width) {
+  // Aggressive HIGH phase: rapid micro-interruptions every 6 us create wideband
+  // harmonic content around the centre frequency, then a sustained tail.
+  for (uint32_t i = 0; i < width; i += 6) {
+    digitalWrite(_gdo0Pin, HIGH); delayMicroseconds(5);
+    digitalWrite(_gdo0Pin, LOW);  delayMicroseconds(1);
+  }
+  digitalWrite(_gdo0Pin, HIGH); delayMicroseconds(width / 3);
+  digitalWrite(_gdo0Pin, LOW);
+  uint32_t lowPeriod = width / 4;   // minimal dead time — maximise duty cycle
+  if (lowPeriod > 0) delayMicroseconds(lowPeriod);
+}
+
+void CC1101Util::_jamRandomBurst(int numPulses) {
+  uint32_t start = millis();
+  for (int i = 0; i < numPulses; i++) {
+    uint32_t pulseWidth = 1 + (micros() % 60);
+    digitalWrite(_gdo0Pin, HIGH); delayMicroseconds(pulseWidth);
+    digitalWrite(_gdo0Pin, LOW);
+    uint32_t spaceWidth = 1 + (micros() % 8);
+    delayMicroseconds(spaceWidth);
+    if (millis() - start > 20) break;  // bounded chunk — keep BACK responsive
+  }
+}
+
 // ── Send ──────────────────────────────────────────────────────────────────
 
 void CC1101Util::sendSignal(const Signal& sig) {

--- a/firmware/src/utils/rf/CC1101Util.h
+++ b/firmware/src/utils/rf/CC1101Util.h
@@ -26,6 +26,19 @@ public:
     RX_FILTER_RAW,
   };
 
+  // Jammer modes — selectable when entering the Jammer screen.
+  //   JAM_FULL  : max duty-cycle carrier keyed over GDO0 (multi-phase glitching)
+  //   JAM_ITMT  : intermittent — swept pulse widths + random noise bursts
+  //   JAM_NOISE : CC1101 PN9 hardware random TX, cycling ASK/2-FSK/MSK
+  //   JAM_SWEEP : hop +/-5 MHz around the target in 50 kHz steps, burst per step
+  enum JamMode : uint8_t {
+    JAM_FULL = 0,
+    JAM_ITMT,
+    JAM_NOISE,
+    JAM_SWEEP,
+    JAM_MODE_COUNT
+  };
+
   struct Signal {
     float frequency = 0;     // MHz
     String preset = "0";     // modulation preset name or RcSwitch protocol number
@@ -147,6 +160,20 @@ public:
 
   // Start TX mode (for jammer — caller controls GDO0 directly)
   void startTx();
+
+  // ── Multi-mode jammer ──────────────────────────────────────────────────────
+  // Non-blocking: startJam() configures the radio for the chosen mode, then the
+  // screen calls jamTick() every frame (each call does one bounded chunk of work
+  // so BACK stays responsive) and stopJam() when leaving. Live stats are read via
+  // jamPulses()/jamSweeps()/jamSweepFreq() for the status line.
+  void     startJam(JamMode mode);
+  void     jamTick();
+  void     stopJam();
+  JamMode  jamMode()      const { return _jamMode; }
+  uint32_t jamPulses()    const { return _jamPulses; }
+  uint32_t jamSweeps()    const { return _jamSweeps; }
+  float    jamSweepFreq() const { return _jamSweepFreq; }
+  static const char* jamModeName(JamMode m);
 
   // Send a signal (handles RAW and RcSwitch/Princeton protocols)
   void sendSignal(const Signal& sig);
@@ -281,6 +308,18 @@ private:
   float _scanForBestFreq(std::function<bool()> cancelCb);
   void  _initTx();
   void  _initRx();
+
+  // ── Jammer state ──────────────────────────────────────────────────────────
+  JamMode  _jamMode      = JAM_FULL;
+  uint32_t _jamPulses    = 0;
+  uint32_t _jamSweeps    = 0;
+  uint32_t _jamStartMs   = 0;
+  uint8_t  _jamNoiseMod  = 0;      // index into the ASK/2-FSK/MSK cycle
+  float    _jamBaseFreq  = 0;      // sweep centre (restored on stop)
+  float    _jamSweepFreq = 0;      // current sweep frequency
+  bool     _jamSweepFwd  = true;   // sweep direction
+  void _jamSendPulse(uint32_t width);   // one glitched OOK pulse over GDO0
+  void _jamRandomBurst(int numPulses);  // bounded random-width noise burst
   // Write the OOK RX sensitivity registers (AGC full gain, ADC retention, SmartRF
   // front-end) after ELECHOUSE Init(), whose FSK-packet defaults cap the gain.
   void  _applyOokRxRegs();


### PR DESCRIPTION
## Summary

The Sub-GHz jammer used to run a single, fixed burst pattern with no options. This PR turns it into a **four-mode jammer** with a mode-select menu, so the user can pick the interference strategy that fits the target. Each mode uses a distinct approach to spread or concentrate RF energy. The active mode is shown on the jamming screen, and the BACK button now lets you switch modes without leaving the jammer.

The mode picker uses the standard Unigeek popup component, so it looks and behaves like the rest of the UI.

## Before / After

**Before**
- Entering **Sub-GHz → Jammer** immediately started one hard-coded burst pattern on the configured frequency.
- No way to change the jamming strategy.
- Pressing **BACK** returned straight to the Sub-GHz menu.

**After**
- Entering **Sub-GHz → Jammer** opens a popup to choose one of four modes.
- The jamming screen shows the name of the active mode.
- Pressing **BACK** while jamming **reopens the mode menu**, so you can switch modes on the fly.
- Pressing **BACK** again (from the mode menu) returns to the Sub-GHz menu.

## The four jammer modes

**1. Full Power** — Maximum duty-cycle carrier, keyed directly on the GDO0 line. It rotates through three attack phases every 100 ms for the widest spectral pollution around the centre frequency:
- ultra-rapid micro-glitches (3 µs HIGH / 1 µs LOW),
- variable-width bursts (2–20 µs),
- a sustained carrier with periodic hard cuts.

This concentrates the most energy on the single configured frequency.

**2. Intermittent** — Sweeps the pulse width from 10 µs up to 500 µs and then fires a random-width noise burst, producing a chirp-like, intermittent disruption. Lower average duty cycle than Full Power, but a broader, more varied temporal pattern that is harder for a receiver to filter out.

**3. Noise Storm** — Switches the CC1101 into its built-in **PN9 pseudo-random TX** mode, so the radio itself generates continuous modulated noise. It uses a high data rate to widen the occupied bandwidth and cycles the modulation scheme every 3 s (**ASK/OOK → 2-FSK → MSK**) for spectral diversity. Because the chip drives the transmission in hardware, the CPU stays mostly idle while jamming.

**4. Freq Sweep** — Keeps an OOK carrier and retunes the CC1101 **±5 MHz around the target in 50 kHz steps**, firing a tight TX burst at each step and reversing direction at the band edges. Instead of hitting a single channel, this spreads interference across a wide band — useful against receivers that sit slightly off the nominal frequency or hop.

## Improvements

- **Non-blocking design.** Each mode runs as a bounded per-frame *tick* rather than a blocking loop, so the BACK button stays responsive and the screen keeps refreshing while jamming.
- **Clean teardown.** After Noise Storm and Freq Sweep, the radio is restored to its async-serial defaults / original frequency, so subsequent RX/TX operations behave normally.
- **UI consistency.** Mode selection reuses the existing selection popup; the jamming view keeps the existing minimal layout and just adds the mode name.
- **No regression for other radios.** The single-pin M5 RF433 path is untouched — the new hooks default to the previous behavior.

## Implementation notes

- New `JamMode` enum plus `startJam()` / `jamTick()` / `stopJam()` API in `CC1101Util`, keeping all the mode logic in the radio layer.
- `RfCaptureScreen` gains two optional virtual hooks: one for the mode-name label on the jamming screen, one for post-stop navigation (so BACK can reopen the mode menu).
- `SubGHzScreen` wires the mode popup and the BACK-to-menu behavior; the "show popup → start jamming" flow is shared between the menu entry and the BACK-from-jam path.

## Testing

Built and flashed to the **M5 Cardputer ADV** (`m5_cardputer_adv`). Verified the mode popup, all four modes starting/stopping, the mode name on the jamming screen, and BACK returning to the mode menu (then to the Sub-GHz menu).
