### PR TITLE
fix(wifi): make DNS-spoof captive probes redirect like Evil Twin's

### DIFF
--- a/firmware/src/utils/network/SharedWebServer.cpp
+++ b/firmware/src/utils/network/SharedWebServer.cpp
@@ -267,9 +267,10 @@ void SharedWebServer::_registerRoutes() {
 
   // ── Captive-detection path redirects ──────────────────────────────────────
   // OS probes well-known paths to detect captive portals. Redirect to / when
-  // captive is active so the host-based routing above handles serving.
+  // captive (Evil Twin/Karma) or DNS-spoof captive (AP screen) is active so
+  // the host-based routing above handles serving.
   auto captiveProbe = [this](AsyncWebServerRequest* req) {
-    if (_captiveActive) req->redirect("/");
+    if (_captiveActive || _dnsSpoofActive) req->redirect("/");
     else req->send(204);
   };
   _server.on("/generate_204",         HTTP_GET, captiveProbe);


### PR DESCRIPTION
Fixes #58

The OS captive-portal probe paths (`/generate_204`, `/fwlink`, `/hotspot-detect.html`, `/connecttest.txt`) only redirected to `/` when `SharedWebServer::_captiveActive` was set. That flag is only true for the Evil Twin/Karma flow (`enableCaptive()`). The plain **Access Point** screen's Captive Portal feature goes through `DnsSpoofServer` instead, which only sets `_dnsSpoofActive` — so those probe paths fell through to a bare `204` ("no portal here"), and connecting clients never saw the selected portal HTML, regardless of which one was picked in the AP menu. That matches the report exactly: it worked in Evil Twin but not in the plain AP screen.

Fix: widen the guard to redirect on either flag. The existing `GET /` handler already delegates correctly to the DNS-spoof callback when `_dnsSpoofActive` is set, so no other logic changes are needed.

Verified with `pio run -e t_embed_cc1101` — builds clean.
