### PR TITLE
feat(wifi): live/rolling target-network scan in Evil Twin, Deauther, EAPOL Capture

### DIFF
--- a/firmware/src/screens/wifi/WifiAnalyzerScreen.cpp
+++ b/firmware/src/screens/wifi/WifiAnalyzerScreen.cpp
@@ -4,7 +4,6 @@
 #include "core/ConfigManager.h"
 #include "core/AchievementManager.h"
 #include "screens/wifi/WifiMenuScreen.h"
-#include "ui/actions/ShowStatusAction.h"
 
 #include <WiFi.h>
 #include <esp_wifi.h>
@@ -78,7 +77,9 @@ static void _clientSnifferCb(void* buf, wifi_promiscuous_pkt_type_t type)
 
 void WifiAnalyzerScreen::onInit()
 {
-  _scan();
+  _entryCount = 0;
+  _showScan();
+  _nextScanAt = millis();
 }
 
 void WifiAnalyzerScreen::onUpdate()
@@ -98,7 +99,19 @@ void WifiAnalyzerScreen::onUpdate()
     }
     return;
   }
+
   ListScreen::onUpdate();
+
+  if (_scanInFlight) {
+    _pollLiveScan();
+  } else if (millis() >= _nextScanAt) {
+    _startLiveScan();
+  }
+
+  if (millis() - _lastPruneAt >= 1000) {
+    _lastPruneAt = millis();
+    _pruneStale();
+  }
 }
 
 void WifiAnalyzerScreen::onItemSelected(uint8_t index)
@@ -124,55 +137,126 @@ void WifiAnalyzerScreen::onBack()
     _showScan();
   } else {
     WiFi.scanDelete();
+    _scanInFlight = false;
     Screen.goBack();
   }
 }
 
 // ── Private ────────────────────────────────────────────────────────────────
 
-void WifiAnalyzerScreen::_scan()
+// ── Live scan ────────────────────────────────────────────────────────────────
+//
+// Instead of one blocking WiFi.scanNetworks() call, we kick an async scan,
+// poll it from onUpdate(), merge results into _entries[] in place (existing
+// BSSIDs keep their row/index so the cursor doesn't jump), then immediately
+// schedule the next cycle. _pruneStale() separately drops APs that haven't
+// been seen in a while, so the list behaves like a live radar while walking.
+
+void WifiAnalyzerScreen::_startLiveScan()
 {
-  ShowStatusAction::show("Scanning...", 0);
-
   WiFi.mode(WIFI_STA);
-  int total = WiFi.scanNetworks(false, true);
-  if (total > MAX_SCAN) total = MAX_SCAN;
-  _entryCount = total;
+  WiFi.scanNetworks(true, true);  // async
+  _scanInFlight = true;
+}
 
-  for (int i = 0; i < total; i++) {
-    int32_t rssi = WiFi.RSSI(i);
-    const char* strength;
-    if      (rssi >= -50) strength = "Very Good";
-    else if (rssi >= -60) strength = "Good";
-    else if (rssi >= -70) strength = "Better";
-    else if (rssi >= -80) strength = "Low";
-    else                  strength = "Very Low";
-
-    snprintf(_entries[i].ssid,    sizeof(_entries[i].ssid),    "%s", WiFi.SSID(i).c_str());
-    snprintf(_entries[i].bssid,   sizeof(_entries[i].bssid),   "%s", WiFi.BSSIDstr(i).c_str());
-    snprintf(_entries[i].rssi,    sizeof(_entries[i].rssi),    "[%d] %s", (int)rssi, strength);
-    snprintf(_entries[i].channel, sizeof(_entries[i].channel), "%d", (int)WiFi.channel(i));
-
-    switch (WiFi.encryptionType(i)) {
-      case WIFI_AUTH_OPEN:           snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "OPEN");            break;
-      case WIFI_AUTH_WEP:            snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "WEP");             break;
-      case WIFI_AUTH_WPA_PSK:        snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "WPA_PSK");         break;
-      case WIFI_AUTH_WPA2_PSK:       snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "WPA2_PSK");        break;
-      case WIFI_AUTH_WPA_WPA2_PSK:   snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "WPA_WPA2_PSK");    break;
-      case WIFI_AUTH_WPA2_ENTERPRISE:snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "WPA2_ENTERPRISE"); break;
-      case WIFI_AUTH_WPA3_PSK:       snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "WPA3_PSK");        break;
-      default:                       snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "UNKNOWN");         break;
-    }
+void WifiAnalyzerScreen::_pollLiveScan()
+{
+  int total = WiFi.scanComplete();
+  if (total == WIFI_SCAN_RUNNING || total == WIFI_SCAN_FAILED) {
+    if (total == WIFI_SCAN_FAILED) { _scanInFlight = false; _nextScanAt = millis() + SCAN_CYCLE_GAP_MS; }
+    return;
   }
+
+  if (total > MAX_SCAN) total = MAX_SCAN;
+  for (int i = 0; i < total; i++) _mergeScanResult(i);
+
+  WiFi.scanDelete();
+  _scanInFlight = false;
+  _nextScanAt   = millis() + SCAN_CYCLE_GAP_MS;
 
   int na = Achievement.inc("wifi_analyzer_scan");
   if (na == 1) Achievement.unlock("wifi_analyzer_scan");
-  if (total >= 20) {
+  if (_entryCount >= 20) {
     int n20 = Achievement.inc("wifi_analyzer_20aps");
     if (n20 == 1) Achievement.unlock("wifi_analyzer_20aps");
   }
 
-  _showScan();
+  _rebuildScanItems();
+  setCount(_entryCount);
+  render();
+}
+
+void WifiAnalyzerScreen::_mergeScanResult(int idx)
+{
+  String bssid = WiFi.BSSIDstr(idx);
+
+  int slot = -1;
+  for (int i = 0; i < _entryCount; i++) {
+    if (bssid.equalsIgnoreCase(_entries[i].bssid)) { slot = i; break; }
+  }
+  if (slot < 0) {
+    if (_entryCount >= MAX_SCAN) return;  // list full — ignore new APs until one drops
+    slot = _entryCount++;
+  }
+
+  int32_t rssi = WiFi.RSSI(idx);
+  const char* strength;
+  if      (rssi >= -50) strength = "Very Good";
+  else if (rssi >= -60) strength = "Good";
+  else if (rssi >= -70) strength = "Better";
+  else if (rssi >= -80) strength = "Low";
+  else                  strength = "Very Low";
+
+  WifiEntry& e = _entries[slot];
+  snprintf(e.ssid,    sizeof(e.ssid),    "%s", WiFi.SSID(idx).c_str());
+  snprintf(e.bssid,   sizeof(e.bssid),   "%s", bssid.c_str());
+  snprintf(e.rssi,    sizeof(e.rssi),    "[%d] %s", (int)rssi, strength);
+  snprintf(e.channel, sizeof(e.channel), "%d", (int)WiFi.channel(idx));
+  e.rssiValue = (int)rssi;
+  e.lastSeen  = millis();
+
+  switch (WiFi.encryptionType(idx)) {
+    case WIFI_AUTH_OPEN:           snprintf(e.encryption, sizeof(e.encryption), "OPEN");            break;
+    case WIFI_AUTH_WEP:            snprintf(e.encryption, sizeof(e.encryption), "WEP");             break;
+    case WIFI_AUTH_WPA_PSK:        snprintf(e.encryption, sizeof(e.encryption), "WPA_PSK");         break;
+    case WIFI_AUTH_WPA2_PSK:       snprintf(e.encryption, sizeof(e.encryption), "WPA2_PSK");        break;
+    case WIFI_AUTH_WPA_WPA2_PSK:   snprintf(e.encryption, sizeof(e.encryption), "WPA_WPA2_PSK");    break;
+    case WIFI_AUTH_WPA2_ENTERPRISE:snprintf(e.encryption, sizeof(e.encryption), "WPA2_ENTERPRISE"); break;
+    case WIFI_AUTH_WPA3_PSK:       snprintf(e.encryption, sizeof(e.encryption), "WPA3_PSK");        break;
+    default:                       snprintf(e.encryption, sizeof(e.encryption), "UNKNOWN");         break;
+  }
+}
+
+void WifiAnalyzerScreen::_pruneStale()
+{
+  if (_state != STATE_SCAN || _entryCount == 0) return;
+
+  uint32_t now     = millis();
+  bool     changed = false;
+
+  for (int i = _entryCount - 1; i >= 0; i--) {
+    if (now - _entries[i].lastSeen <= STALE_TIMEOUT_MS) continue;
+
+    for (int j = i; j < _entryCount - 1; j++) _entries[j] = _entries[j + 1];
+    _entryCount--;
+    changed = true;
+
+    if (_selectedIndex > i) _selectedIndex--;
+  }
+
+  if (!changed) return;
+  _rebuildScanItems();
+  setCount(_entryCount);
+  render();
+}
+
+void WifiAnalyzerScreen::_rebuildScanItems()
+{
+  for (int i = 0; i < _entryCount; i++) {
+    _scanItems[i]         = {_entries[i].ssid, _entries[i].bssid};
+    _scanItems[i].rssi    = (int16_t)_entries[i].rssiValue;
+    _scanItems[i].hasRssi = true;
+  }
 }
 
 void WifiAnalyzerScreen::_showScan()
@@ -180,15 +264,20 @@ void WifiAnalyzerScreen::_showScan()
   _state = STATE_SCAN;
   strncpy(_title, "WiFi Analyzer", sizeof(_title));
 
-  for (int i = 0; i < _entryCount; i++) {
-    _scanItems[i] = {_entries[i].ssid, _entries[i].bssid};
-  }
-
+  _rebuildScanItems();
   setItems(_scanItems, _entryCount);
+  _nextScanAt = millis();
 }
 
 void WifiAnalyzerScreen::_showClients(int index)
 {
+  // Hand the radio over to the client sniffer — abort any in-flight scan
+  // first so it doesn't collide with the promiscuous/channel-lock setup.
+  if (_scanInFlight) {
+    WiFi.scanDelete();
+    _scanInFlight = false;
+  }
+
   _selectedAp = index;
   _state      = STATE_CLIENTS;
 

--- a/firmware/src/screens/wifi/WifiAnalyzerScreen.h
+++ b/firmware/src/screens/wifi/WifiAnalyzerScreen.h
@@ -8,8 +8,8 @@ class WifiAnalyzerScreen : public ListScreen
 public:
   const char* title() override { return _title; }
 
-  // Keep WiFi awake while sniffing clients (promiscuous mode).
-  bool inhibitPowerSave() override { return _state == STATE_CLIENTS; }
+  // Keep WiFi awake while sniffing clients or mid-scan (promiscuous/scan use the radio).
+  bool inhibitPowerSave() override { return _state == STATE_CLIENTS || _scanInFlight; }
 
   void onInit() override;
   void onUpdate() override;
@@ -21,20 +21,31 @@ private:
   static constexpr int MAX_SCAN    = 20;
   static constexpr int MAX_CLIENTS = 32;  // keep in sync with kMaxClients in .cpp
 
+  // Live-scan tuning: how long to rest between completed async scans, and
+  // how long an AP can go unseen before it's dropped from the list.
+  static constexpr uint32_t SCAN_CYCLE_GAP_MS = 3000;
+  static constexpr uint32_t STALE_TIMEOUT_MS  = 15000;
+
   enum State { STATE_SCAN, STATE_CLIENTS };
   State _state = STATE_SCAN;
 
   struct WifiEntry {
-    char ssid[33];
-    char bssid[18];
-    char rssi[20];
-    char channel[4];
-    char encryption[20];
+    char     ssid[33];
+    char     bssid[18];
+    char     rssi[20];
+    char     channel[4];
+    char     encryption[20];
+    int      rssiValue = 0;
+    uint32_t lastSeen  = 0;
   };
 
   char      _title[16]         = "WiFi Analyzer";
   WifiEntry _entries[MAX_SCAN];
   int       _entryCount        = 0;
+
+  bool      _scanInFlight      = false;
+  uint32_t  _nextScanAt        = 0;
+  uint32_t  _lastPruneAt       = 0;
 
   ListItem       _scanItems[MAX_SCAN];
   ScrollListView _scrollView;
@@ -48,9 +59,14 @@ private:
   int                 _lastClientCount   = -1;
   uint32_t            _lastClientRefresh = 0;
 
-  void _scan();
   void _showScan();
   void _showClients(int index);
   void _stopClients();
   void _refreshClients(bool force);
+
+  void _startLiveScan();
+  void _pollLiveScan();
+  void _mergeScanResult(int idx);
+  void _pruneStale();
+  void _rebuildScanItems();
 };

--- a/firmware/src/screens/wifi/WifiDeautherScreen.cpp
+++ b/firmware/src/screens/wifi/WifiDeautherScreen.cpp
@@ -22,6 +22,7 @@ WifiDeautherScreen::~WifiDeautherScreen()
     delete _attacker;
     _attacker = nullptr;
   }
+  _stopLiveScan();
 }
 
 // ── Lifecycle ─────────────────────────────────────────────────────────────
@@ -46,10 +47,11 @@ void WifiDeautherScreen::onItemSelected(uint8_t index)
     }
   } else if (_state == STATE_SELECT_WIFI && index < _scanCount) {
     _target.ssid    = _scanLabels[index];
-    _target.channel = atoi(_scanLabels[index] + 1);
+    _target.channel = _scanChannel[index];
     sscanf(_scanValues[index], "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
            &_target.bssid[0], &_target.bssid[1], &_target.bssid[2],
            &_target.bssid[3], &_target.bssid[4], &_target.bssid[5]);
+    _stopLiveScan();
     _showMain();
   }
 }
@@ -58,6 +60,18 @@ void WifiDeautherScreen::onUpdate()
 {
   if (_state != STATE_DEAUTHING) {
     ListScreen::onUpdate();
+
+    if (_state == STATE_SELECT_WIFI) {
+      if (_scanInFlight) {
+        _pollLiveScan();
+      } else if (millis() >= _nextScanAt) {
+        _startLiveScan();
+      }
+      if (millis() - _lastPruneAt >= 1000) {
+        _lastPruneAt = millis();
+        _pruneStale();
+      }
+    }
     return;
   }
 
@@ -88,6 +102,7 @@ void WifiDeautherScreen::onUpdate()
 void WifiDeautherScreen::onBack()
 {
   if (_state == STATE_SELECT_WIFI) {
+    _stopLiveScan();
     _showMain();
   } else if (_state == STATE_DEAUTHING) {
     _stopDeauth();
@@ -121,30 +136,116 @@ void WifiDeautherScreen::_showMain()
   }
 }
 
+// ── WiFi Scan (live/rolling) ─────────────────────────────────────────────────
+//
+// Async scan, polled from onUpdate() while STATE_SELECT_WIFI is active.
+// Results are merged into the per-slot arrays by BSSID so an already-listed
+// network keeps its row (stable cursor); networks not re-seen for
+// STALE_TIMEOUT_MS are pruned. Mirrors WifiAnalyzerScreen/WifiEvilTwinScreen.
+
 void WifiDeautherScreen::_selectWifi()
 {
-  _state = STATE_SELECT_WIFI;
-  ShowStatusAction::show("Scanning...", 0);
+  _state     = STATE_SELECT_WIFI;
+  _scanCount = 0;
+  setItems(_scanItems, 0);
+  _nextScanAt = millis();
+}
 
+void WifiDeautherScreen::_startLiveScan()
+{
   WiFi.mode(WIFI_STA);
-  const int total = WiFi.scanNetworks();
+  WiFi.scanNetworks(true, false);
+  _scanInFlight = true;
+}
 
-  if (total == 0) {
-    ShowStatusAction::show("No networks found");
-    _showMain();
+void WifiDeautherScreen::_pollLiveScan()
+{
+  int total = WiFi.scanComplete();
+  if (total == WIFI_SCAN_RUNNING) return;
+  if (total == WIFI_SCAN_FAILED) {
+    _scanInFlight = false;
+    _nextScanAt   = millis() + SCAN_CYCLE_GAP_MS;
     return;
   }
 
-  _scanCount = total > MAX_SCAN ? MAX_SCAN : total;
+  if (total > MAX_SCAN) total = MAX_SCAN;
+  for (int i = 0; i < total; i++) _mergeScanResult(i);
+
+  WiFi.scanDelete();
+  _scanInFlight = false;
+  _nextScanAt   = millis() + SCAN_CYCLE_GAP_MS;
+
+  _rebuildScanItems();
+  setCount(_scanCount);
+  render();
+}
+
+void WifiDeautherScreen::_mergeScanResult(int idx)
+{
+  String bssid = WiFi.BSSIDstr(idx);
+
+  int slot = -1;
   for (int i = 0; i < _scanCount; i++) {
-    snprintf(_scanLabels[i], sizeof(_scanLabels[i]), "[%2d] %s",
-             WiFi.channel(i), WiFi.SSID(i).c_str());
-    snprintf(_scanValues[i], sizeof(_scanValues[i]), "%s",
-             WiFi.BSSIDstr(i).c_str());
-    _scanItems[i] = {_scanLabels[i], _scanValues[i]};
+    if (bssid.equalsIgnoreCase(_scanValues[i])) { slot = i; break; }
+  }
+  if (slot < 0) {
+    if (_scanCount >= MAX_SCAN) return;
+    slot = _scanCount++;
   }
 
-  setItems(_scanItems, _scanCount);
+  snprintf(_scanSsid[slot],   sizeof(_scanSsid[slot]),   "%s", WiFi.SSID(idx).c_str());
+  snprintf(_scanValues[slot], sizeof(_scanValues[slot]), "%s", bssid.c_str());
+  _scanChannel[slot]  = (uint8_t)WiFi.channel(idx);
+  _scanRssi[slot]     = (int16_t)WiFi.RSSI(idx);
+  _scanLastSeen[slot] = millis();
+}
+
+void WifiDeautherScreen::_pruneStale()
+{
+  if (_state != STATE_SELECT_WIFI || _scanCount == 0) return;
+
+  unsigned long now     = millis();
+  bool          changed = false;
+
+  for (int i = _scanCount - 1; i >= 0; i--) {
+    if (now - _scanLastSeen[i] <= STALE_TIMEOUT_MS) continue;
+
+    for (int j = i; j < _scanCount - 1; j++) {
+      memcpy(_scanSsid[j],   _scanSsid[j + 1],   sizeof(_scanSsid[j]));
+      memcpy(_scanValues[j], _scanValues[j + 1], sizeof(_scanValues[j]));
+      _scanChannel[j]  = _scanChannel[j + 1];
+      _scanRssi[j]     = _scanRssi[j + 1];
+      _scanLastSeen[j] = _scanLastSeen[j + 1];
+    }
+    _scanCount--;
+    changed = true;
+
+    if (_selectedIndex > i) _selectedIndex--;
+  }
+
+  if (!changed) return;
+  _rebuildScanItems();
+  setCount(_scanCount);
+  render();
+}
+
+void WifiDeautherScreen::_rebuildScanItems()
+{
+  for (int i = 0; i < _scanCount; i++) {
+    snprintf(_scanLabels[i], sizeof(_scanLabels[i]), "[%2d] %s",
+             _scanChannel[i], _scanSsid[i]);
+    _scanItems[i]         = {_scanLabels[i], _scanValues[i]};
+    _scanItems[i].rssi    = _scanRssi[i];
+    _scanItems[i].hasRssi = true;
+  }
+}
+
+void WifiDeautherScreen::_stopLiveScan()
+{
+  if (_scanInFlight) {
+    WiFi.scanDelete();
+    _scanInFlight = false;
+  }
 }
 
 void WifiDeautherScreen::_startDeauth()

--- a/firmware/src/screens/wifi/WifiDeautherScreen.h
+++ b/firmware/src/screens/wifi/WifiDeautherScreen.h
@@ -59,10 +59,28 @@ private:
   String   _modeSub;
   String   _targetSub;
 
+  static constexpr unsigned long SCAN_CYCLE_GAP_MS = 3000;
+  static constexpr unsigned long STALE_TIMEOUT_MS  = 15000;
+
   ListItem _scanItems[MAX_SCAN];
   char     _scanLabels[MAX_SCAN][52];
-  char     _scanValues[MAX_SCAN][18];
+  char     _scanValues[MAX_SCAN][18];  // BSSID string, also the sublabel
+  char     _scanSsid[MAX_SCAN][33];
+  uint8_t  _scanChannel[MAX_SCAN]  = {};
+  int16_t  _scanRssi[MAX_SCAN]     = {};
+  unsigned long _scanLastSeen[MAX_SCAN] = {};
   int      _scanCount = 0;
+
+  bool          _scanInFlight = false;
+  unsigned long _nextScanAt   = 0;
+  unsigned long _lastPruneAt  = 0;
+
+  void _startLiveScan();
+  void _pollLiveScan();
+  void _mergeScanResult(int idx);
+  void _pruneStale();
+  void _rebuildScanItems();
+  void _stopLiveScan();
 
   static ApEntry      _allTargets[MAX_ALL];
   static int          _allCount;

--- a/firmware/src/screens/wifi/WifiEapolCaptureScreen.cpp
+++ b/firmware/src/screens/wifi/WifiEapolCaptureScreen.cpp
@@ -75,6 +75,7 @@ struct PcapPktHdr {
 // ── Destructor ────────────────────────────────────────────────────────────
 
 WifiEapolCaptureScreen::~WifiEapolCaptureScreen() {
+  _stopLiveScan();
   _skipBeacons = false;
   esp_wifi_set_promiscuous_rx_cb(nullptr);
   esp_wifi_set_promiscuous(false);
@@ -147,13 +148,12 @@ void WifiEapolCaptureScreen::_showMenu() {
 void WifiEapolCaptureScreen::onItemSelected(uint8_t index) {
   if (_phase == PHASE_SELECT_WIFI) {
     if (index >= _scanCount) return;
-    // _scanLabels[index] is "[ch] ssid"
-    _target.channel = atoi(_scanLabels[index] + 1);
-    const char* sp = strchr(_scanLabels[index], ']');
-    _target.ssid = (sp && sp[1]) ? String(sp + 2) : String("(hidden)");
+    _target.channel = _scanChannel[index];
+    _target.ssid    = _scanSsid[index];
     sscanf(_scanValues[index], "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
            &_target.bssid[0], &_target.bssid[1], &_target.bssid[2],
            &_target.bssid[3], &_target.bssid[4], &_target.bssid[5]);
+    _stopLiveScan();
     _phase = PHASE_MENU;
     _showMenu();
     return;
@@ -275,42 +275,136 @@ void WifiEapolCaptureScreen::onItemSelected(uint8_t index) {
   }
 }
 
+// ── WiFi Scan (live/rolling) ─────────────────────────────────────────────────
+//
+// Async scan, polled from onUpdate() while PHASE_SELECT_WIFI is active.
+// Results merge into the per-slot arrays by BSSID (stable cursor); entries
+// not re-seen for STALE_TIMEOUT_MS are pruned. Same pattern as
+// WifiAnalyzerScreen/WifiEvilTwinScreen/WifiDeautherScreen.
+//
+// Async mode sidesteps the old blocking-scan concern entirely: the framework's
+// hard 10 s cap (WiFiScan.cpp's WIFI_SCAN_DONE_BIT wait) only applies to the
+// *synchronous* scanNetworks() call this used to make — with async=true we
+// just poll scanComplete() ourselves, so the per-channel dwell below (600 ms,
+// tuned so weaker/less chatty APs still get airtime) no longer has to fit
+// under that timeout.
+
 void WifiEapolCaptureScreen::_selectWifi() {
-  _phase = PHASE_SELECT_WIFI;
-  ShowStatusAction::show("Scanning (10s)...", 0);
+  _phase     = PHASE_SELECT_WIFI;
+  _scanCount = 0;
+  setItems(_scanItems, 0);
 
   WiFi.mode(WIFI_STA);
   WiFi.disconnect();
-  // Long-ish sweep so weaker / less chatty APs get airtime, but the per-channel
-  // dwell MUST stay under the framework's hard 10 s sync-scan timeout
-  // (WiFiScan.cpp waits WIFI_SCAN_DONE_BIT for 10000 ms, else WIFI_SCAN_FAILED).
-  // 600 ms × up to 14 channels = 8.4 s — comfortably below 10 s. The previous
-  // 770 ms × 13 channels = 10.01 s tipped over the timeout in 13-channel
-  // regulatory domains (EU/BR), so every scan returned "No networks found".
-  const int total = WiFi.scanNetworks(false, false, false, 600, 0);
+  _nextScanAt = millis();
+}
 
-  if (total <= 0) {
-    ShowStatusAction::show("No networks found");
-    _phase = PHASE_MENU;
-    _showMenu();
+void WifiEapolCaptureScreen::_startLiveScan() {
+  WiFi.scanNetworks(true, false, false, 600, 0);
+  _scanInFlight = true;
+}
+
+void WifiEapolCaptureScreen::_pollLiveScan() {
+  int total = WiFi.scanComplete();
+  if (total == WIFI_SCAN_RUNNING) return;
+  if (total == WIFI_SCAN_FAILED) {
+    _scanInFlight = false;
+    _nextScanAt   = millis() + SCAN_CYCLE_GAP_MS;
     return;
   }
 
-  _scanCount = total > MAX_SCAN ? MAX_SCAN : total;
+  if (total > MAX_SCAN) total = MAX_SCAN;
+  for (int i = 0; i < total; i++) _mergeScanResult(i);
+
+  WiFi.scanDelete();
+  _scanInFlight = false;
+  _nextScanAt   = millis() + SCAN_CYCLE_GAP_MS;
+
+  _rebuildScanItems();
+  setCount(_scanCount);
+  render();
+}
+
+void WifiEapolCaptureScreen::_mergeScanResult(int idx) {
+  String bssid = WiFi.BSSIDstr(idx);
+
+  int slot = -1;
   for (int i = 0; i < _scanCount; i++) {
-    snprintf(_scanLabels[i], sizeof(_scanLabels[i]), "[%2d] %s",
-             WiFi.channel(i), WiFi.SSID(i).c_str());
-    snprintf(_scanValues[i], sizeof(_scanValues[i]), "%s",
-             WiFi.BSSIDstr(i).c_str());
-    _scanItems[i] = {_scanLabels[i], _scanValues[i]};
+    if (bssid.equalsIgnoreCase(_scanValues[i])) { slot = i; break; }
+  }
+  if (slot < 0) {
+    if (_scanCount >= MAX_SCAN) return;
+    slot = _scanCount++;
   }
 
-  setItems(_scanItems, _scanCount);
+  String ssid = WiFi.SSID(idx);
+  snprintf(_scanSsid[slot],   sizeof(_scanSsid[slot]),   "%s", ssid.isEmpty() ? "(hidden)" : ssid.c_str());
+  snprintf(_scanValues[slot], sizeof(_scanValues[slot]), "%s", bssid.c_str());
+  _scanChannel[slot]  = (uint8_t)WiFi.channel(idx);
+  _scanRssi[slot]     = (int16_t)WiFi.RSSI(idx);
+  _scanLastSeen[slot] = millis();
+}
+
+void WifiEapolCaptureScreen::_pruneStale() {
+  if (_phase != PHASE_SELECT_WIFI || _scanCount == 0) return;
+
+  unsigned long now     = millis();
+  bool          changed = false;
+
+  for (int i = _scanCount - 1; i >= 0; i--) {
+    if (now - _scanLastSeen[i] <= STALE_TIMEOUT_MS) continue;
+
+    for (int j = i; j < _scanCount - 1; j++) {
+      memcpy(_scanSsid[j],   _scanSsid[j + 1],   sizeof(_scanSsid[j]));
+      memcpy(_scanValues[j], _scanValues[j + 1], sizeof(_scanValues[j]));
+      _scanChannel[j]  = _scanChannel[j + 1];
+      _scanRssi[j]     = _scanRssi[j + 1];
+      _scanLastSeen[j] = _scanLastSeen[j + 1];
+    }
+    _scanCount--;
+    changed = true;
+
+    if (_selectedIndex > i) _selectedIndex--;
+  }
+
+  if (!changed) return;
+  _rebuildScanItems();
+  setCount(_scanCount);
+  render();
+}
+
+void WifiEapolCaptureScreen::_rebuildScanItems() {
+  for (int i = 0; i < _scanCount; i++) {
+    snprintf(_scanLabels[i], sizeof(_scanLabels[i]), "[%2d] %s",
+             _scanChannel[i], _scanSsid[i]);
+    _scanItems[i]         = {_scanLabels[i], _scanValues[i]};
+    _scanItems[i].rssi    = _scanRssi[i];
+    _scanItems[i].hasRssi = true;
+  }
+}
+
+void WifiEapolCaptureScreen::_stopLiveScan() {
+  if (_scanInFlight) {
+    WiFi.scanDelete();
+    _scanInFlight = false;
+  }
 }
 
 void WifiEapolCaptureScreen::onUpdate() {
   if (_phase == PHASE_MENU || _phase == PHASE_SELECT_WIFI) {
     ListScreen::onUpdate();
+
+    if (_phase == PHASE_SELECT_WIFI) {
+      if (_scanInFlight) {
+        _pollLiveScan();
+      } else if (millis() >= _nextScanAt) {
+        _startLiveScan();
+      }
+      if (millis() - _lastPruneAt >= 1000) {
+        _lastPruneAt = millis();
+        _pruneStale();
+      }
+    }
     return;
   }
 
@@ -448,6 +542,7 @@ void WifiEapolCaptureScreen::onRender() {
 
 void WifiEapolCaptureScreen::onBack() {
   if (_phase == PHASE_SELECT_WIFI) {
+    _stopLiveScan();
     _phase = PHASE_MENU;
     _showMenu();
     return;

--- a/firmware/src/screens/wifi/WifiEapolCaptureScreen.h
+++ b/firmware/src/screens/wifi/WifiEapolCaptureScreen.h
@@ -149,12 +149,30 @@ private:
   void          _showMenu();
   void          _selectWifi();
 
-  // ── Network scan list ────────────────────────────────────────────────────
+  // ── Network scan list (live/rolling while PHASE_SELECT_WIFI) ─────────────
   static constexpr int MAX_SCAN = 20;
+  static constexpr unsigned long SCAN_CYCLE_GAP_MS = 3000;
+  static constexpr unsigned long STALE_TIMEOUT_MS  = 15000;
+
   ListItem _scanItems[MAX_SCAN];
   char     _scanLabels[MAX_SCAN][52];
-  char     _scanValues[MAX_SCAN][18];
+  char     _scanValues[MAX_SCAN][18];  // BSSID string, also the sublabel
+  char     _scanSsid[MAX_SCAN][33];
+  uint8_t  _scanChannel[MAX_SCAN]  = {};
+  int16_t  _scanRssi[MAX_SCAN]     = {};
+  unsigned long _scanLastSeen[MAX_SCAN] = {};
   int      _scanCount = 0;
+
+  bool          _scanInFlight = false;
+  unsigned long _nextScanAt   = 0;
+  unsigned long _lastPruneAt  = 0;
+
+  void _startLiveScan();
+  void _pollLiveScan();
+  void _mergeScanResult(int idx);
+  void _pruneStale();
+  void _rebuildScanItems();
+  void _stopLiveScan();
   int           _discoveryCount   = 0;    // channels scanned in current discovery pass
   uint8_t       _attackChans[13]  = {};   // unique channels with APs needing EAPOL
   int           _attackChanCount  = 0;

--- a/firmware/src/screens/wifi/WifiEvilTwinScreen.cpp
+++ b/firmware/src/screens/wifi/WifiEvilTwinScreen.cpp
@@ -13,6 +13,7 @@
 WifiEvilTwinScreen::~WifiEvilTwinScreen()
 {
   _stopAttack();
+  _stopLiveScan();
 }
 
 // ── Callbacks ───────────────────────────────────────────────────────────────
@@ -127,11 +128,12 @@ void WifiEvilTwinScreen::onItemSelected(uint8_t index)
     _portal.setPortalFolder(_browser.entry(index).name);
     _showMenu();
   } else if (_state == STATE_SELECT_WIFI && index < _scanCount) {
-    _target.ssid    = WiFi.SSID(index);
-    _target.channel = WiFi.channel(index);
+    _target.ssid    = _scanSsid[index];
+    _target.channel = _scanChannel[index];
     sscanf(_scanValues[index], "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx",
            &_target.bssid[0], &_target.bssid[1], &_target.bssid[2],
            &_target.bssid[3], &_target.bssid[4], &_target.bssid[5]);
+    _stopLiveScan();
     _showMenu();
   }
 }
@@ -140,6 +142,18 @@ void WifiEvilTwinScreen::onUpdate()
 {
   if (_state != STATE_RUNNING) {
     ListScreen::onUpdate();
+
+    if (_state == STATE_SELECT_WIFI) {
+      if (_scanInFlight) {
+        _pollLiveScan();
+      } else if (millis() >= _nextScanAt) {
+        _startLiveScan();
+      }
+      if (millis() - _lastPruneAt >= 1000) {
+        _lastPruneAt = millis();
+        _pruneStale();
+      }
+    }
     return;
   }
 
@@ -184,7 +198,10 @@ void WifiEvilTwinScreen::onRender()
 
 void WifiEvilTwinScreen::onBack()
 {
-  if (_state == STATE_SELECT_WIFI || _state == STATE_SELECT_PORTAL) {
+  if (_state == STATE_SELECT_WIFI) {
+    _stopLiveScan();
+    _showMenu();
+  } else if (_state == STATE_SELECT_PORTAL) {
     _showMenu();
   } else if (_state == STATE_RUNNING) {
     _stopAttack();
@@ -214,32 +231,116 @@ void WifiEvilTwinScreen::_showMenu()
   setItems(_menuItems, 6);
 }
 
-// ── WiFi Scan ───────────────────────────────────────────────────────────────
+// ── WiFi Scan (live/rolling) ─────────────────────────────────────────────────
+//
+// Async scan, polled from onUpdate() while STATE_SELECT_WIFI is active.
+// Results are merged into the per-slot arrays by BSSID so an already-listed
+// network keeps its row (stable cursor); networks not re-seen for
+// STALE_TIMEOUT_MS are pruned. Mirrors the pattern used in WifiAnalyzerScreen.
 
 void WifiEvilTwinScreen::_selectWifi()
 {
-  _state = STATE_SELECT_WIFI;
-  ShowStatusAction::show("Scanning...", 0);
+  _state     = STATE_SELECT_WIFI;
+  _scanCount = 0;
+  setItems(_scanItems, 0);
+  _nextScanAt = millis();
+}
 
+void WifiEvilTwinScreen::_startLiveScan()
+{
   WiFi.mode(WIFI_STA);
-  const int total = WiFi.scanNetworks();
+  WiFi.scanNetworks(true, false);
+  _scanInFlight = true;
+}
 
-  if (total == 0) {
-    ShowStatusAction::show("No networks found");
-    _showMenu();
+void WifiEvilTwinScreen::_pollLiveScan()
+{
+  int total = WiFi.scanComplete();
+  if (total == WIFI_SCAN_RUNNING) return;
+  if (total == WIFI_SCAN_FAILED) {
+    _scanInFlight = false;
+    _nextScanAt   = millis() + SCAN_CYCLE_GAP_MS;
     return;
   }
 
-  _scanCount = total > MAX_SCAN ? MAX_SCAN : total;
+  if (total > MAX_SCAN) total = MAX_SCAN;
+  for (int i = 0; i < total; i++) _mergeScanResult(i);
+
+  WiFi.scanDelete();
+  _scanInFlight = false;
+  _nextScanAt   = millis() + SCAN_CYCLE_GAP_MS;
+
+  _rebuildScanItems();
+  setCount(_scanCount);
+  render();
+}
+
+void WifiEvilTwinScreen::_mergeScanResult(int idx)
+{
+  String bssid = WiFi.BSSIDstr(idx);
+
+  int slot = -1;
   for (int i = 0; i < _scanCount; i++) {
-    snprintf(_scanLabels[i], sizeof(_scanLabels[i]), "[%2d] %s",
-             WiFi.channel(i), WiFi.SSID(i).c_str());
-    snprintf(_scanValues[i], sizeof(_scanValues[i]), "%s",
-             WiFi.BSSIDstr(i).c_str());
-    _scanItems[i] = {_scanLabels[i], _scanValues[i]};
+    if (bssid.equalsIgnoreCase(_scanValues[i])) { slot = i; break; }
+  }
+  if (slot < 0) {
+    if (_scanCount >= MAX_SCAN) return;
+    slot = _scanCount++;
   }
 
-  setItems(_scanItems, _scanCount);
+  snprintf(_scanSsid[slot],   sizeof(_scanSsid[slot]),   "%s", WiFi.SSID(idx).c_str());
+  snprintf(_scanValues[slot], sizeof(_scanValues[slot]), "%s", bssid.c_str());
+  _scanChannel[slot]  = (uint8_t)WiFi.channel(idx);
+  _scanRssi[slot]     = (int16_t)WiFi.RSSI(idx);
+  _scanLastSeen[slot] = millis();
+}
+
+void WifiEvilTwinScreen::_pruneStale()
+{
+  if (_state != STATE_SELECT_WIFI || _scanCount == 0) return;
+
+  unsigned long now     = millis();
+  bool          changed = false;
+
+  for (int i = _scanCount - 1; i >= 0; i--) {
+    if (now - _scanLastSeen[i] <= STALE_TIMEOUT_MS) continue;
+
+    for (int j = i; j < _scanCount - 1; j++) {
+      memcpy(_scanSsid[j],   _scanSsid[j + 1],   sizeof(_scanSsid[j]));
+      memcpy(_scanValues[j], _scanValues[j + 1], sizeof(_scanValues[j]));
+      _scanChannel[j]  = _scanChannel[j + 1];
+      _scanRssi[j]     = _scanRssi[j + 1];
+      _scanLastSeen[j] = _scanLastSeen[j + 1];
+    }
+    _scanCount--;
+    changed = true;
+
+    if (_selectedIndex > i) _selectedIndex--;
+  }
+
+  if (!changed) return;
+  _rebuildScanItems();
+  setCount(_scanCount);
+  render();
+}
+
+void WifiEvilTwinScreen::_rebuildScanItems()
+{
+  for (int i = 0; i < _scanCount; i++) {
+    snprintf(_scanLabels[i], sizeof(_scanLabels[i]), "[%2d] %s",
+             _scanChannel[i], _scanSsid[i]);
+    _scanItems[i]         = {_scanLabels[i], _scanValues[i]};
+    _scanItems[i].rssi    = _scanRssi[i];
+    _scanItems[i].hasRssi = true;
+  }
+}
+
+void WifiEvilTwinScreen::_stopLiveScan()
+{
+  if (_scanInFlight) {
+    WiFi.scanDelete();
+    _scanInFlight = false;
+  }
 }
 
 // ── Try Password ────────────────────────────────────────────────────────────

--- a/firmware/src/screens/wifi/WifiEvilTwinScreen.h
+++ b/firmware/src/screens/wifi/WifiEvilTwinScreen.h
@@ -54,12 +54,32 @@ private:
   String   _portalSub;
   String   _fmSub;
 
-  // Scan items
+  // Scan items — live/rolling scan while STATE_SELECT_WIFI is active.
+  // Existing BSSIDs keep their slot across refresh cycles (stable cursor);
+  // entries not re-seen for STALE_TIMEOUT_MS are dropped.
   static constexpr int MAX_SCAN = 20;
+  static constexpr unsigned long SCAN_CYCLE_GAP_MS = 3000;
+  static constexpr unsigned long STALE_TIMEOUT_MS  = 15000;
+
   ListItem _scanItems[MAX_SCAN];
   char     _scanLabels[MAX_SCAN][52];
-  char     _scanValues[MAX_SCAN][18];
+  char     _scanValues[MAX_SCAN][18];  // BSSID string, also the sublabel
+  char     _scanSsid[MAX_SCAN][33];
+  uint8_t  _scanChannel[MAX_SCAN]  = {};
+  int16_t  _scanRssi[MAX_SCAN]     = {};
+  unsigned long _scanLastSeen[MAX_SCAN] = {};
   int      _scanCount = 0;
+
+  bool          _scanInFlight = false;
+  unsigned long _nextScanAt   = 0;
+  unsigned long _lastPruneAt  = 0;
+
+  void _startLiveScan();
+  void _pollLiveScan();
+  void _mergeScanResult(int idx);
+  void _pruneStale();
+  void _rebuildScanItems();
+  void _stopLiveScan();
 
   // Running state
   int      _pwdCount    = 0;

--- a/firmware/src/ui/templates/ListScreen.h
+++ b/firmware/src/ui/templates/ListScreen.h
@@ -5,10 +5,17 @@
 class ListScreen : public BaseScreen
 {
 public:
+  // NOTE: no default member initializers here — this project builds with a
+  // C++ standard where NSDMI disqualify aggregate-init, and dozens of call
+  // sites rely on brace-init like `{"Label"}` / `{"Label", "Sub"}`, which
+  // needs ListItem to stay a plain aggregate (trailing members then get
+  // zero/false from aggregate-init, same effective default).
   struct ListItem
   {
     const char* label;
     const char* sublabel;
+    int16_t     rssi;      // dBm, only meaningful when hasRssi
+    bool        hasRssi;   // when true, label is tinted by RSSI strength
   };
 
   template <size_t N>
@@ -67,6 +74,7 @@ public:
       {
         _selectedIndex = (_selectedIndex == 0) ? eff - 1 : _selectedIndex - 1;
         _scrollIfNeeded();
+        _resetMarquee();
         onRender();
         if (Uni.Speaker) Uni.Speaker->beep();
       }
@@ -74,6 +82,7 @@ public:
       {
         _selectedIndex = (_selectedIndex >= eff - 1) ? 0 : _selectedIndex + 1;
         _scrollIfNeeded();
+        _resetMarquee();
         onRender();
         if (Uni.Speaker) Uni.Speaker->beep();
       }
@@ -82,6 +91,7 @@ public:
         uint8_t page = bodyH() / ITEM_H;
         _selectedIndex = (_selectedIndex >= page) ? _selectedIndex - page : 0;
         _scrollIfNeeded();
+        _resetMarquee();
         onRender();
         if (Uni.Speaker) Uni.Speaker->beep();
       }
@@ -91,6 +101,7 @@ public:
         uint8_t last = eff - 1;
         _selectedIndex = (_selectedIndex + page <= last) ? _selectedIndex + page : last;
         _scrollIfNeeded();
+        _resetMarquee();
         onRender();
         if (Uni.Speaker) Uni.Speaker->beep();
       }
@@ -98,7 +109,10 @@ public:
       {
         onItemSelected(_selectedIndex);
       }
+      return;
     }
+
+    _updateMarquee();
   }
 
   void onRender() override
@@ -120,7 +134,8 @@ public:
       const ListItem* item     = &_items[idx];
       bool     selected = (idx == _selectedIndex);
       uint16_t bg       = selected ? Config.getThemeColor() : TFT_BLACK;
-      uint16_t fg       = selected ? TFT_WHITE : TFT_LIGHTGREY;
+      uint16_t fg       = item->hasRssi ? _rssiColor(item->rssi)
+                                         : (selected ? TFT_WHITE : TFT_LIGHTGREY);
 
       Sprite sprite(&lcd);
       sprite.createSprite(listW, rowH);
@@ -132,17 +147,20 @@ public:
 
       sprite.setTextColor(fg, bg);
 
+      int16_t labelAvailW = listW - 12;
       if (item->sublabel)
       {
-        sprite.drawString(item->label, 6, (ITEM_H / 2) - 4 + dy);
         sprite.setTextColor(selected ? TFT_CYAN : TFT_DARKGREY, bg);
         int16_t subX = listW - 6 - sprite.textWidth(item->sublabel);
         sprite.drawString(item->sublabel, subX, (ITEM_H / 2) - 4 + dy);
+        labelAvailW = subX - 6 - 4;
+        sprite.setTextColor(fg, bg);
       }
+
+      if (selected && sprite.textWidth(item->label) > labelAvailW)
+        sprite.drawString(_marqueeWindow(sprite, item->label, labelAvailW), 6, (ITEM_H / 2) - 4 + dy);
       else
-      {
         sprite.drawString(item->label, 6, (ITEM_H / 2) - 4 + dy);
-      }
 
       sprite.pushSprite(bodyX(), bodyY() + screenY);
       sprite.deleteSprite();
@@ -217,6 +235,7 @@ protected:
     uint8_t eff = _effectiveCount();
     if (eff > 0 && _selectedIndex >= eff) _selectedIndex = eff - 1;
     _scrollIfNeeded();
+    _marqueeOffset = 0;
   }
 
 private:
@@ -225,7 +244,67 @@ private:
   uint8_t       _scrollOffset     = 0;
   bool          _partialTopActive = false;
 
+  uint32_t      _marqueeTimer     = 0;
+  int16_t       _marqueeOffset    = 0;
+
   static constexpr uint8_t ITEM_H = 22;
+
+  static uint16_t _rssiColor(int16_t rssi)
+  {
+    if (rssi >= -60) return TFT_GREEN;
+    if (rssi >= -75) return TFT_YELLOW;
+    return TFT_RED;
+  }
+
+  void _resetMarquee()
+  {
+    _marqueeOffset = 0;
+    _marqueeTimer  = millis();
+  }
+
+  // Redraws the whole list (small — a handful of rows, each a cheap sprite
+  // blit) only while the selected row's label actually overflows its
+  // available width. No-op for every other ListScreen subclass's rows.
+  void _updateMarquee()
+  {
+    uint8_t eff = _effectiveCount();
+    if (eff == 0 || _selectedIndex >= eff) return;
+
+    const ListItem& item   = _items[_selectedIndex];
+    int16_t         listW  = bodyW() - 4;
+    int16_t         availW = listW - 12;
+    if (item.sublabel)
+      availW = (listW - 6 - Uni.Lcd.textWidth(item.sublabel)) - 10;
+
+    if (Uni.Lcd.textWidth(item.label) <= availW) {
+      if (_marqueeOffset != 0) { _marqueeOffset = 0; onRender(); }
+      return;
+    }
+
+    if (millis() - _marqueeTimer < 180) return;
+    _marqueeTimer = millis();
+    _marqueeOffset++;
+    onRender();
+  }
+
+  // Returns the visible slice of `label` for the current marquee offset,
+  // shrinking from the right until it fits `availW` pixels. The label loops
+  // ("label     label     ...") so the ticker scrolls seamlessly.
+  String _marqueeWindow(Sprite& sprite, const char* label, int16_t availW)
+  {
+    String base(label);
+    base += "     ";
+    int16_t loopLen = (int16_t)base.length();
+    if (loopLen <= 0) return String(label);
+
+    int16_t off = _marqueeOffset % loopLen;
+    String  doubled = base + base;
+    String  window  = doubled.substring(off);
+
+    int16_t n = window.length();
+    while (n > 1 && sprite.textWidth(window.substring(0, n)) > availW) n--;
+    return window.substring(0, n);
+  }
 
   uint8_t _effectiveCount()
   {


### PR DESCRIPTION
## Problem
Evil Twin, WiFi Deauther (target mode), and EAPOL Capture (target mode) each carried their own copy of the same pattern: pick a target network by doing one blocking `WiFi.scanNetworks()` call (freezing the UI for several seconds), then show a static list that only refreshes if you back out of the screen and re-enter it.

## Fix
Replaced all three with the same async scan-and-merge loop introduced for WiFi Analyzer in #65: a non-blocking scan polled from `onUpdate()`, merged into a per-slot array by BSSID (existing entries update in place — RSSI, cursor position stable — new ones append, stale ones after 15s get dropped). Rows get the same RSSI color + marquee treatment.

Each screen stops its in-flight scan cleanly before handing the WiFi radio to whatever comes next — deauth injection, promiscuous handshake capture, or repeated STA connect attempts — so there's no conflict between scanning and the attack phase that follows target selection.

EAPOL Capture's scan additionally moves from a synchronous, carefully-timed sweep (600ms/channel, deliberately kept under the framework's hard 10s blocking-scan cap — see the removed comment) to the same async model; that 10s ceiling only ever applied to the *blocking* call, so it no longer constrains the per-channel dwell at all.

## What improves
- No more multi-second UI freeze when opening the target picker on any of the three screens.
- Target list stays live while you're choosing — walk closer to a weak AP and watch it strengthen instead of having to back out and rescan.
- Consistent RSSI color/marquee UX with WiFi Analyzer.

**Depends on #65** (adds the `ListScreen` RSSI/marquee support and is included in this branch until it merges).
