### PR TITLE
feat(ble): live/rolling scan with RSSI color and marquee in BLE Analyzer

### DIFF
--- a/firmware/src/screens/ble/BLEAnalyzerScreen.cpp
+++ b/firmware/src/screens/ble/BLEAnalyzerScreen.cpp
@@ -3,7 +3,6 @@
 #include "core/ScreenManager.h"
 #include "core/AchievementManager.h"
 #include "screens/ble/BLEMenuScreen.h"
-#include "ui/actions/ShowStatusAction.h"
 
 static String _toHex(const std::string& data)
 {
@@ -312,6 +311,9 @@ static String _buildPayloadText(NimBLEAdvertisedDevice& dev)
 
 // ── Lifecycle ──────────────────────────────────────────────────────────────
 
+portMUX_TYPE  BLEAnalyzerScreen::_scanLock      = portMUX_INITIALIZER_UNLOCKED;
+volatile bool BLEAnalyzerScreen::_scanCycleDone = false;
+
 BLEAnalyzerScreen::~BLEAnalyzerScreen()
 {
   if (_bleScan != nullptr) {
@@ -332,6 +334,7 @@ void BLEAnalyzerScreen::onItemSelected(uint8_t index)
 {
   if (_state == STATE_LIST) {
     if (index < (uint8_t)_scanResults.getCount()) {
+      _stopLiveScan();
       _selectedDeviceIdx = index;
       _showInfo();
     }
@@ -355,7 +358,9 @@ void BLEAnalyzerScreen::onBack()
   } else if (_state == STATE_INFO) {
     _selectedDeviceIdx = -1;
     _showList();
+    _nextScanAt = millis();  // resume live scanning
   } else {
+    _stopLiveScan();
     Screen.goBack();
   }
 }
@@ -366,6 +371,18 @@ void BLEAnalyzerScreen::onUpdate()
 {
   if (_state != STATE_DETAIL) {
     ListScreen::onUpdate();
+
+    if (_state == STATE_LIST || _state == STATE_SCAN) {
+      if (_scanInFlight) {
+        _pollLiveScan();
+      } else if (millis() >= _nextScanAt) {
+        _startLiveScan();
+      }
+      if (millis() - _lastPruneAt >= 1000) {
+        _lastPruneAt = millis();
+        _pruneStale();
+      }
+    }
     return;
   }
   if (!Uni.Nav->wasPressed()) return;
@@ -396,47 +413,125 @@ void BLEAnalyzerScreen::_showDetail(const char* titleText, const String& content
 
 // ── Private ────────────────────────────────────────────────────────────────
 
+// ── Live scan (rolling) ──────────────────────────────────────────────────────
+//
+// NimBLEScan::start(duration, cb, is_continue=true) restarts scanning without
+// clearing previous results — the library itself merges by address and
+// refreshes RSSI/payload/timestamp in place for repeat sightings, so we get
+// "existing device updates, new device appends" for free. We only add the
+// restart cadence and staleness pruning (erase() for devices not re-seen in
+// a while) on top. The completion callback fires on the NimBLE host task —
+// it only flips a lock-protected flag; _pollLiveScan() does the real work
+// (reading results, building rows) on the main loop during the safe window
+// between one cycle ending and the next being kicked off.
+
 void BLEAnalyzerScreen::_startScan()
 {
-  _state = STATE_SCAN;
   _selectedDeviceIdx = -1;
-  ShowStatusAction::show("Scanning...", 0);
   _bleScan->clearResults();
-  _scanResults = _bleScan->start(5, false);
+  _scanResults = NimBLEScanResults();
+  _showList();
+  _nextScanAt = millis();
+}
+
+void BLEAnalyzerScreen::_startLiveScan()
+{
+  _bleScan->start(kScanCycleSeconds, &BLEAnalyzerScreen::_onScanComplete, true);
+  _scanInFlight = true;
+}
+
+void BLEAnalyzerScreen::_onScanComplete(NimBLEScanResults /*results*/)
+{
+  portENTER_CRITICAL(&_scanLock);
+  _scanCycleDone = true;
+  portEXIT_CRITICAL(&_scanLock);
+}
+
+void BLEAnalyzerScreen::_pollLiveScan()
+{
+  bool done;
+  portENTER_CRITICAL(&_scanLock);
+  done = _scanCycleDone;
+  if (done) _scanCycleDone = false;
+  portEXIT_CRITICAL(&_scanLock);
+  if (!done) return;
+
+  _scanInFlight = false;
+  _nextScanAt   = millis() + kScanCycleGapMs;
+  _scanResults  = _bleScan->getResults();
 
   int ns = Achievement.inc("ble_analyzer_scan");
   if (ns == 1) Achievement.unlock("ble_analyzer_scan");
+  if ((int)_scanResults.getCount() >= 20) {
+    int n20 = Achievement.inc("ble_analyzer_20");
+    if (n20 == 1) Achievement.unlock("ble_analyzer_20");
+  }
 
-  _showList();
+  _rebuildDevItems();
+  setCount(_devCount);
+  render();
+}
+
+void BLEAnalyzerScreen::_pruneStale()
+{
+  if (_state != STATE_LIST || _scanInFlight) return;
+
+  time_t now     = time(nullptr);
+  bool   changed = false;
+
+  for (int i = (int)_scanResults.getCount() - 1; i >= 0; i--) {
+    NimBLEAdvertisedDevice dev = _scanResults.getDevice(i);
+    if (now - dev.getTimestamp() <= kStaleTimeoutSec) continue;
+
+    _bleScan->erase(dev.getAddress());
+    changed = true;
+    if (_selectedIndex > i) _selectedIndex--;
+  }
+
+  if (!changed) return;
+  _scanResults = _bleScan->getResults();
+  _rebuildDevItems();
+  setCount(_devCount);
+  render();
+}
+
+void BLEAnalyzerScreen::_rebuildDevItems()
+{
+  int count = min((int)_scanResults.getCount(), (int)kMaxDevices);
+  _devCount = 0;
+  for (int i = 0; i < count; i++) {
+    NimBLEAdvertisedDevice dev = _scanResults.getDevice(i);
+    String name = _resolveName(dev);
+    if (name.length() > 0) {
+      _devLabel[i] = name;
+      _devSub[i]   = dev.getAddress().toString().c_str();
+    } else {
+      _devLabel[i] = dev.getAddress().toString().c_str();
+      _devSub[i]   = "";
+    }
+    _devItems[i]         = {_devLabel[i].c_str(),
+                             _devSub[i].length() > 0 ? _devSub[i].c_str() : nullptr};
+    _devItems[i].rssi    = (int16_t)dev.getRSSI();
+    _devItems[i].hasRssi = true;
+    _devCount++;
+  }
+}
+
+void BLEAnalyzerScreen::_stopLiveScan()
+{
+  if (_scanInFlight) {
+    _bleScan->stop();
+    _scanInFlight = false;
+    portENTER_CRITICAL(&_scanLock);
+    _scanCycleDone = false;
+    portEXIT_CRITICAL(&_scanLock);
+  }
 }
 
 void BLEAnalyzerScreen::_showList()
 {
   _state = STATE_LIST;
-  _devCount = 0;
-
-  int count = min((int)_scanResults.getCount(), (int)kMaxDevices);
-
-  if ((int)_scanResults.getCount() >= 20) {
-    int n20 = Achievement.inc("ble_analyzer_20");
-    if (n20 == 1) Achievement.unlock("ble_analyzer_20");
-  }
-  for (int i = 0; i < count; i++) {
-    NimBLEAdvertisedDevice dev = _scanResults.getDevice(i);
-    _devLabel[i] = dev.getAddress().toString().c_str();
-    _devSub[i]   = _resolveName(dev);
-    _devItems[i] = {_devLabel[i].c_str(),
-                    _devSub[i].length() > 0 ? _devSub[i].c_str() : nullptr};
-    _devCount++;
-  }
-
-  // Ensure non-empty list so DIR_BACK always works
-  if (_devCount == 0) {
-    _devLabel[0] = "No devices found";
-    _devItems[0] = {_devLabel[0].c_str()};
-    _devCount    = 1;
-  }
-
+  _rebuildDevItems();
   setItems(_devItems, _devCount);
 }
 

--- a/firmware/src/screens/ble/BLEAnalyzerScreen.h
+++ b/firmware/src/screens/ble/BLEAnalyzerScreen.h
@@ -26,8 +26,11 @@ private:
     STATE_DETAIL,
   } _state = STATE_SCAN;
 
-  static constexpr uint8_t kMaxDevices = 40;
-  static constexpr uint8_t kInfoRows   = 16;
+  static constexpr uint8_t  kMaxDevices = 40;
+  static constexpr uint8_t  kInfoRows   = 16;
+  static constexpr uint32_t kScanCycleSeconds = 3;     // async scan window per cycle
+  static constexpr unsigned long kScanCycleGapMs = 300; // rest between cycles
+  static constexpr time_t   kStaleTimeoutSec = 20;      // device not re-advertised -> dropped
 
   NimBLEScan*       _bleScan           = nullptr;
   NimBLEScanResults _scanResults;
@@ -38,6 +41,26 @@ private:
   String   _devSub[kMaxDevices];
   ListItem _devItems[kMaxDevices];
   uint8_t  _devCount = 0;
+
+  // Live/rolling scan — kept accumulating (is_continue=true) across restarts
+  // so NimBLEScan's own results vector already merges by address and updates
+  // RSSI in place; we only add periodic staleness pruning (via erase()) and
+  // the restart cadence. The completion callback runs on the NimBLE host
+  // task, so it only flips a lock-protected flag — all the real work (
+  // reading results, pruning, rebuilding rows) happens on the main loop.
+  bool          _scanInFlight = false;
+  unsigned long _nextScanAt   = 0;
+  unsigned long _lastPruneAt  = 0;
+
+  static portMUX_TYPE _scanLock;
+  static volatile bool _scanCycleDone;
+  static void _onScanComplete(NimBLEScanResults results);
+
+  void _startLiveScan();
+  void _pollLiveScan();
+  void _pruneStale();
+  void _rebuildDevItems();
+  void _stopLiveScan();
 
   // Info view (16 fixed rows)
   String   _infoVal[kInfoRows];

--- a/firmware/src/screens/wifi/WifiAnalyzerScreen.cpp
+++ b/firmware/src/screens/wifi/WifiAnalyzerScreen.cpp
@@ -4,7 +4,6 @@
 #include "core/ConfigManager.h"
 #include "core/AchievementManager.h"
 #include "screens/wifi/WifiMenuScreen.h"
-#include "ui/actions/ShowStatusAction.h"
 
 #include <WiFi.h>
 #include <esp_wifi.h>
@@ -78,7 +77,9 @@ static void _clientSnifferCb(void* buf, wifi_promiscuous_pkt_type_t type)
 
 void WifiAnalyzerScreen::onInit()
 {
-  _scan();
+  _entryCount = 0;
+  _showScan();
+  _nextScanAt = millis();
 }
 
 void WifiAnalyzerScreen::onUpdate()
@@ -98,7 +99,19 @@ void WifiAnalyzerScreen::onUpdate()
     }
     return;
   }
+
   ListScreen::onUpdate();
+
+  if (_scanInFlight) {
+    _pollLiveScan();
+  } else if (millis() >= _nextScanAt) {
+    _startLiveScan();
+  }
+
+  if (millis() - _lastPruneAt >= 1000) {
+    _lastPruneAt = millis();
+    _pruneStale();
+  }
 }
 
 void WifiAnalyzerScreen::onItemSelected(uint8_t index)
@@ -124,55 +137,126 @@ void WifiAnalyzerScreen::onBack()
     _showScan();
   } else {
     WiFi.scanDelete();
+    _scanInFlight = false;
     Screen.goBack();
   }
 }
 
 // ── Private ────────────────────────────────────────────────────────────────
 
-void WifiAnalyzerScreen::_scan()
+// ── Live scan ────────────────────────────────────────────────────────────────
+//
+// Instead of one blocking WiFi.scanNetworks() call, we kick an async scan,
+// poll it from onUpdate(), merge results into _entries[] in place (existing
+// BSSIDs keep their row/index so the cursor doesn't jump), then immediately
+// schedule the next cycle. _pruneStale() separately drops APs that haven't
+// been seen in a while, so the list behaves like a live radar while walking.
+
+void WifiAnalyzerScreen::_startLiveScan()
 {
-  ShowStatusAction::show("Scanning...", 0);
-
   WiFi.mode(WIFI_STA);
-  int total = WiFi.scanNetworks(false, true);
-  if (total > MAX_SCAN) total = MAX_SCAN;
-  _entryCount = total;
+  WiFi.scanNetworks(true, true);  // async
+  _scanInFlight = true;
+}
 
-  for (int i = 0; i < total; i++) {
-    int32_t rssi = WiFi.RSSI(i);
-    const char* strength;
-    if      (rssi >= -50) strength = "Very Good";
-    else if (rssi >= -60) strength = "Good";
-    else if (rssi >= -70) strength = "Better";
-    else if (rssi >= -80) strength = "Low";
-    else                  strength = "Very Low";
-
-    snprintf(_entries[i].ssid,    sizeof(_entries[i].ssid),    "%s", WiFi.SSID(i).c_str());
-    snprintf(_entries[i].bssid,   sizeof(_entries[i].bssid),   "%s", WiFi.BSSIDstr(i).c_str());
-    snprintf(_entries[i].rssi,    sizeof(_entries[i].rssi),    "[%d] %s", (int)rssi, strength);
-    snprintf(_entries[i].channel, sizeof(_entries[i].channel), "%d", (int)WiFi.channel(i));
-
-    switch (WiFi.encryptionType(i)) {
-      case WIFI_AUTH_OPEN:           snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "OPEN");            break;
-      case WIFI_AUTH_WEP:            snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "WEP");             break;
-      case WIFI_AUTH_WPA_PSK:        snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "WPA_PSK");         break;
-      case WIFI_AUTH_WPA2_PSK:       snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "WPA2_PSK");        break;
-      case WIFI_AUTH_WPA_WPA2_PSK:   snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "WPA_WPA2_PSK");    break;
-      case WIFI_AUTH_WPA2_ENTERPRISE:snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "WPA2_ENTERPRISE"); break;
-      case WIFI_AUTH_WPA3_PSK:       snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "WPA3_PSK");        break;
-      default:                       snprintf(_entries[i].encryption, sizeof(_entries[i].encryption), "UNKNOWN");         break;
-    }
+void WifiAnalyzerScreen::_pollLiveScan()
+{
+  int total = WiFi.scanComplete();
+  if (total == WIFI_SCAN_RUNNING || total == WIFI_SCAN_FAILED) {
+    if (total == WIFI_SCAN_FAILED) { _scanInFlight = false; _nextScanAt = millis() + SCAN_CYCLE_GAP_MS; }
+    return;
   }
+
+  if (total > MAX_SCAN) total = MAX_SCAN;
+  for (int i = 0; i < total; i++) _mergeScanResult(i);
+
+  WiFi.scanDelete();
+  _scanInFlight = false;
+  _nextScanAt   = millis() + SCAN_CYCLE_GAP_MS;
 
   int na = Achievement.inc("wifi_analyzer_scan");
   if (na == 1) Achievement.unlock("wifi_analyzer_scan");
-  if (total >= 20) {
+  if (_entryCount >= 20) {
     int n20 = Achievement.inc("wifi_analyzer_20aps");
     if (n20 == 1) Achievement.unlock("wifi_analyzer_20aps");
   }
 
-  _showScan();
+  _rebuildScanItems();
+  setCount(_entryCount);
+  render();
+}
+
+void WifiAnalyzerScreen::_mergeScanResult(int idx)
+{
+  String bssid = WiFi.BSSIDstr(idx);
+
+  int slot = -1;
+  for (int i = 0; i < _entryCount; i++) {
+    if (bssid.equalsIgnoreCase(_entries[i].bssid)) { slot = i; break; }
+  }
+  if (slot < 0) {
+    if (_entryCount >= MAX_SCAN) return;  // list full — ignore new APs until one drops
+    slot = _entryCount++;
+  }
+
+  int32_t rssi = WiFi.RSSI(idx);
+  const char* strength;
+  if      (rssi >= -50) strength = "Very Good";
+  else if (rssi >= -60) strength = "Good";
+  else if (rssi >= -70) strength = "Better";
+  else if (rssi >= -80) strength = "Low";
+  else                  strength = "Very Low";
+
+  WifiEntry& e = _entries[slot];
+  snprintf(e.ssid,    sizeof(e.ssid),    "%s", WiFi.SSID(idx).c_str());
+  snprintf(e.bssid,   sizeof(e.bssid),   "%s", bssid.c_str());
+  snprintf(e.rssi,    sizeof(e.rssi),    "[%d] %s", (int)rssi, strength);
+  snprintf(e.channel, sizeof(e.channel), "%d", (int)WiFi.channel(idx));
+  e.rssiValue = (int)rssi;
+  e.lastSeen  = millis();
+
+  switch (WiFi.encryptionType(idx)) {
+    case WIFI_AUTH_OPEN:           snprintf(e.encryption, sizeof(e.encryption), "OPEN");            break;
+    case WIFI_AUTH_WEP:            snprintf(e.encryption, sizeof(e.encryption), "WEP");             break;
+    case WIFI_AUTH_WPA_PSK:        snprintf(e.encryption, sizeof(e.encryption), "WPA_PSK");         break;
+    case WIFI_AUTH_WPA2_PSK:       snprintf(e.encryption, sizeof(e.encryption), "WPA2_PSK");        break;
+    case WIFI_AUTH_WPA_WPA2_PSK:   snprintf(e.encryption, sizeof(e.encryption), "WPA_WPA2_PSK");    break;
+    case WIFI_AUTH_WPA2_ENTERPRISE:snprintf(e.encryption, sizeof(e.encryption), "WPA2_ENTERPRISE"); break;
+    case WIFI_AUTH_WPA3_PSK:       snprintf(e.encryption, sizeof(e.encryption), "WPA3_PSK");        break;
+    default:                       snprintf(e.encryption, sizeof(e.encryption), "UNKNOWN");         break;
+  }
+}
+
+void WifiAnalyzerScreen::_pruneStale()
+{
+  if (_state != STATE_SCAN || _entryCount == 0) return;
+
+  uint32_t now     = millis();
+  bool     changed = false;
+
+  for (int i = _entryCount - 1; i >= 0; i--) {
+    if (now - _entries[i].lastSeen <= STALE_TIMEOUT_MS) continue;
+
+    for (int j = i; j < _entryCount - 1; j++) _entries[j] = _entries[j + 1];
+    _entryCount--;
+    changed = true;
+
+    if (_selectedIndex > i) _selectedIndex--;
+  }
+
+  if (!changed) return;
+  _rebuildScanItems();
+  setCount(_entryCount);
+  render();
+}
+
+void WifiAnalyzerScreen::_rebuildScanItems()
+{
+  for (int i = 0; i < _entryCount; i++) {
+    _scanItems[i]         = {_entries[i].ssid, _entries[i].bssid};
+    _scanItems[i].rssi    = (int16_t)_entries[i].rssiValue;
+    _scanItems[i].hasRssi = true;
+  }
 }
 
 void WifiAnalyzerScreen::_showScan()
@@ -180,15 +264,20 @@ void WifiAnalyzerScreen::_showScan()
   _state = STATE_SCAN;
   strncpy(_title, "WiFi Analyzer", sizeof(_title));
 
-  for (int i = 0; i < _entryCount; i++) {
-    _scanItems[i] = {_entries[i].ssid, _entries[i].bssid};
-  }
-
+  _rebuildScanItems();
   setItems(_scanItems, _entryCount);
+  _nextScanAt = millis();
 }
 
 void WifiAnalyzerScreen::_showClients(int index)
 {
+  // Hand the radio over to the client sniffer — abort any in-flight scan
+  // first so it doesn't collide with the promiscuous/channel-lock setup.
+  if (_scanInFlight) {
+    WiFi.scanDelete();
+    _scanInFlight = false;
+  }
+
   _selectedAp = index;
   _state      = STATE_CLIENTS;
 

--- a/firmware/src/screens/wifi/WifiAnalyzerScreen.h
+++ b/firmware/src/screens/wifi/WifiAnalyzerScreen.h
@@ -8,8 +8,8 @@ class WifiAnalyzerScreen : public ListScreen
 public:
   const char* title() override { return _title; }
 
-  // Keep WiFi awake while sniffing clients (promiscuous mode).
-  bool inhibitPowerSave() override { return _state == STATE_CLIENTS; }
+  // Keep WiFi awake while sniffing clients or mid-scan (promiscuous/scan use the radio).
+  bool inhibitPowerSave() override { return _state == STATE_CLIENTS || _scanInFlight; }
 
   void onInit() override;
   void onUpdate() override;
@@ -21,20 +21,31 @@ private:
   static constexpr int MAX_SCAN    = 20;
   static constexpr int MAX_CLIENTS = 32;  // keep in sync with kMaxClients in .cpp
 
+  // Live-scan tuning: how long to rest between completed async scans, and
+  // how long an AP can go unseen before it's dropped from the list.
+  static constexpr uint32_t SCAN_CYCLE_GAP_MS = 3000;
+  static constexpr uint32_t STALE_TIMEOUT_MS  = 15000;
+
   enum State { STATE_SCAN, STATE_CLIENTS };
   State _state = STATE_SCAN;
 
   struct WifiEntry {
-    char ssid[33];
-    char bssid[18];
-    char rssi[20];
-    char channel[4];
-    char encryption[20];
+    char     ssid[33];
+    char     bssid[18];
+    char     rssi[20];
+    char     channel[4];
+    char     encryption[20];
+    int      rssiValue = 0;
+    uint32_t lastSeen  = 0;
   };
 
   char      _title[16]         = "WiFi Analyzer";
   WifiEntry _entries[MAX_SCAN];
   int       _entryCount        = 0;
+
+  bool      _scanInFlight      = false;
+  uint32_t  _nextScanAt        = 0;
+  uint32_t  _lastPruneAt       = 0;
 
   ListItem       _scanItems[MAX_SCAN];
   ScrollListView _scrollView;
@@ -48,9 +59,14 @@ private:
   int                 _lastClientCount   = -1;
   uint32_t            _lastClientRefresh = 0;
 
-  void _scan();
   void _showScan();
   void _showClients(int index);
   void _stopClients();
   void _refreshClients(bool force);
+
+  void _startLiveScan();
+  void _pollLiveScan();
+  void _mergeScanResult(int idx);
+  void _pruneStale();
+  void _rebuildScanItems();
 };

--- a/firmware/src/ui/templates/ListScreen.h
+++ b/firmware/src/ui/templates/ListScreen.h
@@ -5,10 +5,17 @@
 class ListScreen : public BaseScreen
 {
 public:
+  // NOTE: no default member initializers here — this project builds with a
+  // C++ standard where NSDMI disqualify aggregate-init, and dozens of call
+  // sites rely on brace-init like `{"Label"}` / `{"Label", "Sub"}`, which
+  // needs ListItem to stay a plain aggregate (trailing members then get
+  // zero/false from aggregate-init, same effective default).
   struct ListItem
   {
     const char* label;
     const char* sublabel;
+    int16_t     rssi;      // dBm, only meaningful when hasRssi
+    bool        hasRssi;   // when true, label is tinted by RSSI strength
   };
 
   template <size_t N>
@@ -67,6 +74,7 @@ public:
       {
         _selectedIndex = (_selectedIndex == 0) ? eff - 1 : _selectedIndex - 1;
         _scrollIfNeeded();
+        _resetMarquee();
         onRender();
         if (Uni.Speaker) Uni.Speaker->beep();
       }
@@ -74,6 +82,7 @@ public:
       {
         _selectedIndex = (_selectedIndex >= eff - 1) ? 0 : _selectedIndex + 1;
         _scrollIfNeeded();
+        _resetMarquee();
         onRender();
         if (Uni.Speaker) Uni.Speaker->beep();
       }
@@ -82,6 +91,7 @@ public:
         uint8_t page = bodyH() / ITEM_H;
         _selectedIndex = (_selectedIndex >= page) ? _selectedIndex - page : 0;
         _scrollIfNeeded();
+        _resetMarquee();
         onRender();
         if (Uni.Speaker) Uni.Speaker->beep();
       }
@@ -91,6 +101,7 @@ public:
         uint8_t last = eff - 1;
         _selectedIndex = (_selectedIndex + page <= last) ? _selectedIndex + page : last;
         _scrollIfNeeded();
+        _resetMarquee();
         onRender();
         if (Uni.Speaker) Uni.Speaker->beep();
       }
@@ -98,7 +109,10 @@ public:
       {
         onItemSelected(_selectedIndex);
       }
+      return;
     }
+
+    _updateMarquee();
   }
 
   void onRender() override
@@ -120,7 +134,8 @@ public:
       const ListItem* item     = &_items[idx];
       bool     selected = (idx == _selectedIndex);
       uint16_t bg       = selected ? Config.getThemeColor() : TFT_BLACK;
-      uint16_t fg       = selected ? TFT_WHITE : TFT_LIGHTGREY;
+      uint16_t fg       = item->hasRssi ? _rssiColor(item->rssi)
+                                         : (selected ? TFT_WHITE : TFT_LIGHTGREY);
 
       Sprite sprite(&lcd);
       sprite.createSprite(listW, rowH);
@@ -132,17 +147,20 @@ public:
 
       sprite.setTextColor(fg, bg);
 
+      int16_t labelAvailW = listW - 12;
       if (item->sublabel)
       {
-        sprite.drawString(item->label, 6, (ITEM_H / 2) - 4 + dy);
         sprite.setTextColor(selected ? TFT_CYAN : TFT_DARKGREY, bg);
         int16_t subX = listW - 6 - sprite.textWidth(item->sublabel);
         sprite.drawString(item->sublabel, subX, (ITEM_H / 2) - 4 + dy);
+        labelAvailW = subX - 6 - 4;
+        sprite.setTextColor(fg, bg);
       }
+
+      if (selected && sprite.textWidth(item->label) > labelAvailW)
+        sprite.drawString(_marqueeWindow(sprite, item->label, labelAvailW), 6, (ITEM_H / 2) - 4 + dy);
       else
-      {
         sprite.drawString(item->label, 6, (ITEM_H / 2) - 4 + dy);
-      }
 
       sprite.pushSprite(bodyX(), bodyY() + screenY);
       sprite.deleteSprite();
@@ -217,6 +235,7 @@ protected:
     uint8_t eff = _effectiveCount();
     if (eff > 0 && _selectedIndex >= eff) _selectedIndex = eff - 1;
     _scrollIfNeeded();
+    _marqueeOffset = 0;
   }
 
 private:
@@ -225,7 +244,67 @@ private:
   uint8_t       _scrollOffset     = 0;
   bool          _partialTopActive = false;
 
+  uint32_t      _marqueeTimer     = 0;
+  int16_t       _marqueeOffset    = 0;
+
   static constexpr uint8_t ITEM_H = 22;
+
+  static uint16_t _rssiColor(int16_t rssi)
+  {
+    if (rssi >= -60) return TFT_GREEN;
+    if (rssi >= -75) return TFT_YELLOW;
+    return TFT_RED;
+  }
+
+  void _resetMarquee()
+  {
+    _marqueeOffset = 0;
+    _marqueeTimer  = millis();
+  }
+
+  // Redraws the whole list (small — a handful of rows, each a cheap sprite
+  // blit) only while the selected row's label actually overflows its
+  // available width. No-op for every other ListScreen subclass's rows.
+  void _updateMarquee()
+  {
+    uint8_t eff = _effectiveCount();
+    if (eff == 0 || _selectedIndex >= eff) return;
+
+    const ListItem& item   = _items[_selectedIndex];
+    int16_t         listW  = bodyW() - 4;
+    int16_t         availW = listW - 12;
+    if (item.sublabel)
+      availW = (listW - 6 - Uni.Lcd.textWidth(item.sublabel)) - 10;
+
+    if (Uni.Lcd.textWidth(item.label) <= availW) {
+      if (_marqueeOffset != 0) { _marqueeOffset = 0; onRender(); }
+      return;
+    }
+
+    if (millis() - _marqueeTimer < 180) return;
+    _marqueeTimer = millis();
+    _marqueeOffset++;
+    onRender();
+  }
+
+  // Returns the visible slice of `label` for the current marquee offset,
+  // shrinking from the right until it fits `availW` pixels. The label loops
+  // ("label     label     ...") so the ticker scrolls seamlessly.
+  String _marqueeWindow(Sprite& sprite, const char* label, int16_t availW)
+  {
+    String base(label);
+    base += "     ";
+    int16_t loopLen = (int16_t)base.length();
+    if (loopLen <= 0) return String(label);
+
+    int16_t off = _marqueeOffset % loopLen;
+    String  doubled = base + base;
+    String  window  = doubled.substring(off);
+
+    int16_t n = window.length();
+    while (n > 1 && sprite.textWidth(window.substring(0, n)) > availW) n--;
+    return window.substring(0, n);
+  }
 
   uint8_t _effectiveCount()
   {


### PR DESCRIPTION
## Problem
BLE Analyzer did one blocking 5-second `NimBLEScan` and never refreshed the device list — same one-shot limitation as the WiFi-side scanners before #65.

## Fix
Switched to a restarting async scan (`NimBLEScan::start(duration, cb, is_continue=true)`) so NimBLE's own results keep accumulating across cycles: RSSI/payload refresh in place for devices seen again, new ones appear as they come into range, and any device not re-advertised in 20s is dropped via `NimBLEScan::erase()`.

The scan-complete callback runs on the NimBLE host task, not the Arduino loop — it only flips a lock-protected flag. All the real work (reading results, pruning, rebuilding rows) happens on the main loop, in the window between one cycle ending and the next being kicked off, so there's no cross-task access to the scan results.

Also swapped which field is the row's label vs sublabel: it was address-as-label / name-as-sublabel, which meant the marquee (which only animates the label) would never help with the long text that actually needs it. Now the resolved device name is the label and the address is the sublabel, matching the SSID/BSSID convention already used on the WiFi side.

## What improves
- BLE Analyzer now updates live while scanning instead of a single 5-second snapshot.
- RSSI color coding and marquee for long device names, consistent with the WiFi-side screens.
- Live scanning correctly pauses while viewing a specific device's detail (no functional need for it there) and resumes on return to the list.

**Depends on #65** (adds the `ListScreen` RSSI/marquee support and is included in this branch until it merges).
