### PR TITLE
fix(wifi): reject EAPOL handshake pairs with mismatched replay counters

### DIFF
--- a/firmware/src/screens/wifi/WifiEapolCaptureScreen.cpp
+++ b/firmware/src/screens/wifi/WifiEapolCaptureScreen.cpp
@@ -9,6 +9,7 @@
 #include "utils/StorageUtil.h"
 
 #include "utils/network/WifiAttackUtil.h"
+#include "utils/network/EapolUtil.h"
 #include <WiFi.h>
 #include <cstring>
 
@@ -604,95 +605,46 @@ void WifiEapolCaptureScreen::_appendPcapFrame(const std::string& path,
   f.close();
 }
 
-// ── EAPOL message type parser ─────────────────────────────────────────────
-
-// Returns: 1=M1, 2=M2, 3=M3, 4=M4 (zero-nonce M2), 0=unknown.
-static int _parseEapolMsg(const uint8_t* data, uint16_t len) {
-  static const uint8_t snap[8] = {0xAA, 0xAA, 0x03, 0x00, 0x00, 0x00, 0x88, 0x8E};
-  for (uint16_t i = 24; i + 16 <= len; i++) {
-    bool match = true;
-    for (int k = 0; k < 8; k++) { if (data[i + k] != snap[k]) { match = false; break; } }
-    if (!match) continue;
-    const uint8_t* e = data + i + 8;
-    if (len < i + 8 + 49) return 0;     // need up to nonce end
-    if (e[1] != 0x03) return 0;
-    if (e[4] != 0x02) return 0;
-    uint16_t ki  = ((uint16_t)e[5] << 8) | e[6];
-    bool     ack = (ki & 0x0080) != 0;
-    bool     mic = (ki & 0x0100) != 0;
-    bool     ins = (ki & 0x0040) != 0;
-    if  (ack && !mic)        return 1;  // M1
-    if  (ack &&  mic)        return 3;  // M3
-    if (!ack &&  mic && !ins) {
-      // Distinguish M2 (non-zero nonce) from M4 (zero nonce)
-      bool nonceZero = true;
-      for (int z = 0; z < 32; z++) { if (e[17 + z] != 0) { nonceZero = false; break; } }
-      return nonceZero ? 4 : 2;
-    }
-    return 0;
-  }
-  return 0;
-}
-
-// ── Handshake validation (in-memory pairing, same logic as brute force) ──
+// ── Handshake validation (in-memory pairing via EapolUtil, shared with
+//    WifiUnigotchiScreen) ───────────────────────────────────────────────────
+//
+// A pair is only "validated" when the M1/M3 and M2 share BOTH the station
+// MAC *and* the EAPOL Replay Counter — MAC alone isn't enough, since this
+// screen actively deauths clients to force retries, and a stale M1/M3 from
+// one attempt paired with a fresh M2 from a later attempt (or vice versa)
+// produces a MIC that can never verify against that ANonce, no matter the
+// password.
 
 int WifiEapolCaptureScreen::_updateValidation(EapolEntry& entry,
                                                 const uint8_t* data, uint16_t len) {
-  static const uint8_t snap[8] = {0xAA, 0xAA, 0x03, 0x00, 0x00, 0x00, 0x88, 0x8E};
-  if (len < 40) return 0;
+  EapolUtil::Frame f;
+  EapolUtil::Msg   msg = EapolUtil::parse(data, len, f);
+  if (msg == EapolUtil::MSG_NONE || msg == EapolUtil::MSG_M4) return (int)msg;
+  if (entry.validated) return (int)msg;  // already confirmed — don't overwrite
 
-  // Find SNAP header
-  int snapOff = -1;
-  for (uint16_t i = 24; i + 16 <= len; i++) {
-    bool match = true;
-    for (int k = 0; k < 8; k++) { if (data[i + k] != snap[k]) { match = false; break; } }
-    if (match) { snapOff = i; break; }
-  }
-  if (snapOff < 0) return 0;
-
-  const uint8_t* e = data + snapOff + 8;
-  if (len < (uint16_t)(snapOff + 8 + 49)) return 0;
-  if (e[1] != 0x03 || e[4] != 0x02) return 0;
-
-  uint16_t ki  = ((uint16_t)e[5] << 8) | e[6];
-  bool     ack = (ki & 0x0080) != 0;
-  bool     mic = (ki & 0x0100) != 0;
-  bool     ins = (ki & 0x0040) != 0;
-
-  int msg = 0;
-  if (ack && !mic)       msg = 1;
-  else if (ack && mic)   msg = 3;
-  else if (!ack && mic && !ins) {
-    bool nonceZero = true;
-    for (int z = 0; z < 32; z++) { if (e[17 + z] != 0) { nonceZero = false; break; } }
-    msg = nonceZero ? 4 : 2;
-  }
-  if (msg == 0 || msg == 4) return msg;
-  if (entry.validated) return msg;  // already confirmed — don't overwrite
-
-  if (msg == 1 || msg == 3) {
-    // M1/M3: store ANonce + STA MAC (addr1 = DA = STA in AP→STA direction)
-    memcpy(entry.anonce, e + 17, 32);
-    memcpy(entry.staMacM1, data + 4, 6);
+  if (msg == EapolUtil::MSG_M1 || msg == EapolUtil::MSG_M3) {
+    memcpy(entry.anonce,   f.nonce,         32);
+    memcpy(entry.replayM1, f.replayCounter, 8);
+    memcpy(entry.staMacM1, f.staMac,        6);
     entry.hasAnonce = true;
-    // Reverse pair: check if buffered M2 from same STA
     if (entry.hasM2Data && entry.beaconWritten &&
-        memcmp(entry.staMacM1, entry.staMacM2, 6) == 0) {
+        memcmp(entry.staMacM1, entry.staMacM2, 6) == 0 &&
+        memcmp(entry.replayM1, entry.replayM2, 8) == 0) {
       entry.validated = true;
     }
-  } else if (msg == 2) {
-    // M2: store SNonce + STA MAC (addr2 = SA = STA in STA→AP direction)
-    memcpy(entry.m2Snonce, e + 17, 32);
-    memcpy(entry.staMacM2, data + 10, 6);
+  } else if (msg == EapolUtil::MSG_M2) {
+    memcpy(entry.m2Snonce, f.nonce,         32);
+    memcpy(entry.replayM2, f.replayCounter, 8);
+    memcpy(entry.staMacM2, f.staMac,        6);
     entry.hasM2Data = true;
-    // Forward pair: check if have M1/M3 from same STA
     if (entry.hasAnonce && entry.beaconWritten &&
-        memcmp(entry.staMacM1, entry.staMacM2, 6) == 0) {
+        memcmp(entry.staMacM1, entry.staMacM2, 6) == 0 &&
+        memcmp(entry.replayM1, entry.replayM2, 8) == 0) {
       entry.validated = true;
     }
   }
 
-  return msg;
+  return (int)msg;
 }
 
 // ── Main loop frame processor ─────────────────────────────────────────────
@@ -800,7 +752,8 @@ void WifiEapolCaptureScreen::_flush() {
       if (entry.validated) continue;
 
       auto  ssidIt = _ssidMap.find(cap.bssid);
-      int msg = _parseEapolMsg(cap.data, cap.len);
+      EapolUtil::Frame ef;
+      int msg = (int)EapolUtil::parse(cap.data, cap.len, ef);
       bool hasSsid = (ssidIt != _ssidMap.end());
 
       bool wasValid = false;  // entry.validated is false here (checked above)

--- a/firmware/src/screens/wifi/WifiEapolCaptureScreen.h
+++ b/firmware/src/screens/wifi/WifiEapolCaptureScreen.h
@@ -48,12 +48,14 @@ public:
     bool        validated     = false;  // confirmed valid handshake (beacon + paired M1+M2)
     std::string filepath;
 
-    // In-memory handshake pairing (same logic as brute force parser)
+    // In-memory handshake pairing (EapolUtil — shared with WifiUnigotchiScreen)
     uint8_t anonce[32]   = {};
+    uint8_t replayM1[8]  = {};      // Replay Counter from the stored M1/M3
     uint8_t staMacM1[6]  = {};
     bool    hasAnonce    = false;   // M1/M3 seen and written to PCAP
 
     uint8_t m2Snonce[32] = {};
+    uint8_t replayM2[8]  = {};      // Replay Counter from the stored M2
     uint8_t staMacM2[6]  = {};
     bool    hasM2Data    = false;   // M2 (non-zero nonce) seen and written to PCAP
   };

--- a/firmware/src/screens/wifi/WifiUnigotchiScreen.cpp
+++ b/firmware/src/screens/wifi/WifiUnigotchiScreen.cpp
@@ -6,6 +6,7 @@
 #include "core/ConfigManager.h"
 #include "utils/StorageUtil.h"
 #include "utils/HackerHead.h"
+#include "utils/network/EapolUtil.h"
 #include "ui/actions/InputSelectAction.h"
 
 #include <WiFi.h>
@@ -51,26 +52,6 @@ struct PcapGlobalHdr {
 };
 struct PcapPktHdr { uint32_t ts_sec; uint32_t ts_usec; uint32_t incl_len; uint32_t orig_len; };
 #pragma pack(pop)
-
-// ── EAPOL message parser (M1..M4) ──────────────────────────────────────────────
-static int _parseEapolMsg(const uint8_t* data, uint16_t len) {
-  static const uint8_t snap[8] = {0xAA, 0xAA, 0x03, 0x00, 0x00, 0x00, 0x88, 0x8E};
-  for (uint16_t i = 24; i + 16 <= len; i++) {
-    bool match = true;
-    for (int k = 0; k < 8; k++) { if (data[i + k] != snap[k]) { match = false; break; } }
-    if (!match) continue;
-    const uint8_t* e = data + i + 8;
-    if (len < i + 8 + 49) return 0;
-    if (e[1] != 0x03 || e[4] != 0x02) return 0;
-    uint16_t ki = ((uint16_t)e[5] << 8) | e[6];
-    bool ack = (ki & 0x0080), mic = (ki & 0x0100), secure = (ki & 0x0200);
-    if (ack && !mic) return 1;          // M1
-    if (ack &&  mic) return 3;          // M3
-    if (!ack && mic) return secure ? 4 : 2;  // M4 sets the Secure bit, M2 doesn't (matches oink)
-    return 0;
-  }
-  return 0;
-}
 
 // ── Lifecycle ───────────────────────────────────────────────────────────────
 
@@ -532,35 +513,40 @@ bool WifiUnigotchiScreen::_extractPmkid(const uint8_t* data, uint16_t len) {
   return false;
 }
 
+// Pairing via EapolUtil (shared with WifiEapolCaptureScreen). A pair is only
+// "validated" when the M1/M3 and M2 share BOTH the station MAC *and* the
+// EAPOL Replay Counter — MAC alone isn't enough, since active mode deauths
+// clients to force retries, and a stale M1/M3 from one attempt paired with
+// a fresh M2 from a later attempt (or vice versa) produces a MIC that can
+// never verify against that ANonce, no matter the password.
 int WifiUnigotchiScreen::_updateValidation(EapolEntry& entry, const uint8_t* data, uint16_t len) {
-  static const uint8_t snap[8] = {0xAA, 0xAA, 0x03, 0x00, 0x00, 0x00, 0x88, 0x8E};
-  if (len < 40) return 0;
-  int so = -1;
-  for (uint16_t i = 24; i + 16 <= len; i++) {
-    bool m = true; for (int k = 0; k < 8; k++) if (data[i + k] != snap[k]) { m = false; break; }
-    if (m) { so = i; break; }
+  EapolUtil::Frame f;
+  EapolUtil::Msg   msg = EapolUtil::parse(data, len, f);
+  if (msg == EapolUtil::MSG_NONE || msg == EapolUtil::MSG_M4) return (int)msg;
+  if (entry.validated) return (int)msg;
+
+  if (msg == EapolUtil::MSG_M1 || msg == EapolUtil::MSG_M3) {
+    memcpy(entry.anonce,   f.nonce,         32);
+    memcpy(entry.replayM1, f.replayCounter, 8);
+    memcpy(entry.staMacM1, f.staMac,        6);
+    entry.hasAnonce = true;
+    if (entry.hasM2Data &&
+        !memcmp(entry.staMacM1, entry.staMacM2, 6) &&
+        !memcmp(entry.replayM1, entry.replayM2, 8)) {
+      entry.validated = true;
+    }
+  } else if (msg == EapolUtil::MSG_M2) {
+    memcpy(entry.m2Snonce, f.nonce,         32);
+    memcpy(entry.replayM2, f.replayCounter, 8);
+    memcpy(entry.staMacM2, f.staMac,        6);
+    entry.hasM2Data = true;
+    if (entry.hasAnonce &&
+        !memcmp(entry.staMacM1, entry.staMacM2, 6) &&
+        !memcmp(entry.replayM1, entry.replayM2, 8)) {
+      entry.validated = true;
+    }
   }
-  if (so < 0) return 0;
-  const uint8_t* e = data + so + 8;
-  if (len < (uint16_t)(so + 8 + 49)) return 0;
-  if (e[1] != 0x03 || e[4] != 0x02) return 0;
-  uint16_t ki = ((uint16_t)e[5] << 8) | e[6];
-  bool ack = (ki & 0x0080), mic = (ki & 0x0100), secure = (ki & 0x0200);
-  int msg = 0;
-  if (ack && !mic) msg = 1; else if (ack && mic) msg = 3;
-  else if (!ack && mic) msg = secure ? 4 : 2;  // Secure bit splits M4 from M2 (matches oink)
-  if (msg == 0 || msg == 4) return msg;
-  if (entry.validated) return msg;
-  // Pair M1 ANonce + M2 SNonce by STA MAC. Validation is independent of storage
-  // and of whether a beacon was seen — the nonces in the frames are enough.
-  if (msg == 1 || msg == 3) {
-    memcpy(entry.anonce, e + 17, 32); memcpy(entry.staMacM1, data + 4, 6); entry.hasAnonce = true;
-    if (entry.hasM2Data && !memcmp(entry.staMacM1, entry.staMacM2, 6)) entry.validated = true;
-  } else if (msg == 2) {
-    memcpy(entry.m2Snonce, e + 17, 32); memcpy(entry.staMacM2, data + 10, 6); entry.hasM2Data = true;
-    if (entry.hasAnonce && !memcmp(entry.staMacM1, entry.staMacM2, 6)) entry.validated = true;
-  }
-  return msg;
+  return (int)msg;
 }
 
 int WifiUnigotchiScreen::_registerApTarget(const MacAddr& bssid, uint8_t ch, int8_t rssi) {
@@ -656,7 +642,8 @@ void WifiUnigotchiScreen::_flush() {
     auto ssidIt = _ssidMap.find(cap.bssid);
     if (ssidIt != _ssidMap.end() && entry.ssid.empty()) entry.ssid = ssidIt->second;
 
-    if (_parseEapolMsg(cap.data, cap.len) == 1 && !entry.pmkidSeen &&
+    EapolUtil::Frame pmkidFrame;
+    if (EapolUtil::parse(cap.data, cap.len, pmkidFrame) == EapolUtil::MSG_M1 && !entry.pmkidSeen &&
         _extractPmkid(cap.data, cap.len)) {
       entry.pmkidSeen = true; _pmkids++;
       if (Uni.Speaker) Uni.Speaker->beep();

--- a/firmware/src/screens/wifi/WifiUnigotchiScreen.h
+++ b/firmware/src/screens/wifi/WifiUnigotchiScreen.h
@@ -54,8 +54,8 @@ public:
     std::string ssid;
     bool beaconWritten = false, validated = false, pmkidSeen = false;
     std::string filepath;
-    uint8_t anonce[32] = {}, staMacM1[6] = {}; bool hasAnonce = false;
-    uint8_t m2Snonce[32] = {}, staMacM2[6] = {}; bool hasM2Data = false;
+    uint8_t anonce[32] = {}, replayM1[8] = {}, staMacM1[6] = {}; bool hasAnonce = false;
+    uint8_t m2Snonce[32] = {}, replayM2[8] = {}, staMacM2[6] = {}; bool hasM2Data = false;
   };
 
   static constexpr int RING_SIZE = 16;

--- a/firmware/src/utils/network/EapolUtil.h
+++ b/firmware/src/utils/network/EapolUtil.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <Arduino.h>
+#include <cstring>
+
+// Shared EAPOL-Key (WPA/WPA2 4-way handshake) frame parser, used by
+// WifiEapolCaptureScreen and WifiUnigotchiScreen so both features classify
+// and pair messages identically instead of keeping separate hand-rolled
+// copies that can (and did) disagree.
+class EapolUtil {
+public:
+  enum Msg { MSG_NONE = 0, MSG_M1 = 1, MSG_M2 = 2, MSG_M3 = 3, MSG_M4 = 4 };
+
+  struct Frame {
+    uint8_t staMac[6];        // station MAC — DA for M1/M3, SA for M2/M4
+    uint8_t nonce[32];        // ANonce (M1/M3) or SNonce (M2/M4)
+    uint8_t replayCounter[8]; // ties a specific M1/M3 to the M2/M4 that answers it
+  };
+
+  // Locates the SNAP+EAPOL-Key header inside an 802.11 data frame payload,
+  // classifies the message, and extracts the fields needed to correlate a
+  // specific challenge (M1/M3) with its specific response (M2/M4).
+  //
+  // Pairing on station MAC alone (the historical bug here) isn't enough:
+  // when a client re-runs the 4-way handshake — e.g. because this tool just
+  // deauthed it to force a retry — a stale M1/M3 from an earlier attempt and
+  // a fresh M2 (or vice versa) share the same MAC but were never part of the
+  // same exchange, so the MIC in that M2 can never verify against that
+  // ANonce no matter the password. The Replay Counter is what the protocol
+  // itself uses to tie a response to its specific challenge, so callers
+  // must additionally compare replayCounter before treating a pair as valid.
+  static Msg parse(const uint8_t* data, uint16_t len, Frame& out) {
+    static const uint8_t snap[8] = {0xAA, 0xAA, 0x03, 0x00, 0x00, 0x00, 0x88, 0x8E};
+    if (len < 40) return MSG_NONE;
+
+    int snapOff = -1;
+    for (uint16_t i = 24; i + 16 <= len; i++) {
+      bool match = true;
+      for (int k = 0; k < 8; k++) { if (data[i + k] != snap[k]) { match = false; break; } }
+      if (match) { snapOff = i; break; }
+    }
+    if (snapOff < 0) return MSG_NONE;
+
+    const uint8_t* e = data + snapOff + 8;
+    if (len < (uint16_t)(snapOff + 8 + 49)) return MSG_NONE;  // need up to nonce end
+    if (e[1] != 0x03 || e[4] != 0x02) return MSG_NONE;
+
+    uint16_t ki     = ((uint16_t)e[5] << 8) | e[6];
+    bool     ack    = (ki & 0x0080) != 0;
+    bool     mic    = (ki & 0x0100) != 0;
+    bool     ins    = (ki & 0x0040) != 0;
+    bool     secure = (ki & 0x0200) != 0;
+
+    Msg msg = MSG_NONE;
+    if (ack && !mic) {
+      msg = MSG_M1;
+    } else if (ack && mic) {
+      msg = MSG_M3;
+    } else if (!ack && mic && !ins) {
+      // M2 vs M4 share ack/mic/ins — M4 is defined as carrying a zero nonce
+      // AND setting the Secure bit; require both so a frame that only
+      // matches one heuristic doesn't get misclassified either way.
+      bool nonceZero = true;
+      for (int z = 0; z < 32; z++) { if (e[17 + z] != 0) { nonceZero = false; break; } }
+      msg = (nonceZero && secure) ? MSG_M4 : MSG_M2;
+    }
+    if (msg == MSG_NONE) return MSG_NONE;
+
+    memcpy(out.nonce, e + 17, 32);
+    memcpy(out.replayCounter, e + 9, 8);
+    if (msg == MSG_M1 || msg == MSG_M3) memcpy(out.staMac, data + 4, 6);   // addr1 = DA
+    else                                 memcpy(out.staMac, data + 10, 6); // addr2 = SA
+
+    return msg;
+  }
+};


### PR DESCRIPTION
## Problem
EAPOL Capture and Unigotchi each carry their own copy of the same handshake-validation logic: an M1/M3 (ANonce) and an M2 (SNonce+MIC) are treated as a valid, crackable 4-way handshake once both are seen for the same AP **and their station MAC addresses match**.

Station MAC alone doesn't prove the pair belongs to the same handshake attempt. Both tools actively deauth clients to force a retry — EAPOL Capture fires repeated deauth bursts per AP, Unigotchi's active mode does the same to "hammer" a client into reconnecting — so it's easy to end up with, say, the M1 from attempt #1 and the M2 from attempt #2 of the same client. Same MAC, different ANonce/replay-counter epoch: the MIC in that M2 was computed against the ANonce the client actually received, not the one sitting in the M1 frame that got saved, so the pair can never verify against **any** password — yet the tool marks it `validated` and writes it out as a capture.

## Fix
The EAPOL-Key Replay Counter (8 bytes, right before the nonce — already inside the buffer both parsers were reading, just never extracted) is what the protocol itself uses to tie a response to its specific challenge. Added a shared parser (`EapolUtil`) used by both screens that extracts it alongside the nonce and station MAC, and pairing now requires the Replay Counter to match too, not just the MAC, before a handshake is considered validated.

This also collapses two separately hand-rolled, slightly-diverging EAPOL parsers into one — the two screens used different heuristics to tell M2 apart from M4, so they could disagree with each other on message classification for the same frame.

## What improves
- Handshakes marked "captured"/"validated" by EAPOL Capture and Unigotchi are now actually crackable — previously a subset (more likely the more aggressive the deauth settings) would silently be unusable despite being reported as valid.
- One parser instead of two, so the two features can no longer classify the same EAPOL frame differently.
