### PR TITLE
fix(wifi): redirect (not serve) captive portal for domain-hosted probes

### DIFF
--- a/firmware/src/utils/network/DnsSpoofServer.cpp
+++ b/firmware/src/utils/network/DnsSpoofServer.cpp
@@ -200,7 +200,17 @@ bool DnsSpoofServer::_isCaptiveDomain(const char* domain)
          strcasecmp(domain, "ipv6.msftncsi.com") == 0 ||
          strcasecmp(domain, "www.msftncsi.com") == 0 ||
          strcasecmp(domain, "nmcheck.gnome.org") == 0 ||
-         strcasecmp(domain, "detectportal.firefox.com") == 0;
+         strcasecmp(domain, "detectportal.firefox.com") == 0 ||
+         // Broader OS/desktop-environment connectivity checkers — catches
+         // things like connectivity-check.ubuntu.com, network-check-*, etc.
+         // that don't have a single canonical hostname worth hardcoding.
+         strcasestr(domain, "ncsi") ||
+         strcasestr(domain, "nmcheck") ||
+         strcasestr(domain, "gnome") ||
+         strcasestr(domain, "ubuntu") ||
+         strcasestr(domain, "canonical") ||
+         strcasestr(domain, "networkcheck") ||
+         strcasestr(domain, "hotspot");
 }
 
 // ── Web Server (delegates to SharedWebServer on port 80) ──────────────────

--- a/firmware/src/utils/network/SharedWebServer.cpp
+++ b/firmware/src/utils/network/SharedWebServer.cpp
@@ -248,8 +248,17 @@ void SharedWebServer::_registerRoutes() {
     } else if (_dnsSpoofActive && _dnsSpoofCb) {
       _dnsSpoofCb(req, _dnsSpoofCtx);
     } else if (_isCaptiveDomain(host.c_str())) {
-      if (_captiveActive) { _visitCount++; if (_onVisit) _onVisit(_ctx); _serveCaptive(req); }
-      else _sendUnavailable(req);
+      if (!_captiveActive) { _sendUnavailable(req); return; }
+      // Some OS connectivity checkers (notably Linux NetworkManager) only
+      // recognize a captive portal when the probe gets redirected to a
+      // *different* host — serving 200 straight back under the domain they
+      // probed isn't reliably picked up. Bounce anything that isn't already
+      // addressed to the AP's own IP before serving the page.
+      if (!host.equalsIgnoreCase(WiFi.softAPIP().toString())) {
+        _redirectToPortal(req);
+        return;
+      }
+      _visitCount++; if (_onVisit) _onVisit(_ctx); _serveCaptive(req);
     } else {
       _sendUnavailable(req);
     }
@@ -269,7 +278,7 @@ void SharedWebServer::_registerRoutes() {
   // OS probes well-known paths to detect captive portals. Redirect to / when
   // captive is active so the host-based routing above handles serving.
   auto captiveProbe = [this](AsyncWebServerRequest* req) {
-    if (_captiveActive) req->redirect("/");
+    if (_captiveActive) _redirectToPortal(req);
     else req->send(204);
   };
   _server.on("/generate_204",         HTTP_GET, captiveProbe);
@@ -381,6 +390,13 @@ void SharedWebServer::_registerRoutes() {
       _dnsSpoofCb(req, _dnsSpoofCtx);
     } else if (_isCaptiveDomain(host.c_str())) {
       if (!_captiveActive) { _sendUnavailable(req); return; }
+      // Same reasoning as GET / — probes under a domain host need to see an
+      // actual redirect elsewhere, not a same-host 200/asset, to be reliably
+      // recognized as "there's a captive portal here".
+      if (!host.equalsIgnoreCase(WiFi.softAPIP().toString())) {
+        _redirectToPortal(req);
+        return;
+      }
       // Serve portal asset if it exists, otherwise redirect to portal root
       if (!_portalBasePath.isEmpty() && Uni.Storage && Uni.Storage->isAvailable()) {
         String asset = _portalBasePath + path;
@@ -389,7 +405,7 @@ void SharedWebServer::_registerRoutes() {
           return;
         }
       }
-      req->redirect("/");
+      _redirectToPortal(req);
     } else {
       _sendUnavailable(req);
     }
@@ -610,7 +626,23 @@ bool SharedWebServer::_isCaptiveDomain(const char* domain) {
          strcasecmp(domain, "ipv6.msftncsi.com") == 0 ||
          strcasecmp(domain, "www.msftncsi.com") == 0 ||
          strcasecmp(domain, "nmcheck.gnome.org") == 0 ||
-         strcasecmp(domain, "detectportal.firefox.com") == 0;
+         strcasecmp(domain, "detectportal.firefox.com") == 0 ||
+         // Broader OS/desktop-environment connectivity checkers — catches
+         // things like connectivity-check.ubuntu.com, network-check-*, etc.
+         // that don't have a single canonical hostname worth hardcoding.
+         strcasestr(domain, "ncsi") ||
+         strcasestr(domain, "nmcheck") ||
+         strcasestr(domain, "gnome") ||
+         strcasestr(domain, "ubuntu") ||
+         strcasestr(domain, "canonical") ||
+         strcasestr(domain, "networkcheck") ||
+         strcasestr(domain, "hotspot");
+}
+
+void SharedWebServer::_redirectToPortal(AsyncWebServerRequest* req) {
+  AsyncWebServerResponse* response = req->beginResponse(302);
+  response->addHeader("Location", "http://" + WiFi.softAPIP().toString() + "/");
+  req->send(response);
 }
 
 void SharedWebServer::_serveCaptive(AsyncWebServerRequest* req) {

--- a/firmware/src/utils/network/SharedWebServer.h
+++ b/firmware/src/utils/network/SharedWebServer.h
@@ -129,4 +129,5 @@ private:
   static bool   _isCaptiveDomain(const char* domain);
   void _serveCaptive(AsyncWebServerRequest* req);
   void _capturePost(AsyncWebServerRequest* req);
+  void _redirectToPortal(AsyncWebServerRequest* req);
 };


### PR DESCRIPTION
## Problem
The Evil Twin / Karma captive portal flow served the portal HTML directly (HTTP 200) under whatever Host header a captive-detection probe arrived on. Some OS connectivity checkers — notably Linux NetworkManager (GNOME/Ubuntu), which probes `/` with the checked domain still in the Host header — only recognize a captive portal when the response is an actual redirect elsewhere, not a 200 with an unexpected body served back under the same host. Getting served the page directly means no "sign in to network" prompt ever appears for those clients.

## Fix
Any request whose Host is a recognized captive-check domain (not the AP's own IP) now gets a 302 redirect to the AP's own IP first; only a request already addressed to the AP IP gets the actual portal page. Applied consistently across the `GET /` handler, the `onNotFound` catch-all, and the well-known probe paths (`/generate_204`, `/fwlink`, `/hotspot-detect.html`, `/connecttest.txt`) via one new `_redirectToPortal()` helper.

Also broadened the recognized-captive-domain check (shared by `SharedWebServer` and `DnsSpoofServer`) with substring matches for `ncsi`, `nmcheck`, `gnome`, `ubuntu`, `canonical`, `networkcheck`, and `hotspot` — the existing list only had exact hostnames like `nmcheck.gnome.org`, missing common variants such as `connectivity-check.ubuntu.com`.

`DnsSpoofServer`'s domain list gets the same broadening, but not the redirect-first behavior — that component treats every domain as a potential phishing target via its custom `dns_config` mappings, not just captive-portal detection, so redirecting first there would also need it to recognize its own AP IP as a valid destination — a larger change out of scope here.

## What improves
- The captive-portal sign-in prompt now reliably triggers on Linux/GNOME/Ubuntu NetworkManager clients connecting to Evil Twin / Karma APs, not just Android/iOS/Windows.
- Broader coverage of desktop-environment connectivity-check domains.
