### PR TITLE
feat(wifi/ble): one-shot Analyzer scans, live RSSI only for the selected item

### DIFF
--- a/firmware/src/screens/ble/BLEAnalyzerScreen.cpp
+++ b/firmware/src/screens/ble/BLEAnalyzerScreen.cpp
@@ -3,6 +3,7 @@
 #include "core/ScreenManager.h"
 #include "core/AchievementManager.h"
 #include "screens/ble/BLEMenuScreen.h"
+#include "ui/actions/ShowStatusAction.h"
 
 static String _toHex(const std::string& data)
 {
@@ -309,14 +310,34 @@ static String _buildPayloadText(NimBLEAdvertisedDevice& dev)
   return s;
 }
 
-// ── Lifecycle ──────────────────────────────────────────────────────────────
+// ── Live RSSI watcher ───────────────────────────────────────────────────────
+//
+// While a device is selected we keep an indefinite, duplicate-passing scan
+// running and record the RSSI of every advertisement from the picked address.
+// setMaxResults(0) makes NimBLEScan drop each result right after the callback,
+// so the scan's results vector never grows behind our back — but it also
+// invalidates _scanResults, which is why the info view reads _selDev instead.
+// The callback runs on the NimBLE host task; _selRssi is a single aligned word,
+// so volatile is enough.
 
-portMUX_TYPE  BLEAnalyzerScreen::_scanLock      = portMUX_INITIALIZER_UNLOCKED;
-volatile bool BLEAnalyzerScreen::_scanCycleDone = false;
+static NimBLEAddress _rssiTarget;
+static volatile int  _selRssi = 0;   // 0 = no advertisement seen yet
+
+class RssiWatcher : public NimBLEAdvertisedDeviceCallbacks {
+public:
+  void onResult(NimBLEAdvertisedDevice* dev) override
+  {
+    if (dev->getAddress() == _rssiTarget) _selRssi = dev->getRSSI();
+  }
+};
+static RssiWatcher _rssiWatcher;
+
+// ── Lifecycle ──────────────────────────────────────────────────────────────
 
 BLEAnalyzerScreen::~BLEAnalyzerScreen()
 {
   if (_bleScan != nullptr) {
+    _stopRssiWatch();   // unregister the callback before the scan object goes away
     _bleScan->stop();
     NimBLEDevice::deinit(true);
     _bleScan = nullptr;
@@ -327,27 +348,27 @@ void BLEAnalyzerScreen::onInit()
 {
   NimBLEDevice::init("");
   _bleScan = NimBLEDevice::getScan();
-  _startScan();
+  _doScan();
 }
 
 void BLEAnalyzerScreen::onItemSelected(uint8_t index)
 {
   if (_state == STATE_LIST) {
-    if (index < (uint8_t)_scanResults.getCount()) {
-      _stopLiveScan();
+    if (index < _devCount) {
       _selectedDeviceIdx = index;
+      _selDev            = _scanResults.getDevice(index);  // snapshot before the watcher runs
       _showInfo();
+      _startRssiWatch();
     }
   } else if (_state == STATE_INFO) {
-    NimBLEAdvertisedDevice dev = _scanResults.getDevice(_selectedDeviceIdx);
-    if (index == 11 && dev.getServiceUUIDCount() > 0)
-      _showDetail("Service UUIDs", _buildServiceUUIDText(dev));
-    else if (index == 12 && dev.getManufacturerDataCount() > 0)
-      _showDetail("Mfr Data", _buildMfrDataText(dev));
-    else if (index == 13 && dev.getServiceDataCount() > 0)
-      _showDetail("Service Data", _buildServiceDataText(dev));
-    else if (index == 15 && dev.getPayloadLength() > 0)
-      _showDetail("Payload", _buildPayloadText(dev));
+    if (index == 11 && _selDev.getServiceUUIDCount() > 0)
+      _showDetail("Service UUIDs", _buildServiceUUIDText(_selDev));
+    else if (index == 12 && _selDev.getManufacturerDataCount() > 0)
+      _showDetail("Mfr Data", _buildMfrDataText(_selDev));
+    else if (index == 13 && _selDev.getServiceDataCount() > 0)
+      _showDetail("Service Data", _buildServiceDataText(_selDev));
+    else if (index == 15 && _selDev.getPayloadLength() > 0)
+      _showDetail("Payload", _buildPayloadText(_selDev));
   }
 }
 
@@ -356,11 +377,11 @@ void BLEAnalyzerScreen::onBack()
   if (_state == STATE_DETAIL) {
     _showInfo();
   } else if (_state == STATE_INFO) {
+    _stopRssiWatch();
     _selectedDeviceIdx = -1;
-    _showList();
-    _nextScanAt = millis();  // resume live scanning
+    _doScan();   // leaving the detail view re-scans, so the list stays current
   } else {
-    _stopLiveScan();
+    _bleScan->stop();
     Screen.goBack();
   }
 }
@@ -372,16 +393,11 @@ void BLEAnalyzerScreen::onUpdate()
   if (_state != STATE_DETAIL) {
     ListScreen::onUpdate();
 
-    if (_state == STATE_LIST || _state == STATE_SCAN) {
-      if (_scanInFlight) {
-        _pollLiveScan();
-      } else if (millis() >= _nextScanAt) {
-        _startLiveScan();
-      }
-      if (millis() - _lastPruneAt >= 1000) {
-        _lastPruneAt = millis();
-        _pruneStale();
-      }
+    // Only the RSSI row of a selected device tracks in real time — the device
+    // list itself is a static snapshot of the last scan.
+    if (_state == STATE_INFO && millis() - _lastRssiRefresh >= 500) {
+      _lastRssiRefresh = millis();
+      _refreshRssiRow();
     }
     return;
   }
@@ -413,52 +429,26 @@ void BLEAnalyzerScreen::_showDetail(const char* titleText, const String& content
 
 // ── Private ────────────────────────────────────────────────────────────────
 
-// ── Live scan (rolling) ──────────────────────────────────────────────────────
+// ── Scan ─────────────────────────────────────────────────────────────────────
 //
-// NimBLEScan::start(duration, cb, is_continue=true) restarts scanning without
-// clearing previous results — the library itself merges by address and
-// refreshes RSSI/payload/timestamp in place for repeat sightings, so we get
-// "existing device updates, new device appends" for free. We only add the
-// restart cadence and staleness pruning (erase() for devices not re-seen in
-// a while) on top. The completion callback fires on the NimBLE host task —
-// it only flips a lock-protected flag; _pollLiveScan() does the real work
-// (reading results, building rows) on the main loop during the safe window
-// between one cycle ending and the next being kicked off.
+// One blocking sweep, same as every other BLE module (Whisper Pair, Chameleon
+// Scan): the list is a snapshot, not a live radar. Re-entering the list — on
+// open, or on BACK out of a device's info view — takes a fresh snapshot.
 
-void BLEAnalyzerScreen::_startScan()
+void BLEAnalyzerScreen::_doScan()
 {
+  _state             = STATE_SCAN;
   _selectedDeviceIdx = -1;
+  ShowStatusAction::show("Scanning BLE...", 0);
+
+  // Undo the watcher's scan config before a storing scan.
+  _bleScan->setAdvertisedDeviceCallbacks(nullptr, false);
+  _bleScan->setMaxResults(0xFF);
   _bleScan->clearResults();
-  _scanResults = NimBLEScanResults();
-  _showList();
-  _nextScanAt = millis();
-}
 
-void BLEAnalyzerScreen::_startLiveScan()
-{
-  _bleScan->start(kScanCycleSeconds, &BLEAnalyzerScreen::_onScanComplete, true);
-  _scanInFlight = true;
-}
+  _scanResults = _bleScan->start(kScanSeconds, false);
 
-void BLEAnalyzerScreen::_onScanComplete(NimBLEScanResults /*results*/)
-{
-  portENTER_CRITICAL(&_scanLock);
-  _scanCycleDone = true;
-  portEXIT_CRITICAL(&_scanLock);
-}
-
-void BLEAnalyzerScreen::_pollLiveScan()
-{
-  bool done;
-  portENTER_CRITICAL(&_scanLock);
-  done = _scanCycleDone;
-  if (done) _scanCycleDone = false;
-  portEXIT_CRITICAL(&_scanLock);
-  if (!done) return;
-
-  _scanInFlight = false;
-  _nextScanAt   = millis() + kScanCycleGapMs;
-  _scanResults  = _bleScan->getResults();
+  if (_scanResults.getCount() == 0) ShowStatusAction::show("No devices found");
 
   int ns = Achievement.inc("ble_analyzer_scan");
   if (ns == 1) Achievement.unlock("ble_analyzer_scan");
@@ -467,31 +457,49 @@ void BLEAnalyzerScreen::_pollLiveScan()
     if (n20 == 1) Achievement.unlock("ble_analyzer_20");
   }
 
-  _rebuildDevItems();
-  setCount(_devCount);
-  render();
+  _showList();
 }
 
-void BLEAnalyzerScreen::_pruneStale()
+// ── Live RSSI of the selected device ────────────────────────────────────────
+
+void BLEAnalyzerScreen::_startRssiWatch()
 {
-  if (_state != STATE_LIST || _scanInFlight) return;
+  _rssiTarget      = _selDev.getAddress();
+  _selRssi         = 0;
+  _lastRssiShown   = 1;
+  _lastRssiRefresh = millis();
 
-  time_t now     = time(nullptr);
-  bool   changed = false;
+  _bleScan->setMaxResults(0);                              // don't store results
+  _bleScan->setAdvertisedDeviceCallbacks(&_rssiWatcher, true);  // pass duplicates
+  _bleScan->start(0, nullptr, false);                      // 0 = scan indefinitely
+  _rssiWatching = true;
+}
 
-  for (int i = (int)_scanResults.getCount() - 1; i >= 0; i--) {
-    NimBLEAdvertisedDevice dev = _scanResults.getDevice(i);
-    if (now - dev.getTimestamp() <= kStaleTimeoutSec) continue;
+void BLEAnalyzerScreen::_stopRssiWatch()
+{
+  if (!_rssiWatching) return;
+  _bleScan->stop();
+  _bleScan->setAdvertisedDeviceCallbacks(nullptr, false);
+  _bleScan->setMaxResults(0xFF);
+  _rssiWatching = false;
+}
 
-    _bleScan->erase(dev.getAddress());
-    changed = true;
-    if (_selectedIndex > i) _selectedIndex--;
-  }
+void BLEAnalyzerScreen::_refreshRssiRow()
+{
+  const int rssi = _selRssi;
+  if (rssi == 0 || rssi == _lastRssiShown) return;
+  _lastRssiShown = rssi;
 
-  if (!changed) return;
-  _scanResults = _bleScan->getResults();
-  _rebuildDevItems();
-  setCount(_devCount);
+  _infoVal[5]   = String(rssi) + " dBm";
+  _infoItems[5] = {"RSSI", _infoVal[5].c_str()};
+
+  // Distance is derived from RSSI, so it has to follow along.
+  bool   haveTx = _selDev.haveTXPower();
+  int8_t tx     = haveTx ? _selDev.getTXPower() : 0;
+  _infoVal[7]   = _distanceEstimate(rssi, tx, haveTx);
+  _infoItems[7] = {"Distance",
+                   _infoVal[7].length() > 0 ? _infoVal[7].c_str() : nullptr};
+
   render();
 }
 
@@ -517,17 +525,6 @@ void BLEAnalyzerScreen::_rebuildDevItems()
   }
 }
 
-void BLEAnalyzerScreen::_stopLiveScan()
-{
-  if (_scanInFlight) {
-    _bleScan->stop();
-    _scanInFlight = false;
-    portENTER_CRITICAL(&_scanLock);
-    _scanCycleDone = false;
-    portEXIT_CRITICAL(&_scanLock);
-  }
-}
-
 void BLEAnalyzerScreen::_showList()
 {
   _state = STATE_LIST;
@@ -543,7 +540,7 @@ void BLEAnalyzerScreen::_showInfo()
   int nd = Achievement.inc("ble_analyzer_detail");
   if (nd == 1) Achievement.unlock("ble_analyzer_detail");
 
-  NimBLEAdvertisedDevice dev = _scanResults.getDevice(_selectedDeviceIdx);
+  NimBLEAdvertisedDevice& dev = _selDev;
 
   const char* addrType;
   switch (dev.getAddressType()) {
@@ -575,12 +572,16 @@ void BLEAnalyzerScreen::_showInfo()
     _infoVal[4] = "";
   }
 
-  _infoVal[5] = String(dev.getRSSI()) + " dBm";
+  // Prefer the live sample (BACK out of a detail view returns here mid-watch);
+  // _lastRssiShown tracks the raw watcher value so the next sample always draws.
+  const int rssi = (_selRssi != 0) ? (int)_selRssi : (int)dev.getRSSI();
+  _lastRssiShown = _selRssi;
+  _infoVal[5]    = String(rssi) + " dBm";
 
   bool haveTx = dev.haveTXPower();
   int8_t tx   = haveTx ? dev.getTXPower() : 0;
   _infoVal[6] = haveTx ? (String((int)tx) + " dBm") : String();
-  _infoVal[7] = _distanceEstimate(dev.getRSSI(), tx, haveTx);
+  _infoVal[7] = _distanceEstimate(rssi, tx, haveTx);
 
   _infoVal[8] = _advTypeName(dev.getAdvType());
   _infoVal[9] = _advFlagsString(dev.getAdvFlags());

--- a/firmware/src/screens/ble/BLEAnalyzerScreen.h
+++ b/firmware/src/screens/ble/BLEAnalyzerScreen.h
@@ -28,9 +28,7 @@ private:
 
   static constexpr uint8_t  kMaxDevices = 40;
   static constexpr uint8_t  kInfoRows   = 16;
-  static constexpr uint32_t kScanCycleSeconds = 3;     // async scan window per cycle
-  static constexpr unsigned long kScanCycleGapMs = 300; // rest between cycles
-  static constexpr time_t   kStaleTimeoutSec = 20;      // device not re-advertised -> dropped
+  static constexpr uint32_t kScanSeconds = 5;   // one-shot blocking sweep
 
   NimBLEScan*       _bleScan           = nullptr;
   NimBLEScanResults _scanResults;
@@ -42,35 +40,33 @@ private:
   ListItem _devItems[kMaxDevices];
   uint8_t  _devCount = 0;
 
-  // Live/rolling scan — kept accumulating (is_continue=true) across restarts
-  // so NimBLEScan's own results vector already merges by address and updates
-  // RSSI in place; we only add periodic staleness pruning (via erase()) and
-  // the restart cadence. The completion callback runs on the NimBLE host
-  // task, so it only flips a lock-protected flag — all the real work (
-  // reading results, pruning, rebuilding rows) happens on the main loop.
-  bool          _scanInFlight = false;
-  unsigned long _nextScanAt   = 0;
-  unsigned long _lastPruneAt  = 0;
-
-  static portMUX_TYPE _scanLock;
-  static volatile bool _scanCycleDone;
-  static void _onScanComplete(NimBLEScanResults results);
-
-  void _startLiveScan();
-  void _pollLiveScan();
-  void _pruneStale();
+  void _doScan();
   void _rebuildDevItems();
-  void _stopLiveScan();
 
   // Info view (16 fixed rows)
+  //
+  // _selDev is a by-value snapshot of the picked device (NimBLEAdvertisedDevice
+  // owns its payload in a std::vector, so the copy is self-contained). The live
+  // RSSI watcher below erases entries from the scan's own results vector, which
+  // would otherwise dangle the pointers _scanResults holds.
+  NimBLEAdvertisedDevice _selDev;
   String   _infoVal[kInfoRows];
   ListItem _infoItems[kInfoRows];
+
+  // Live RSSI of the selected device: an indefinite duplicate-passing scan
+  // whose callback only records the RSSI of the matching address.
+  int           _lastRssiShown  = 1;   // sentinel: nothing rendered yet
+  bool          _rssiWatching   = false;
+  unsigned long _lastRssiRefresh = 0;
+
+  void _startRssiWatch();
+  void _stopRssiWatch();
+  void _refreshRssiRow();
 
   // Detail view — wrapped scrolling text for clickable info-row drill-downs.
   TextScrollView _textView;
   String         _detailTitle;
 
-  void _startScan();
   void _showList();
   void _showInfo();
   void _showDetail(const char* titleText, const String& content);

--- a/firmware/src/screens/wifi/WifiAnalyzerScreen.cpp
+++ b/firmware/src/screens/wifi/WifiAnalyzerScreen.cpp
@@ -4,6 +4,7 @@
 #include "core/ConfigManager.h"
 #include "core/AchievementManager.h"
 #include "screens/wifi/WifiMenuScreen.h"
+#include "ui/actions/ShowStatusAction.h"
 
 #include <WiFi.h>
 #include <esp_wifi.h>
@@ -12,9 +13,11 @@
 // ── Client sniffer (promiscuous) ─────────────────────────────────────────────
 //
 // When an AP is selected we lock the radio to its channel, turn on promiscuous
-// mode and record the unique station MACs seen talking to/from that BSSID.
-// The callback runs in the WiFi task, so the shared store is guarded with a
+// mode and record the unique station MACs seen talking to/from that BSSID,
+// plus the live RSSI of the AP's own frames (beacons alone give ~10 samples/s).
+// The callback runs in the WiFi task, so the shared MAC store is guarded with a
 // portMUX spinlock; the screen copies it out and renders on the main loop.
+// _apRssi is a single aligned word — volatile is enough, no lock needed.
 
 static constexpr uint8_t kMaxClients = 32;  // must match MAX_CLIENTS in the header
 
@@ -22,6 +25,7 @@ static portMUX_TYPE _cliMux = portMUX_INITIALIZER_UNLOCKED;
 static uint8_t      _cliMacs[kMaxClients][6];
 static volatile uint8_t _cliCount = 0;
 static uint8_t      _targetBssid[6];
+static volatile int _apRssi = 0;   // 0 = no frame from the AP seen yet
 
 // Multicast/broadcast group bit (LSB of the first octet). Group-addressed
 // frames never identify a real station, so they are ignored.
@@ -57,6 +61,10 @@ static void _clientSnifferCb(void* buf, wifi_promiscuous_pkt_type_t type)
   const uint8_t* a2 = pl + 10;   // addr2
   const uint8_t* a3 = pl + 16;   // addr3
 
+  // Live RSSI: only frames the AP itself transmitted (addr2 == BSSID) measure
+  // the AP's signal — a client's uplink frame would report the client's level.
+  if (memcmp(a2, _targetBssid, 6) == 0) _apRssi = pkt->rx_ctrl.rssi;
+
   // Resolve which address is the BSSID and which is the station from the
   // toDS/fromDS flags. WDS (both set) uses a 4-address header — skip it.
   const uint8_t* bssid;
@@ -78,8 +86,7 @@ static void _clientSnifferCb(void* buf, wifi_promiscuous_pkt_type_t type)
 void WifiAnalyzerScreen::onInit()
 {
   _entryCount = 0;
-  _showScan();
-  _nextScanAt = millis();
+  _doScan();
 }
 
 void WifiAnalyzerScreen::onUpdate()
@@ -87,13 +94,15 @@ void WifiAnalyzerScreen::onUpdate()
   if (_state == STATE_CLIENTS) {
     if (Uni.Nav->wasPressed()) {
       auto dir = Uni.Nav->readDirection();
-      if (dir == INavigation::DIR_BACK) { _stopClients(); _showScan(); return; }
+      if (dir == INavigation::DIR_BACK) { _stopClients(); _doScan(); return; }
 #ifndef DEVICE_HAS_KEYBOARD
-      if (dir == INavigation::DIR_PRESS) { _stopClients(); _showScan(); return; }
+      if (dir == INavigation::DIR_PRESS) { _stopClients(); _doScan(); return; }
 #endif
       _scrollView.onNav(dir);
     }
-    if (millis() - _lastClientRefresh >= 700) {
+    // 500 ms cadence so the live RSSI reads as a moving value; _refreshClients
+    // bails out early when neither the RSSI nor the client count changed.
+    if (millis() - _lastClientRefresh >= 500) {
       _lastClientRefresh = millis();
       _refreshClients(false);
     }
@@ -101,17 +110,6 @@ void WifiAnalyzerScreen::onUpdate()
   }
 
   ListScreen::onUpdate();
-
-  if (_scanInFlight) {
-    _pollLiveScan();
-  } else if (millis() >= _nextScanAt) {
-    _startLiveScan();
-  }
-
-  if (millis() - _lastPruneAt >= 1000) {
-    _lastPruneAt = millis();
-    _pruneStale();
-  }
 }
 
 void WifiAnalyzerScreen::onItemSelected(uint8_t index)
@@ -134,45 +132,73 @@ void WifiAnalyzerScreen::onBack()
 {
   if (_state == STATE_CLIENTS) {
     _stopClients();
-    _showScan();
+    _doScan();      // leaving the detail view re-scans, so the list stays current
   } else {
     WiFi.scanDelete();
-    _scanInFlight = false;
     Screen.goBack();
   }
 }
 
 // ── Private ────────────────────────────────────────────────────────────────
 
-// ── Live scan ────────────────────────────────────────────────────────────────
+// ── Scan ─────────────────────────────────────────────────────────────────────
 //
-// Instead of one blocking WiFi.scanNetworks() call, we kick an async scan,
-// poll it from onUpdate(), merge results into _entries[] in place (existing
-// BSSIDs keep their row/index so the cursor doesn't jump), then immediately
-// schedule the next cycle. _pruneStale() separately drops APs that haven't
-// been seen in a while, so the list behaves like a live radar while walking.
+// One blocking sweep, same as every other WiFi module (Deauther, EAPOL Capture,
+// Evil Twin): the list is a snapshot, not a live radar. Re-entering the list —
+// on open, or on BACK out of an AP's detail view — takes a fresh snapshot.
+// Real-time tracking is limited to the RSSI of a selected AP, sampled from its
+// own frames by the promiscuous callback.
 
-void WifiAnalyzerScreen::_startLiveScan()
+static const char* _strengthLabel(int rssi)
 {
-  WiFi.mode(WIFI_STA);
-  WiFi.scanNetworks(true, true);  // async
-  _scanInFlight = true;
+  if (rssi >= -50) return "Very Good";
+  if (rssi >= -60) return "Good";
+  if (rssi >= -70) return "Better";
+  if (rssi >= -80) return "Low";
+  return "Very Low";
 }
 
-void WifiAnalyzerScreen::_pollLiveScan()
+void WifiAnalyzerScreen::_doScan()
 {
-  int total = WiFi.scanComplete();
-  if (total == WIFI_SCAN_RUNNING || total == WIFI_SCAN_FAILED) {
-    if (total == WIFI_SCAN_FAILED) { _scanInFlight = false; _nextScanAt = millis() + SCAN_CYCLE_GAP_MS; }
+  _state = STATE_SCAN;
+  strncpy(_title, "WiFi Analyzer", sizeof(_title));
+  ShowStatusAction::show("Scanning (10s)...", 0);
+
+  WiFi.mode(WIFI_STA);
+  WiFi.disconnect();
+  int total = WiFi.scanNetworks(false, false, false, SCAN_DWELL_MS, 0);
+
+  _entryCount = 0;
+  if (total <= 0) {
+    ShowStatusAction::show("No networks found");
+    setItems(_scanItems, 0);
     return;
   }
 
   if (total > MAX_SCAN) total = MAX_SCAN;
-  for (int i = 0; i < total; i++) _mergeScanResult(i);
+  for (int i = 0; i < total; i++) {
+    const int   rssi = (int)WiFi.RSSI(i);
+    WifiEntry&  e    = _entries[_entryCount++];
+
+    snprintf(e.ssid,    sizeof(e.ssid),    "%s", WiFi.SSID(i).c_str());
+    snprintf(e.bssid,   sizeof(e.bssid),   "%s", WiFi.BSSIDstr(i).c_str());
+    snprintf(e.rssi,    sizeof(e.rssi),    "[%d] %s", rssi, _strengthLabel(rssi));
+    snprintf(e.channel, sizeof(e.channel), "%d", (int)WiFi.channel(i));
+    e.rssiValue = rssi;
+
+    switch (WiFi.encryptionType(i)) {
+      case WIFI_AUTH_OPEN:           snprintf(e.encryption, sizeof(e.encryption), "OPEN");            break;
+      case WIFI_AUTH_WEP:            snprintf(e.encryption, sizeof(e.encryption), "WEP");             break;
+      case WIFI_AUTH_WPA_PSK:        snprintf(e.encryption, sizeof(e.encryption), "WPA_PSK");         break;
+      case WIFI_AUTH_WPA2_PSK:       snprintf(e.encryption, sizeof(e.encryption), "WPA2_PSK");        break;
+      case WIFI_AUTH_WPA_WPA2_PSK:   snprintf(e.encryption, sizeof(e.encryption), "WPA_WPA2_PSK");    break;
+      case WIFI_AUTH_WPA2_ENTERPRISE:snprintf(e.encryption, sizeof(e.encryption), "WPA2_ENTERPRISE"); break;
+      case WIFI_AUTH_WPA3_PSK:       snprintf(e.encryption, sizeof(e.encryption), "WPA3_PSK");        break;
+      default:                       snprintf(e.encryption, sizeof(e.encryption), "UNKNOWN");         break;
+    }
+  }
 
   WiFi.scanDelete();
-  _scanInFlight = false;
-  _nextScanAt   = millis() + SCAN_CYCLE_GAP_MS;
 
   int na = Achievement.inc("wifi_analyzer_scan");
   if (na == 1) Achievement.unlock("wifi_analyzer_scan");
@@ -181,73 +207,7 @@ void WifiAnalyzerScreen::_pollLiveScan()
     if (n20 == 1) Achievement.unlock("wifi_analyzer_20aps");
   }
 
-  _rebuildScanItems();
-  setCount(_entryCount);
-  render();
-}
-
-void WifiAnalyzerScreen::_mergeScanResult(int idx)
-{
-  String bssid = WiFi.BSSIDstr(idx);
-
-  int slot = -1;
-  for (int i = 0; i < _entryCount; i++) {
-    if (bssid.equalsIgnoreCase(_entries[i].bssid)) { slot = i; break; }
-  }
-  if (slot < 0) {
-    if (_entryCount >= MAX_SCAN) return;  // list full — ignore new APs until one drops
-    slot = _entryCount++;
-  }
-
-  int32_t rssi = WiFi.RSSI(idx);
-  const char* strength;
-  if      (rssi >= -50) strength = "Very Good";
-  else if (rssi >= -60) strength = "Good";
-  else if (rssi >= -70) strength = "Better";
-  else if (rssi >= -80) strength = "Low";
-  else                  strength = "Very Low";
-
-  WifiEntry& e = _entries[slot];
-  snprintf(e.ssid,    sizeof(e.ssid),    "%s", WiFi.SSID(idx).c_str());
-  snprintf(e.bssid,   sizeof(e.bssid),   "%s", bssid.c_str());
-  snprintf(e.rssi,    sizeof(e.rssi),    "[%d] %s", (int)rssi, strength);
-  snprintf(e.channel, sizeof(e.channel), "%d", (int)WiFi.channel(idx));
-  e.rssiValue = (int)rssi;
-  e.lastSeen  = millis();
-
-  switch (WiFi.encryptionType(idx)) {
-    case WIFI_AUTH_OPEN:           snprintf(e.encryption, sizeof(e.encryption), "OPEN");            break;
-    case WIFI_AUTH_WEP:            snprintf(e.encryption, sizeof(e.encryption), "WEP");             break;
-    case WIFI_AUTH_WPA_PSK:        snprintf(e.encryption, sizeof(e.encryption), "WPA_PSK");         break;
-    case WIFI_AUTH_WPA2_PSK:       snprintf(e.encryption, sizeof(e.encryption), "WPA2_PSK");        break;
-    case WIFI_AUTH_WPA_WPA2_PSK:   snprintf(e.encryption, sizeof(e.encryption), "WPA_WPA2_PSK");    break;
-    case WIFI_AUTH_WPA2_ENTERPRISE:snprintf(e.encryption, sizeof(e.encryption), "WPA2_ENTERPRISE"); break;
-    case WIFI_AUTH_WPA3_PSK:       snprintf(e.encryption, sizeof(e.encryption), "WPA3_PSK");        break;
-    default:                       snprintf(e.encryption, sizeof(e.encryption), "UNKNOWN");         break;
-  }
-}
-
-void WifiAnalyzerScreen::_pruneStale()
-{
-  if (_state != STATE_SCAN || _entryCount == 0) return;
-
-  uint32_t now     = millis();
-  bool     changed = false;
-
-  for (int i = _entryCount - 1; i >= 0; i--) {
-    if (now - _entries[i].lastSeen <= STALE_TIMEOUT_MS) continue;
-
-    for (int j = i; j < _entryCount - 1; j++) _entries[j] = _entries[j + 1];
-    _entryCount--;
-    changed = true;
-
-    if (_selectedIndex > i) _selectedIndex--;
-  }
-
-  if (!changed) return;
-  _rebuildScanItems();
-  setCount(_entryCount);
-  render();
+  _showScan();
 }
 
 void WifiAnalyzerScreen::_rebuildScanItems()
@@ -266,18 +226,10 @@ void WifiAnalyzerScreen::_showScan()
 
   _rebuildScanItems();
   setItems(_scanItems, _entryCount);
-  _nextScanAt = millis();
 }
 
 void WifiAnalyzerScreen::_showClients(int index)
 {
-  // Hand the radio over to the client sniffer — abort any in-flight scan
-  // first so it doesn't collide with the promiscuous/channel-lock setup.
-  if (_scanInFlight) {
-    WiFi.scanDelete();
-    _scanInFlight = false;
-  }
-
   _selectedAp = index;
   _state      = STATE_CLIENTS;
 
@@ -289,8 +241,10 @@ void WifiAnalyzerScreen::_showClients(int index)
   for (int i = 0; i < 6; i++) _targetBssid[i] = (uint8_t)v[i];
   _cliCount = 0;
   portEXIT_CRITICAL(&_cliMux);
+  _apRssi = 0;
 
   _lastClientCount   = -1;
+  _lastRssiShown     = 1;
   _lastClientRefresh = millis();
   _scrollView.resetScroll();
 
@@ -324,13 +278,25 @@ void WifiAnalyzerScreen::_refreshClients(bool force)
   for (uint8_t i = 0; i < n; i++) memcpy(macs[i], _cliMacs[i], 6);
   portEXIT_CRITICAL(&_cliMux);
 
-  if (!force && (int)n == _lastClientCount) return;  // nothing new to show
+  const int rssi = _apRssi;
+
+  // Nothing new to show — skip the rebuild and the full-body redraw.
+  if (!force && (int)n == _lastClientCount && rssi == _lastRssiShown) return;
   _lastClientCount = n;
+  _lastRssiShown   = rssi;
+
+  // Live RSSI from the AP's own frames; falls back to the scan value until the
+  // first beacon lands on this channel.
+  if (rssi != 0) {
+    snprintf(_rssiRow, sizeof(_rssiRow), "[%d] %s", rssi, _strengthLabel(rssi));
+  } else {
+    snprintf(_rssiRow, sizeof(_rssiRow), "%s", _entries[_selectedAp].rssi);
+  }
 
   // Row 0..4: the AP details (kept visible regardless of client count).
   _rows[0] = {"SSID",       _entries[_selectedAp].ssid};
   _rows[1] = {"BSSID",      _entries[_selectedAp].bssid};
-  _rows[2] = {"RSSI",       _entries[_selectedAp].rssi};
+  _rows[2] = {"RSSI",       _rssiRow};
   _rows[3] = {"Channel",    _entries[_selectedAp].channel};
   _rows[4] = {"Encryption", _entries[_selectedAp].encryption};
 

--- a/firmware/src/screens/wifi/WifiAnalyzerScreen.h
+++ b/firmware/src/screens/wifi/WifiAnalyzerScreen.h
@@ -8,8 +8,8 @@ class WifiAnalyzerScreen : public ListScreen
 public:
   const char* title() override { return _title; }
 
-  // Keep WiFi awake while sniffing clients or mid-scan (promiscuous/scan use the radio).
-  bool inhibitPowerSave() override { return _state == STATE_CLIENTS || _scanInFlight; }
+  // Keep WiFi awake while sniffing a selected AP (promiscuous uses the radio).
+  bool inhibitPowerSave() override { return _state == STATE_CLIENTS; }
 
   void onInit() override;
   void onUpdate() override;
@@ -21,31 +21,26 @@ private:
   static constexpr int MAX_SCAN    = 20;
   static constexpr int MAX_CLIENTS = 32;  // keep in sync with kMaxClients in .cpp
 
-  // Live-scan tuning: how long to rest between completed async scans, and
-  // how long an AP can go unseen before it's dropped from the list.
-  static constexpr uint32_t SCAN_CYCLE_GAP_MS = 3000;
-  static constexpr uint32_t STALE_TIMEOUT_MS  = 15000;
+  // Per-channel dwell for the one-shot scan. 600 ms x up to 14 channels = 8.4 s,
+  // which stays under the framework's hard 10 s sync-scan timeout (see
+  // WifiEapolCaptureScreen::_selectWifi for the full rationale).
+  static constexpr int SCAN_DWELL_MS = 600;
 
   enum State { STATE_SCAN, STATE_CLIENTS };
   State _state = STATE_SCAN;
 
   struct WifiEntry {
-    char     ssid[33];
-    char     bssid[18];
-    char     rssi[20];
-    char     channel[4];
-    char     encryption[20];
-    int      rssiValue = 0;
-    uint32_t lastSeen  = 0;
+    char ssid[33];
+    char bssid[18];
+    char rssi[20];
+    char channel[4];
+    char encryption[20];
+    int  rssiValue = 0;
   };
 
-  char      _title[16]         = "WiFi Analyzer";
+  char      _title[16]   = "WiFi Analyzer";
   WifiEntry _entries[MAX_SCAN];
-  int       _entryCount        = 0;
-
-  bool      _scanInFlight      = false;
-  uint32_t  _nextScanAt        = 0;
-  uint32_t  _lastPruneAt       = 0;
+  int       _entryCount  = 0;
 
   ListItem       _scanItems[MAX_SCAN];
   ScrollListView _scrollView;
@@ -59,14 +54,15 @@ private:
   int                 _lastClientCount   = -1;
   uint32_t            _lastClientRefresh = 0;
 
+  // Live RSSI of the selected AP, sampled from its own transmissions by the
+  // promiscuous callback. Sentinel 1 dBm = "nothing rendered yet".
+  char _rssiRow[24]     = {};
+  int  _lastRssiShown   = 1;
+
+  void _doScan();
   void _showScan();
   void _showClients(int index);
   void _stopClients();
   void _refreshClients(bool force);
-
-  void _startLiveScan();
-  void _pollLiveScan();
-  void _mergeScanResult(int idx);
-  void _pruneStale();
   void _rebuildScanItems();
 };


### PR DESCRIPTION
## What

The Analyzers no longer refresh their lists on a timer. Both now take a **single
scan** and hold it, and real-time updates are limited to the **RSSI of whatever
you select**.

### WiFi Analyzer
- List comes from one blocking `WiFi.scanNetworks(false, false, false, 600, 0)`,
  the same pattern the other WiFi modules already use (Deauther, EAPOL Capture,
  Evil Twin). 600 ms/channel keeps a 14-channel sweep at 8.4 s, under the
  framework's hard 10 s sync-scan timeout.
- Removed: async poll/merge, staleness pruning, and the cursor bookkeeping they
  needed.
- Live RSSI for a selected AP is sampled by the promiscuous callback that was
  already sniffing that BSSID's clients — but only from frames the AP itself
  transmitted (`addr2 == BSSID`). A client's uplink frame reports the *client's*
  level, not the AP's, so filtering on the transmitter matters. Beacons alone
  give ~10 samples/s.

### BLE Analyzer
- The 3 s rolling cycle (`is_continue=true`) is replaced by one blocking 5 s
  scan, matching Whisper Pair and Chameleon Scan. The completion callback, its
  spinlock/flag and the pruning are gone.
- Live RSSI comes from an indefinite scan whose callback records only the
  selected address.

## Why

The lists moved constantly, which made them hard to read and to pick from. A
snapshot is what the rest of the firmware already does, so this also removes a
pattern that only these two screens used.

## Implementation note worth reviewing

`setMaxResults(0)` makes NimBLE drop each result right after the callback, so the
results vector cannot grow or reallocate underneath the main loop. The catch is
that it also invalidates the pointers `_scanResults` holds. The info view
therefore reads `_selDev`, a by-value snapshot taken *before* the watcher starts
— `NimBLEAdvertisedDevice` owns its payload in a `std::vector`, so the copy is
self-contained. Scan config is restored on teardown and before any storing scan.

## Refresh behaviour

Re-entering a list re-scans: on open, and on BACK out of a detail view. That is
the way to refresh, and it is deliberate — there is no timer anymore.

## Testing

- Built `m5_cardputer_adv` (ESP32-S3, keyboard) and flashed to hardware: list is
  static, RSSI of a selected AP/device tracks live, clients still enumerate.
- Both files also compile for `m5stickcplus_2` (ESP32, no keyboard), which
  exercises the `#ifndef DEVICE_HAS_KEYBOARD` branch in the WiFi detail view.
  Note that env's build fails later in `ArpSpoofer.cpp` on a pre-existing
  `ntohl` macro redefinition, unrelated to these files and present on `main`.

