### PR TITLE
Fix PN532 I2X not detected on T-Embed CC1101

### DIFF
--- a/firmware/boards/t_embed_cc1101/core/Device.cpp
+++ b/firmware/boards/t_embed_cc1101/core/Device.cpp
@@ -1,7 +1,6 @@
 //
 // LilyGO T-Embed CC1101 — Device factory
 //
-
 #include "core/Device.h"
 #include "Navigation.h"
 #include "Display.h"
@@ -33,6 +32,11 @@ Device* Device::createInstance() {
   pinMode(LCD_BL, OUTPUT);
   digitalWrite(LCD_BL, HIGH);
 
+  // PN532 reset/power-down pin — must be HIGH before I2C is begun,
+  // or the chip stays in power-down and never ACKs on the bus
+  pinMode(PN532_RESET_PIN, OUTPUT);
+  digitalWrite(PN532_RESET_PIN, HIGH);
+
   // Assert CS pins high before SPI init
   const uint8_t spi_cs_pins[] = { LCD_CS, SD_CS, CC1101_CS_PIN };
   for (auto pin : spi_cs_pins) {
@@ -42,8 +46,10 @@ Device* Device::createInstance() {
 
   Wire.begin(GROVE_SDA, GROVE_SCL);
   sharedSpi.begin(SPI_SCK_PIN, SPI_MISO_PIN, SPI_MOSI_PIN, -1);
-
   ledRing.begin();
 
-  return new Device(display, power, &navigation, nullptr, &sharedSpi, &speaker);
+  Device* dev = new Device(display, power, &navigation, nullptr, &sharedSpi, &speaker);
+  dev->InI2C = &Wire;   // Wire already begun above on GROVE_SDA/GROVE_SCL (GPIO 8/18) —
+                         // shared with PN532, BQ27220 fuel gauge, BQ25896 charger
+  return dev;
 }

--- a/firmware/boards/t_embed_cc1101/pins_arduino.h
+++ b/firmware/boards/t_embed_cc1101/pins_arduino.h
@@ -25,6 +25,9 @@ static const uint8_t SCK  = SPI_SCK_PIN;
 static const uint8_t SDA = GROVE_SDA;
 static const uint8_t SCL = GROVE_SCL;
 
+// ─── PN532 NFC ────────────────────────────────────────────
+#define PN532_RESET_PIN  45   // RSTPDN — must be driven HIGH to bring PN532 out of reset/power-down
+
 // ─── LCD ──────────────────────────────────────────────────
 #define LCD_CS  41
 #define LCD_DC  16

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -260,6 +260,12 @@ bool PN532I2cScreen::_initModule() {
 
   // Fall back to InI2C
   if (Uni.InI2C) {
+    Uni.InI2C->end();      // tear down first — Adafruit_I2CDevice::begin() below calls
+                          // _wire->begin() unconditionally; without end(), that's a
+                          // double-init on an already-running bus → crash on this ESP32-S3 core
+    Uni.InI2C->begin();    // no explicit pins needed — this board's pins_arduino.h aliases the
+                          // global SDA/SCL constants to GROVE_SDA/GROVE_SCL (8/18)
+
     _nfc = new Adafruit_PN532(255, 255, Uni.InI2C);
     _nfc->begin();
     ProgressView::progress("Probing InI2C...", 35);


### PR DESCRIPTION
## Fix: PN532 I2C not detected on LilyGO T-Embed CC1101

Closes #56 

### Root causes (three separate issues, all needed to be fixed)

1. **`Device::createInstance()` never assigned `InI2C`.**
   The internal I2C bus (`Wire`, GPIO 8/18 — shared with the PN532,
   BQ27220 fuel gauge, and BQ25896 charger) was begun correctly at boot,
   but `Uni.InI2C` was left `nullptr` on this board. `PN532I2cScreen`'s
   internal-bus fallback checks `if (Uni.InI2C)` before probing, so it
   always skipped straight to "not found."

2. **Assigning `InI2C = &Wire` alone caused a crash.**
   `Adafruit_I2CDevice::begin()` (in Adafruit_BusIO) calls `_wire->begin()`
   unconditionally with no guard. Since `Wire` was already running from
   boot, this re-initializes an already-installed I2C port — which
   panics/reboots on this ESP32-S3 Arduino core. Fixed by calling
   `Uni.InI2C->end()` immediately before `Uni.InI2C->begin()` in
   `PN532I2cScreen::_initModule()`'s internal-bus branch, so the
   library's internal re-init lands on a clean bus instead of a live one.

3. **PN532 reset/power-down pin (RSTPDN, GPIO 45) was never defined
   or driven.** Per LilyGO's own pin table this board wires PN532_RF_RES
   to GPIO 45, but it was absent from `pins_arduino.h` and never touched
   in `Device::createInstance()`. Without it being driven HIGH, the PN532
   stayed in its power-down state and never ACKed on the bus — even
   though the bus itself was healthy (fuel gauge/charger were reachable
   at `0x55`/`0x6B`, but PN532 at `0x24` was silent).

### Changes
- `firmware/boards/t_embed_cc1101/pins_arduino.h`
  Added `#define PN532_RESET_PIN 45`.
- `firmware/boards/t_embed_cc1101/Device.cpp`
  Drive `PN532_RESET_PIN` HIGH before `Wire.begin()`; assign
  `dev->InI2C = &Wire` on the returned `Device` instance.
- `<path-to-PN532I2cScreen.cpp>`
  Added `Uni.InI2C->end(); Uni.InI2C->begin();` before constructing the
  `Adafruit_PN532` driver on the internal-bus fallback path.