### PR TITLE
Add global sound toggle

### DIFF
--- a/firmware/src/core/ConfigManager.h
+++ b/firmware/src/core/ConfigManager.h
@@ -22,6 +22,8 @@
 #define APP_CONFIG_BRIGHTNESS_DEFAULT           "70"
 #define APP_CONFIG_VOLUME                       "volume"
 #define APP_CONFIG_VOLUME_DEFAULT               "75"
+#define APP_CONFIG_SOUND                        "sound"
+#define APP_CONFIG_SOUND_DEFAULT                "1"
 #define APP_CONFIG_NAV_SOUND                    "nav_sound"
 #define APP_CONFIG_NAV_SOUND_DEFAULT            "1"
 #define APP_CONFIG_PRIMARY_COLOR                "primary_color"

--- a/firmware/src/core/SpeakerI2S.h
+++ b/firmware/src/core/SpeakerI2S.h
@@ -45,6 +45,7 @@ public:
   }
 
   void tone(uint16_t freq, uint32_t durationMs) override {
+    if (!isSoundEnabled()) return;
     _stopTask();
     _freq     = freq;
     _duration = durationMs;
@@ -73,7 +74,12 @@ public:
 
   bool isPlaying() override { return _taskHandle != nullptr; }
 
+  bool isSoundEnabled() const {
+    return Config.get(APP_CONFIG_SOUND, APP_CONFIG_SOUND_DEFAULT).toInt();
+  }
+
   void beep() override {
+    if (!isSoundEnabled()) return;
     if (!Config.get(APP_CONFIG_NAV_SOUND, APP_CONFIG_NAV_SOUND_DEFAULT).toInt()) return;
     if (_taskHandle) return;  // already playing — skip rapid beeps to avoid DMA stall
     playRandomTone();
@@ -87,6 +93,7 @@ public:
   }
 
   void playWav(const uint8_t* data, size_t size) override {
+    if (!isSoundEnabled()) return;
     _stopTask();
     if (size < 44) return;
 
@@ -123,6 +130,7 @@ public:
   void playLose()         override { if (_taskHandle) return; playWav(LOSE_SOUND,         sizeof(LOSE_SOUND));         }
 
   void playCorrectAnswer() override {
+    if (!isSoundEnabled()) return;
     if (_taskHandle) return;
     _seq[0] = {523,  180, 100};
     _seq[1] = {784,  120, 0  };
@@ -131,6 +139,7 @@ public:
   }
 
   void playWrongAnswer() override {
+    if (!isSoundEnabled()) return;
     if (_taskHandle) return;
     _seq[0] = {1109, 150, 100};
     _seq[1] = {1109, 150, 0  };

--- a/firmware/src/screens/setting/SettingScreen.cpp
+++ b/firmware/src/screens/setting/SettingScreen.cpp
@@ -45,6 +45,7 @@ void SettingScreen::_refresh() {
   _volSub      = Config.get(APP_CONFIG_VOLUME,               APP_CONFIG_VOLUME_DEFAULT)                + "%";
 #endif
 #ifdef DEVICE_HAS_SOUND
+  _soundSub    = Config.get(APP_CONFIG_SOUND,                APP_CONFIG_SOUND_DEFAULT).toInt() ? "On" : "Off";
   _navSndSub   = Config.get(APP_CONFIG_NAV_SOUND,            APP_CONFIG_NAV_SOUND_DEFAULT).toInt() ? "On" : "Off";
 #endif
   _colorSub    = Config.get(APP_CONFIG_PRIMARY_COLOR,        APP_CONFIG_PRIMARY_COLOR_DEFAULT);
@@ -81,6 +82,7 @@ void SettingScreen::_refresh() {
   _items[SETT_VOLUME].sublabel    = _volSub.c_str();
 #endif
 #ifdef DEVICE_HAS_SOUND
+  _items[SETT_SOUND].sublabel     = _soundSub.c_str();
   _items[SETT_NAV_SOUND].sublabel = _navSndSub.c_str();
 #endif
   _items[SETT_COLOR].sublabel        = _colorSub.c_str();
@@ -187,6 +189,18 @@ void SettingScreen::onItemSelected(uint8_t index) {
 #endif
 
 #ifdef DEVICE_HAS_SOUND
+    case SETT_SOUND: {
+      bool cur = Config.get(APP_CONFIG_SOUND, APP_CONFIG_SOUND_DEFAULT).toInt();
+      Config.set(APP_CONFIG_SOUND, cur ? "0" : "1");
+      Config.save(Uni.Storage);
+
+      // If sound is disabled while audio is already playing, stop it now.
+      if (cur && Uni.Speaker) Uni.Speaker->noTone();
+
+      _refresh();
+      break;
+    }
+
     case SETT_NAV_SOUND: {
       bool cur = Config.get(APP_CONFIG_NAV_SOUND, APP_CONFIG_NAV_SOUND_DEFAULT).toInt();
       Config.set(APP_CONFIG_NAV_SOUND, cur ? "0" : "1");

--- a/firmware/src/screens/setting/SettingScreen.h
+++ b/firmware/src/screens/setting/SettingScreen.h
@@ -31,6 +31,7 @@ private:
     SETT_VOLUME,
 #endif
 #ifdef DEVICE_HAS_SOUND
+    SETT_SOUND,
     SETT_NAV_SOUND,
     SETT_SPEAKER_TEST,
 #endif
@@ -72,6 +73,7 @@ private:
   String _volSub;
 #endif
 #ifdef DEVICE_HAS_SOUND
+  String _soundSub;
   String _navSndSub;
 #endif
   String _colorSub;
@@ -103,6 +105,7 @@ private:
     {"Volume",           ""},
 #endif
 #ifdef DEVICE_HAS_SOUND
+    {"Sound",            ""},
     {"Navigation Sound", ""},
     {"Speaker Test"},
 #endif


### PR DESCRIPTION
Adds a global Sound setting to disable all device audio while preserving the existing Navigation Sound setting.

When Sound is disabled, speaker output is suppressed globally, including boot sounds, notifications, SubGHz feedback, and speaker tests. The setting takes effect immediately and persists across reboots.

Navigation Sound remains independently configurable.

Tested on LilyGO T-Embed CC1101 Plus.