### PR TITLE
Add power submenu with deep sleep and power off

### DIFF
--- a/firmware/boards/t_embed_cc1101/core/Device.cpp
+++ b/firmware/boards/t_embed_cc1101/core/Device.cpp
@@ -2,6 +2,7 @@
 // LilyGO T-Embed CC1101 — Device factory
 //
 #include "core/Device.h"
+#include "core/ConfigManager.h"
 #include "Navigation.h"
 #include "Display.h"
 #include "Power.h"
@@ -18,6 +19,32 @@ static SpeakerEmbedCC1101 speaker;
 
 void Device::boardHook() {
   ledRing.update();
+
+#ifdef DEVICE_HAS_LIGHT_SLEEP
+  // Global shortcut: hold the dedicated Back button for 3 seconds.
+  // Navigation already tracks the current direction and hold duration.
+  if (Nav &&
+      Nav->isPressed() &&
+      Nav->currentDirection() == INavigation::DIR_BACK &&
+      Nav->heldDuration() >= 2000) {
+
+    // Use the same display-safe sequence as Power -> Light Sleep:
+    // turn the PWM-controlled backlight off through IDisplay, enter real
+    // ESP32-S3 Light Sleep, then restore the configured brightness.
+    uint8_t brightness =
+      (uint8_t)Config.get(APP_CONFIG_BRIGHTNESS, APP_CONFIG_BRIGHTNESS_DEFAULT).toInt();
+
+    Lcd.setBrightness(0);
+    Power.lightSleep();
+    Lcd.setBrightness(brightness);
+
+    // lightSleep() waits for the physical Back button to be released, but the
+    // navigation state still represents the press from before sleep until the
+    // next Nav->update(). Suppress that release so it does not also execute a
+    // normal Back action on the current screen.
+    Nav->suppressCurrentPress();
+  }
+#endif
 }
 
 Device* Device::createInstance() {

--- a/firmware/boards/t_embed_cc1101/core/Device.cpp
+++ b/firmware/boards/t_embed_cc1101/core/Device.cpp
@@ -21,12 +21,12 @@ void Device::boardHook() {
   ledRing.update();
 
 #ifdef DEVICE_HAS_LIGHT_SLEEP
-  // Global shortcut: hold the dedicated Back button for 3 seconds.
+  // Global shortcut: hold the dedicated Back button for 1.3 seconds.
   // Navigation already tracks the current direction and hold duration.
   if (Nav &&
       Nav->isPressed() &&
       Nav->currentDirection() == INavigation::DIR_BACK &&
-      Nav->heldDuration() >= 2000) {
+      Nav->heldDuration() >= 1300) {
 
     // Use the same display-safe sequence as Power -> Light Sleep:
     // turn the PWM-controlled backlight off through IDisplay, enter real

--- a/firmware/boards/t_embed_cc1101/core/Power.h
+++ b/firmware/boards/t_embed_cc1101/core/Power.h
@@ -8,6 +8,7 @@
 #include "pins_arduino.h"
 #include <Wire.h>
 #include <esp_sleep.h>
+#include <driver/gpio.h>
 
 // ─── BQ27220 Fuel Gauge ───────────────────────────────────
 #define BQ27220_ADDR        0x55
@@ -51,18 +52,59 @@ public:
     return (chrg == 0x01 || chrg == 0x02);
   }
 
-  void powerOff() override
+  void lightSleep() override
   {
-    // Backlight off so the screen is dark whether we cut power or just sleep.
+    // Keep the board powered while the ESP32-S3 is in light sleep.
+    digitalWrite(PIN_POWER_ON, HIGH);
+
+    // Use the dedicated Back button (ENCODER_BK = GPIO6, active LOW)
+    // as the only Light Sleep wake source.
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
+    gpio_wakeup_enable((gpio_num_t)ENCODER_BK, GPIO_INTR_LOW_LEVEL);
+    esp_sleep_enable_gpio_wakeup();
+
+    // Execution resumes here as soon as Back is pressed.
+    esp_light_sleep_start();
+
+    // Do not return control to the UI until the wake button is released.
+    while (digitalRead(ENCODER_BK) == LOW) {
+      delay(10);
+    }
+    delay(50); // release debounce
+
+    // Remove the temporary GPIO wake configuration.
+    gpio_wakeup_disable((gpio_num_t)ENCODER_BK);
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_GPIO);
+  }
+
+  void deepSleep() override
+  {
+    // Keep the board powered while the ESP32-S3 is in deep sleep.
+    digitalWrite(PIN_POWER_ON, HIGH);
     digitalWrite(LCD_BL, LOW);
 
-    // Release the BQ25896 power latch. On battery this is a true power-off
-    // (the rail drops). On USB the BQ25896 keeps the rail alive, so we fall
-    // through into deep sleep as a low-power standby instead.
-    digitalWrite(PIN_POWER_ON, LOW);
-
     // Wake on the back button (ENCODER_BK = GPIO6, active LOW).
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
     esp_sleep_enable_ext0_wakeup((gpio_num_t)ENCODER_BK, 0);
+
+    // Deep-sleep wake restarts the ESP32-S3.
+    esp_deep_sleep_start();
+  }
+
+  void powerOff() override
+  {
+    // Turn off the backlight first.
+    digitalWrite(LCD_BL, LOW);
+
+    // Put the BQ25896 into BATFET-disable (shipping) mode.
+    // REG09 bit 5 = BATFET_DIS. This disconnects the battery from SYS.
+    uint8_t reg09 = _readReg8(BQ25896_ADDR, 0x09);
+    reg09 |= (1 << 5);
+    _writeReg(BQ25896_ADDR, 0x09, reg09);
+
+    // If USB power keeps the MCU alive, remain in deep sleep. Do not configure
+    // GPIO wake here: true power-off should require QON/physical power or USB.
+    esp_sleep_disable_wakeup_source(ESP_SLEEP_WAKEUP_ALL);
     esp_deep_sleep_start();
   }
 

--- a/firmware/boards/t_embed_cc1101/pins_arduino.h
+++ b/firmware/boards/t_embed_cc1101/pins_arduino.h
@@ -93,4 +93,7 @@ static const uint8_t SCL = GROVE_SCL;
 #define DEVICE_HAS_USB_HID        // ESP32-S3 native USB OTG
 #define DEVICE_HAS_WEBAUTHN       // FIDO2 / WebAuthn USB security key (CTAP2 + U2F)
 #define DEVICE_HAS_LED_RING       // WS2812B ring → LED Effect setting
+#define DEVICE_HAS_LIGHT_SLEEP    // Light sleep with wake via dedicated back button
+#define DEVICE_HAS_DEEP_SLEEP     // Deep sleep with wake via dedicated back button
+#define DEVICE_HAS_POWER_OFF      // BQ25896 can power off the device
 #define APP_MENU_POWER_OFF        // BQ25896 can power off the device

--- a/firmware/src/core/IPower.h
+++ b/firmware/src/core/IPower.h
@@ -11,6 +11,7 @@ public:
   virtual void    begin()                       = 0;
   virtual uint8_t getBatteryPercentage()        = 0;
   virtual bool    isCharging()                  = 0;
+  virtual void    lightSleep()                  {}
   virtual void    deepSleep()                   {}
   virtual void    powerOff()                    = 0;
   virtual void    setExtOutput(bool /*enable*/) {}  // Grove 5V: true=output, false=input

--- a/firmware/src/core/IPower.h
+++ b/firmware/src/core/IPower.h
@@ -11,6 +11,7 @@ public:
   virtual void    begin()                       = 0;
   virtual uint8_t getBatteryPercentage()        = 0;
   virtual bool    isCharging()                  = 0;
+  virtual void    deepSleep()                   {}
   virtual void    powerOff()                    = 0;
   virtual void    setExtOutput(bool /*enable*/) {}  // Grove 5V: true=output, false=input
 };

--- a/firmware/src/screens/MainMenuScreen.cpp
+++ b/firmware/src/screens/MainMenuScreen.cpp
@@ -13,6 +13,7 @@
 #include "screens/LuaScreen.h"
 #include "screens/setting/SettingScreen.h"
 #include "screens/CharacterScreen.h"
+#include "screens/PowerMenuScreen.h"
 #include "ui/components/Icon.h"
 
 
@@ -25,7 +26,14 @@ void MainMenuScreen::onInit() {
   _items[5] = {"LUA", Icons::drawLua};
   _items[6] = {"Games", Icons::drawGame};
   _items[7] = {"Settings", Icons::drawSetting};
-#ifdef APP_MENU_POWER_OFF
+#if defined(DEVICE_HAS_DEEP_SLEEP) || defined(DEVICE_HAS_POWER_OFF)
+# ifdef DEVICE_HAS_TOUCH_NAV
+  _items[8] = {"Home", Icons::drawHome};
+  _items[9] = {"Power", Icons::drawPower};
+# else
+  _items[8] = {"Power", Icons::drawPower};
+# endif
+#elif defined(APP_MENU_POWER_OFF)
 # ifdef DEVICE_HAS_TOUCH_NAV
   _items[8] = {"Home", Icons::drawHome};
   _items[9] = {"Power Off", Icons::drawPower};
@@ -296,7 +304,14 @@ void MainMenuScreen::onItemSelected(uint8_t index) {
   case 5: Screen.push(new LuaScreen());          break;
   case 6: Screen.push(new GameMenuScreen());     break;
   case 7: Screen.push(new SettingScreen());      break;
-#ifdef APP_MENU_POWER_OFF
+#if defined(DEVICE_HAS_DEEP_SLEEP) || defined(DEVICE_HAS_POWER_OFF)
+# ifdef DEVICE_HAS_TOUCH_NAV
+  case 8: onBack(); break;
+  case 9: Screen.push(new PowerMenuScreen()); break;
+# else
+  case 8: Screen.push(new PowerMenuScreen()); break;
+# endif
+#elif defined(APP_MENU_POWER_OFF)
 # ifdef DEVICE_HAS_TOUCH_NAV
   case 8: onBack(); break;
   case 9: Uni.Power.powerOff(); break;

--- a/firmware/src/screens/MainMenuScreen.cpp
+++ b/firmware/src/screens/MainMenuScreen.cpp
@@ -16,7 +16,6 @@
 #include "screens/PowerMenuScreen.h"
 #include "ui/components/Icon.h"
 
-
 void MainMenuScreen::onInit() {
   _items[0] = {"Wifi", Icons::drawWifi};
   _items[1] = {"Bluetooth", Icons::drawBluetooth};
@@ -26,7 +25,7 @@ void MainMenuScreen::onInit() {
   _items[5] = {"LUA", Icons::drawLua};
   _items[6] = {"Games", Icons::drawGame};
   _items[7] = {"Settings", Icons::drawSetting};
-#if defined(DEVICE_HAS_DEEP_SLEEP) || defined(DEVICE_HAS_POWER_OFF)
+#if defined(DEVICE_HAS_LIGHT_SLEEP) || defined(DEVICE_HAS_DEEP_SLEEP) || defined(DEVICE_HAS_POWER_OFF)
 # ifdef DEVICE_HAS_TOUCH_NAV
   _items[8] = {"Home", Icons::drawHome};
   _items[9] = {"Power", Icons::drawPower};
@@ -304,7 +303,7 @@ void MainMenuScreen::onItemSelected(uint8_t index) {
   case 5: Screen.push(new LuaScreen());          break;
   case 6: Screen.push(new GameMenuScreen());     break;
   case 7: Screen.push(new SettingScreen());      break;
-#if defined(DEVICE_HAS_DEEP_SLEEP) || defined(DEVICE_HAS_POWER_OFF)
+#if defined(DEVICE_HAS_LIGHT_SLEEP) || defined(DEVICE_HAS_DEEP_SLEEP) || defined(DEVICE_HAS_POWER_OFF)
 # ifdef DEVICE_HAS_TOUCH_NAV
   case 8: onBack(); break;
   case 9: Screen.push(new PowerMenuScreen()); break;

--- a/firmware/src/screens/MainMenuScreen.h
+++ b/firmware/src/screens/MainMenuScreen.h
@@ -28,9 +28,9 @@ private:
     DrawIconFunc drawIcon;
   };
 
-#if defined(APP_MENU_POWER_OFF) && defined(DEVICE_HAS_TOUCH_NAV)
+#if (defined(DEVICE_HAS_DEEP_SLEEP) || defined(DEVICE_HAS_POWER_OFF) || defined(APP_MENU_POWER_OFF)) && defined(DEVICE_HAS_TOUCH_NAV)
   static const uint8_t ITEM_COUNT = 10;
-#elif defined(APP_MENU_POWER_OFF) || defined(DEVICE_HAS_TOUCH_NAV)
+#elif defined(DEVICE_HAS_DEEP_SLEEP) || defined(DEVICE_HAS_POWER_OFF) || defined(APP_MENU_POWER_OFF) || defined(DEVICE_HAS_TOUCH_NAV)
   static const uint8_t ITEM_COUNT = 9;
 #else
   static const uint8_t ITEM_COUNT = 8;

--- a/firmware/src/screens/MainMenuScreen.h
+++ b/firmware/src/screens/MainMenuScreen.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "ui/templates/BaseScreen.h"
+#include "pins_arduino.h"
 
 class MainMenuScreen : public BaseScreen
 {
@@ -28,9 +29,9 @@ private:
     DrawIconFunc drawIcon;
   };
 
-#if (defined(DEVICE_HAS_DEEP_SLEEP) || defined(DEVICE_HAS_POWER_OFF) || defined(APP_MENU_POWER_OFF)) && defined(DEVICE_HAS_TOUCH_NAV)
+#if (defined(DEVICE_HAS_LIGHT_SLEEP) || defined(DEVICE_HAS_DEEP_SLEEP) || defined(DEVICE_HAS_POWER_OFF) || defined(APP_MENU_POWER_OFF)) && defined(DEVICE_HAS_TOUCH_NAV)
   static const uint8_t ITEM_COUNT = 10;
-#elif defined(DEVICE_HAS_DEEP_SLEEP) || defined(DEVICE_HAS_POWER_OFF) || defined(APP_MENU_POWER_OFF) || defined(DEVICE_HAS_TOUCH_NAV)
+#elif defined(DEVICE_HAS_LIGHT_SLEEP) || defined(DEVICE_HAS_DEEP_SLEEP) || defined(DEVICE_HAS_POWER_OFF) || defined(APP_MENU_POWER_OFF) || defined(DEVICE_HAS_TOUCH_NAV)
   static const uint8_t ITEM_COUNT = 9;
 #else
   static const uint8_t ITEM_COUNT = 8;

--- a/firmware/src/screens/PowerMenuScreen.cpp
+++ b/firmware/src/screens/PowerMenuScreen.cpp
@@ -1,9 +1,16 @@
 #include "PowerMenuScreen.h"
 #include "core/Device.h"
+#include "core/ConfigManager.h"
 
 void PowerMenuScreen::onInit()
 {
   _count = 0;
+
+#ifdef DEVICE_HAS_LIGHT_SLEEP
+  _items[_count]    = {"Light Sleep"};
+  _actions[_count]  = ACTION_LIGHT_SLEEP;
+  _count++;
+#endif
 
 #ifdef DEVICE_HAS_DEEP_SLEEP
   _items[_count]   = {"Deep Sleep"};
@@ -26,6 +33,18 @@ void PowerMenuScreen::onItemSelected(uint8_t index)
 
   switch (_actions[index])
   {
+    case ACTION_LIGHT_SLEEP: {
+      // Preserve configured brightness and use the display abstraction
+      // rather than manipulating the PWM-controlled backlight pin directly.
+      uint8_t brightness =
+        (uint8_t)Config.get(APP_CONFIG_BRIGHTNESS, APP_CONFIG_BRIGHTNESS_DEFAULT).toInt();
+
+      Uni.Lcd.setBrightness(0);
+      Uni.Power.lightSleep();
+      Uni.Lcd.setBrightness(brightness);
+      break;
+    }
+
     case ACTION_DEEP_SLEEP:
       Uni.Power.deepSleep();
       break;

--- a/firmware/src/screens/PowerMenuScreen.cpp
+++ b/firmware/src/screens/PowerMenuScreen.cpp
@@ -1,0 +1,37 @@
+#include "PowerMenuScreen.h"
+#include "core/Device.h"
+
+void PowerMenuScreen::onInit()
+{
+  _count = 0;
+
+#ifdef DEVICE_HAS_DEEP_SLEEP
+  _items[_count]   = {"Deep Sleep"};
+  _actions[_count] = ACTION_DEEP_SLEEP;
+  _count++;
+#endif
+
+#ifdef DEVICE_HAS_POWER_OFF
+  _items[_count]   = {"Power Off"};
+  _actions[_count] = ACTION_POWER_OFF;
+  _count++;
+#endif
+
+  setItems(_items, _count);
+}
+
+void PowerMenuScreen::onItemSelected(uint8_t index)
+{
+  if (index >= _count) return;
+
+  switch (_actions[index])
+  {
+    case ACTION_DEEP_SLEEP:
+      Uni.Power.deepSleep();
+      break;
+
+    case ACTION_POWER_OFF:
+      Uni.Power.powerOff();
+      break;
+  }
+}

--- a/firmware/src/screens/PowerMenuScreen.h
+++ b/firmware/src/screens/PowerMenuScreen.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "ui/templates/ListScreen.h"
+#include "pins_arduino.h"
 
 class PowerMenuScreen : public ListScreen
 {
@@ -12,11 +13,12 @@ public:
 
 private:
   enum Action : uint8_t {
+    ACTION_LIGHT_SLEEP,
     ACTION_DEEP_SLEEP,
     ACTION_POWER_OFF,
   };
 
-  ListItem _items[2];
-  Action   _actions[2];
+  ListItem _items[3];
+  Action   _actions[3];
   uint8_t  _count = 0;
 };

--- a/firmware/src/screens/PowerMenuScreen.h
+++ b/firmware/src/screens/PowerMenuScreen.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+
+class PowerMenuScreen : public ListScreen
+{
+public:
+  const char* title() override { return "Power"; }
+
+  void onInit() override;
+  void onItemSelected(uint8_t index) override;
+
+private:
+  enum Action : uint8_t {
+    ACTION_DEEP_SLEEP,
+    ACTION_POWER_OFF,
+  };
+
+  ListItem _items[2];
+  Action   _actions[2];
+  uint8_t  _count = 0;
+};


### PR DESCRIPTION
## Summary

This PR adds a dedicated Power submenu to the main menu.

## Changes

- Adds a Power entry to the main menu.
- Introduces a dedicated Power submenu.
- Adds Deep Sleep functionality.
- Adds Power Off functionality.
- Extends the power interface with deep sleep support.

## Motivation

Power-related actions are currently not easily accessible from the main interface.

A dedicated submenu provides a simple and consistent place for device power management and makes deep sleep and shutdown directly accessible from the UI.