### PR TITLE
Add NDEF read and write support to PN532-I2C

### DIFF
--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -931,6 +931,7 @@ void PN532I2cScreen::_doReadNdef() {
   _ndefTarget = NDEF_TARGET_ULTRALIGHT;
   _hasNdef = false;
   _ndefLen = 0;
+  _ndefCapacity = 0;
   ShowStatusAction::show("Place UL/NTAG on reader...", 0);
 
   uint8_t uid[7];
@@ -1045,6 +1046,16 @@ void PN532I2cScreen::_showNdefResult(const uint8_t* uid, uint8_t uidLen,
   char lenBuf[24];
   snprintf(lenBuf, sizeof(lenBuf), "%u bytes", (unsigned)ndefLen);
   _pushRow("NDEF Size", lenBuf);
+
+  if (_ndefCapacity > 0) {
+    char capBuf[24];
+    char freeBuf[24];
+    snprintf(capBuf, sizeof(capBuf), "%u bytes", (unsigned)_ndefCapacity);
+    size_t freeBytes = (_ndefCapacity > ndefLen) ? (_ndefCapacity - ndefLen) : 0;
+    snprintf(freeBuf, sizeof(freeBuf), "%u bytes", (unsigned)freeBytes);
+    _pushRow("Capacity", capBuf);
+    _pushRow("Free", freeBuf);
+  }
 
   if (ndefLen == 0) {
     _pushRow("NDEF", "Empty");
@@ -1343,6 +1354,7 @@ void PN532I2cScreen::_doReadClassicNdef() {
   _ndefTarget = NDEF_TARGET_MIFARE_CLASSIC;
   _hasNdef = false;
   _ndefLen = 0;
+  _ndefCapacity = 0;
 
   if (!_scanCardOrShow(5000)) {
     _goMifare();
@@ -1362,6 +1374,11 @@ void PN532I2cScreen::_doReadClassicNdef() {
     ShowStatusAction::show("No NDEF sectors in MAD");
     _goMifare();
     return;
+  }
+
+  _ndefCapacity = 0;
+  for (size_t i = 0; i < sectorCount; i++) {
+    _ndefCapacity += (sectors[i] < 32) ? 48 : 240;
   }
 
   uint8_t* area = nullptr;
@@ -1845,12 +1862,16 @@ void PN532I2cScreen::_doSaveNdef() {
   uid.replace(":", "");
   if (uid.length() == 0) uid = "unknown";
 
-  // Follow the project's duplicate-name convention:
-  // <UID>.ndef, <UID>_(2).ndef, <UID>_(3).ndef, ...
-  String path = String(_dumpPath) + "/" + uid + ".ndef";
+  const char* tagSuffix =
+      (_ndefTarget == NDEF_TARGET_MIFARE_CLASSIC) ? "_mifare" : "_ntag";
+  String baseName = uid + tagSuffix;
+
+  // <UID>_<type>.ndef, <UID>_<type>_(2).ndef, ...
+  String path = String(_dumpPath) + "/" + baseName + ".ndef";
   if (Uni.Storage->exists(path.c_str())) {
     for (int n = 2; n < 1000; n++) {
-      String candidate = String(_dumpPath) + "/" + uid + "_(" + n + ").ndef";
+      String candidate =
+          String(_dumpPath) + "/" + baseName + "_(" + n + ").ndef";
       if (!Uni.Storage->exists(candidate.c_str())) {
         path = candidate;
         break;
@@ -1989,6 +2010,8 @@ void PN532I2cScreen::_doEraseNdef() {
     _goUltralight();
     return;
   }
+
+  _ndefCapacity = (size_t)cc[2] * 8;
 
   // Logical NDEF erase:
   // 03 = NDEF Message TLV

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -1907,7 +1907,7 @@ void PN532I2cScreen::_doWriteNdefEmail() {
 }
 
 void PN532I2cScreen::_doWriteNdefPhone() {
-  String phone = InputTextAction::popup("Enter phone", "");
+  String phone = InputTextAction::popup("Enter phone", "", InputTextAction::INPUT_PHONE);
   if (InputTextAction::wasCancelled() || phone.length() == 0) {
     _goNdefWrite();
     return;

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -134,9 +134,25 @@ void PN532I2cScreen::onUpdate() {
     if (Uni.Nav->wasPressed()) {
       auto dir = Uni.Nav->readDirection();
       if (dir == INavigation::DIR_BACK) {
-        _goNdefParent();
+        if (_ndefFilePreview) {
+          _ndefFilePreview = false;
+          _doWriteNdefFromFile();
+        } else {
+          _goNdefParent();
+        }
       } else if (dir == INavigation::DIR_PRESS && _hasNdef) {
-        _showNdefActions();
+        if (_ndefFilePreview) {
+          bool ok = _writeNdefRecord(_ndefBuf, _ndefLen);
+          if (ok) {
+            _ndefFilePreview = false;
+            _ndefPickDir = "";
+            _goNdefParent();
+          } else {
+            render();
+          }
+        } else {
+          _showNdefActions();
+        }
       } else {
         _scrollView.onNav(dir);
       }
@@ -287,7 +303,12 @@ void PN532I2cScreen::onBack() {
       _goMain();
       break;
     case STATE_NDEF_RESULT:
-      _goNdefParent();
+      if (_ndefFilePreview) {
+        _ndefFilePreview = false;
+        _doWriteNdefFromFile();
+      } else {
+        _goNdefParent();
+      }
       break;
     case STATE_NDEF_FILE_SELECT:
       if (_ndefPickDir == _nfcPath || _ndefPickDir.length() == 0) {
@@ -407,6 +428,7 @@ void PN532I2cScreen::_goUltralight() {
 }
 
 void PN532I2cScreen::_goNdefWrite() {
+  _ndefFilePreview = false;
   _state = STATE_NDEF_WRITE_MENU;
   setItems(_ndefWriteItems, 6);
   render();
@@ -1118,12 +1140,16 @@ void PN532I2cScreen::_showNdefResult(const uint8_t* uid, uint8_t uidLen,
   _state = STATE_NDEF_RESULT;
   _resetRows();
 
-  memcpy(_uid, uid, uidLen);
-  _uidLen = uidLen;
+  if (!_ndefFilePreview && uid && uidLen > 0) {
+    memcpy(_uid, uid, uidLen);
+    _uidLen = uidLen;
+  }
   _hasNdef = false;
   _ndefLen = 0;
 
-  _pushRow("UID", _hexUid(uid, uidLen));
+  if (uid && uidLen > 0) {
+    _pushRow("UID", _hexUid(uid, uidLen));
+  }
 
   if (!ndef) {
     _pushRow("NDEF", "Not found");
@@ -1372,7 +1398,9 @@ void PN532I2cScreen::_showNdefResult(const uint8_t* uid, uint8_t uidLen,
     _pushRow("Payload", _hexBlock(payload, rawLen));
   }
 
-  if (_hasNdef) _pushRow("[Press]", "Actions");
+  if (_hasNdef) {
+    _pushRow("[Press]", _ndefFilePreview ? "Write to Tag" : "Actions");
+  }
 
   _scrollView.setRows(_rows, _rowCount);
   render();
@@ -2587,11 +2615,12 @@ void PN532I2cScreen::_doWriteNdefFileSelected(uint8_t fileIndex) {
     return;
   }
 
-  bool ok = _writeNdefRecord(buf, len);
-  _ndefPickDir = "";
-
-  if (ok) _goNdefParent();
-  else _goNdefWrite();
+  // Preview the selected NDEF using the exact same parser/layout as Read NDEF.
+  // _ndefTarget remains unchanged, so confirmation writes to the correct
+  // destination: MIFARE Classic or Ultralight / NTAG.
+  _ndefFilePreview = true;
+  _ndefCapacity = 0;
+  _showNdefResult(nullptr, 0, buf, len);
 }
 
 void PN532I2cScreen::_doEraseNdef() {

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -90,6 +90,7 @@ const char* PN532I2cScreen::title() {
     case STATE_NDEF_WRITE_MENU: return "Write NDEF";
     case STATE_NDEF_RESULT:     return "NDEF Result";
     case STATE_NDEF_FILE_SELECT:return "NDEF Files";
+    case STATE_NDEF_GENERATE_MENU:return "Generate NDEF Record";
   }
   return "PN532 I2C";
 }
@@ -178,6 +179,7 @@ void PN532I2cScreen::onItemSelected(uint8_t index) {
         case 2: _goUltralight();      break;
         case 3: _goMagic();           break;
         case 4: _showFirmwareInfo();  break;
+        case 5: _goNdefGenerate();    break;
       }
       break;
     case STATE_MIFARE_MENU:
@@ -224,6 +226,13 @@ void PN532I2cScreen::onItemSelected(uint8_t index) {
       else if (index == 2) _doWriteNdefEmail();
       else if (index == 3) _doWriteNdefPhone();
       else if (index == 4) _doWriteNdefFromFile();
+      break;
+    case STATE_NDEF_GENERATE_MENU:
+      if (index == 0) _doGenerateNdefText();
+      else if (index == 1) _doGenerateNdefUrl();
+      else if (index == 2) _doGenerateNdefVcard();
+      else if (index == 3) _doGenerateNdefPhone();
+      else if (index == 4) _doGenerateNdefEmail();
       break;
     case STATE_NDEF_FILE_SELECT:
       _doWriteNdefFileSelected(index);
@@ -272,6 +281,9 @@ void PN532I2cScreen::onBack() {
       break;
     case STATE_NDEF_WRITE_MENU:
       _goNdefParent();
+      break;
+    case STATE_NDEF_GENERATE_MENU:
+      _goMain();
       break;
     case STATE_NDEF_RESULT:
       _goNdefParent();
@@ -375,7 +387,7 @@ void PN532I2cScreen::_cleanup() {
 
 void PN532I2cScreen::_goMain() {
   _state = STATE_MAIN_MENU;
-  setItems(_mainItems, 5);
+  setItems(_mainItems, 6);
   render();
 }
 
@@ -394,6 +406,12 @@ void PN532I2cScreen::_goUltralight() {
 void PN532I2cScreen::_goNdefWrite() {
   _state = STATE_NDEF_WRITE_MENU;
   setItems(_ndefWriteItems, 5);
+  render();
+}
+
+void PN532I2cScreen::_goNdefGenerate() {
+  _state = STATE_NDEF_GENERATE_MENU;
+  setItems(_ndefGenerateItems, 5);
   render();
 }
 
@@ -1251,8 +1269,99 @@ void PN532I2cScreen::_showNdefResult(const uint8_t* uid, uint8_t uidLen,
     String uri = _ndefUriPrefix(payload[0]);
     for (size_t i = 1; i < payloadLen; i++) uri += (char)payload[i];
 
-    _pushRow("Record", "URI");
-    _pushWrappedRow("URI", uri);
+    if (uri.startsWith("mailto:")) {
+      _pushRow("Record", "Email");
+      _pushWrappedRow("Mail", uri.substring(7));
+    }
+    else if (uri.startsWith("tel:")) {
+      _pushRow("Record", "Phone");
+      _pushWrappedRow("Phone", uri.substring(4));
+    }
+    else {
+      _pushRow("Record", "URI");
+      _pushWrappedRow("URI", uri);
+    }
+  }
+  // MIME vCard record. Common NFC writers use either text/vcard or
+  // text/x-vcard. Keep this read-only for now: parse useful contact fields
+  // from the payload and display them using the existing wrapped-row UI.
+  else if (tnf == 0x02 &&
+           (typeStr.equalsIgnoreCase("text/vcard") ||
+            typeStr.equalsIgnoreCase("text/x-vcard"))) {
+    String vcard;
+    vcard.reserve(payloadLen);
+    for (size_t i = 0; i < payloadLen; i++) vcard += (char)payload[i];
+    vcard.replace("\r\n", "\n");
+    vcard.replace("\r", "\n");
+
+    _pushRow("Record", "vCard");
+
+    auto vcardValue = [&](const char* key) -> String {
+      const String prefix = String(key) + ":";
+      int start = 0;
+      while (start < (int)vcard.length()) {
+        int end = vcard.indexOf('\n', start);
+        if (end < 0) end = vcard.length();
+
+        String line = vcard.substring(start, end);
+        line.trim();
+
+        // Accept parameters such as TEL;TYPE=CELL:... and
+        // EMAIL;TYPE=INTERNET:...
+        int colon = line.indexOf(':');
+        if (colon > 0) {
+          String lhs = line.substring(0, colon);
+          int semi = lhs.indexOf(';');
+          if (semi >= 0) lhs = lhs.substring(0, semi);
+
+          if (lhs.equalsIgnoreCase(key)) {
+            String value = line.substring(colon + 1);
+            value.replace("\\n", "\n");
+            value.replace("\\,", ",");
+            value.replace("\\;", ";");
+            value.replace("\\\\", "\\");
+            value.trim();
+            return value;
+          }
+        }
+        start = end + 1;
+      }
+      return "";
+    };
+
+    String name = vcardValue("FN");
+    if (name.length() == 0) name = vcardValue("N");
+    String company = vcardValue("ORG");
+    String address = vcardValue("ADR");
+    String phone = vcardValue("TEL");
+    String mail = vcardValue("EMAIL");
+    String website = vcardValue("URL");
+
+    // vCard structured fields use semicolons. For display, collapse empty
+    // components and show them as a readable comma-separated value.
+    auto cleanStructured = [](String value) -> String {
+      while (value.indexOf(";;") >= 0) value.replace(";;", ";");
+      while (value.startsWith(";")) value.remove(0, 1);
+      while (value.endsWith(";")) value.remove(value.length() - 1);
+      value.replace(";", ", ");
+      return value;
+    };
+
+    name = cleanStructured(name);
+    company = cleanStructured(company);
+    address = cleanStructured(address);
+
+    if (name.length())    _pushWrappedRow("Contact name", name);
+    if (company.length()) _pushWrappedRow("Company", company);
+    if (address.length()) _pushWrappedRow("Address", address);
+    if (phone.length())   _pushWrappedRow("Phone", phone);
+    if (mail.length())    _pushWrappedRow("Mail", mail);
+    if (website.length()) _pushWrappedRow("Website", website);
+
+    if (!name.length() && !company.length() && !address.length() &&
+        !phone.length() && !mail.length() && !website.length()) {
+      _pushWrappedRow("vCard", vcard);
+    }
   }
   else {
     _pushRow("Record", "Unsupported");
@@ -1781,6 +1890,298 @@ bool PN532I2cScreen::_writeUltralightNdefRecord(const uint8_t* ndef, size_t ndef
 
   ShowStatusAction::show(success ? "NDEF write OK" : "NDEF write failed");
   return success;
+}
+
+
+static String _sanitizeGeneratedNdefName(String name) {
+  name.trim();
+  if (name.length() == 0) name = "record";
+
+  for (int i = 0; i < (int)name.length(); i++) {
+    const char c = name[i];
+    const bool ok =
+        (c >= 'a' && c <= 'z') ||
+        (c >= 'A' && c <= 'Z') ||
+        (c >= '0' && c <= '9') ||
+        c == '-' || c == '_';
+    if (!ok) name.setCharAt(i, '_');
+  }
+
+  while (name.indexOf("__") >= 0) name.replace("__", "_");
+  while (name.startsWith("_")) name.remove(0, 1);
+  while (name.endsWith("_")) name.remove(name.length() - 1);
+  if (name.length() == 0) name = "record";
+  return name;
+}
+
+bool PN532I2cScreen::_saveGeneratedNdef(const uint8_t* ndef, size_t ndefLen,
+                                        const String& suggestedName) {
+  if (!ndef || ndefLen == 0 || ndefLen > MAX_NDEF_BYTES) {
+    ShowStatusAction::show("Invalid NDEF record");
+    return false;
+  }
+
+  if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+    ShowStatusAction::show("Storage unavailable");
+    return false;
+  }
+
+  static constexpr const char* NDEF_DIR = "/unigeek/nfc/ndefs";
+  Uni.Storage->makeDir("/unigeek/nfc");
+  Uni.Storage->makeDir(NDEF_DIR);
+
+  const String base = _sanitizeGeneratedNdefName(suggestedName);
+  String path = String(NDEF_DIR) + "/" + base + ".ndef";
+
+  if (Uni.Storage->exists(path.c_str())) {
+    for (int n = 2; n < 1000; n++) {
+      String candidate =
+          String(NDEF_DIR) + "/" + base + "_(" + n + ").ndef";
+      if (!Uni.Storage->exists(candidate.c_str())) {
+        path = candidate;
+        break;
+      }
+    }
+  }
+
+  fs::File f = Uni.Storage->open(path.c_str(), "w");
+  if (!f) {
+    ShowStatusAction::show("Save failed");
+    return false;
+  }
+
+  const size_t written = f.write(ndef, ndefLen);
+  f.close();
+
+  if (written != ndefLen) {
+    ShowStatusAction::show("Save failed");
+    return false;
+  }
+
+  const int slash = path.lastIndexOf('/');
+  const String name = (slash >= 0) ? path.substring(slash + 1) : path;
+  ShowStatusAction::show(("Saved: " + name).c_str(), 1500);
+  return true;
+}
+
+static bool _buildGeneratedUriNdef(const String& input, uint8_t prefix,
+                                   const char* stripPrefix,
+                                   uint8_t* out, size_t& outLen,
+                                   size_t maxNdefBytes) {
+  String body = input;
+  if (stripPrefix && body.startsWith(stripPrefix)) {
+    body = body.substring(strlen(stripPrefix));
+  }
+
+  const size_t payloadLen = 1 + body.length();
+  const size_t ndefLen = 4 + payloadLen;
+  if (ndefLen > maxNdefBytes || payloadLen > 255) return false;
+
+  out[0] = 0xD1;
+  out[1] = 0x01;
+  out[2] = (uint8_t)payloadLen;
+  out[3] = 'U';
+  out[4] = prefix;
+  memcpy(&out[5], body.c_str(), body.length());
+  outLen = ndefLen;
+  return true;
+}
+
+void PN532I2cScreen::_doGenerateNdefText() {
+  String value = InputTextAction::popup("Text", "");
+  if (InputTextAction::wasCancelled() || value.length() == 0) {
+    _goNdefGenerate();
+    return;
+  }
+
+  const size_t payloadLen = 3 + value.length();
+  const size_t ndefLen = 4 + payloadLen;
+  if (ndefLen > MAX_NDEF_BYTES || payloadLen > 255) {
+    ShowStatusAction::show("Text too long");
+    _goNdefGenerate();
+    return;
+  }
+
+  uint8_t* ndef = new uint8_t[ndefLen]();
+  if (!ndef) {
+    ShowStatusAction::show("Out of memory");
+    _goNdefGenerate();
+    return;
+  }
+
+  ndef[0] = 0xD1;
+  ndef[1] = 0x01;
+  ndef[2] = (uint8_t)payloadLen;
+  ndef[3] = 'T';
+  ndef[4] = 0x02;
+  ndef[5] = 'e';
+  ndef[6] = 'n';
+  memcpy(&ndef[7], value.c_str(), value.length());
+
+  String name = InputTextAction::popup("File name", "text");
+  if (!InputTextAction::wasCancelled()) _saveGeneratedNdef(ndef, ndefLen, name);
+  delete[] ndef;
+  _goNdefGenerate();
+}
+
+void PN532I2cScreen::_doGenerateNdefUrl() {
+  String url = InputTextAction::popup("URL", "https://");
+  if (InputTextAction::wasCancelled() || url.length() == 0) {
+    _goNdefGenerate();
+    return;
+  }
+
+  uint8_t prefix = 0x00;
+  const char* strip = nullptr;
+  if      (url.startsWith("https://www.")) { prefix = 0x02; strip = "https://www."; }
+  else if (url.startsWith("http://www."))  { prefix = 0x01; strip = "http://www."; }
+  else if (url.startsWith("https://"))      { prefix = 0x04; strip = "https://"; }
+  else if (url.startsWith("http://"))       { prefix = 0x03; strip = "http://"; }
+
+  uint8_t* ndef = new uint8_t[MAX_NDEF_BYTES]();
+  if (!ndef) {
+    ShowStatusAction::show("Out of memory");
+    _goNdefGenerate();
+    return;
+  }
+  size_t ndefLen = 0;
+  if (!_buildGeneratedUriNdef(url, prefix, strip, ndef, ndefLen, MAX_NDEF_BYTES)) {
+    delete[] ndef;
+    ShowStatusAction::show("URL too long");
+    _goNdefGenerate();
+    return;
+  }
+
+  String name = InputTextAction::popup("File name", "url");
+  if (!InputTextAction::wasCancelled()) _saveGeneratedNdef(ndef, ndefLen, name);
+  delete[] ndef;
+  _goNdefGenerate();
+}
+
+void PN532I2cScreen::_doGenerateNdefPhone() {
+  String phone = InputTextAction::popup("Phone", "", InputTextAction::INPUT_PHONE);
+  if (InputTextAction::wasCancelled() || phone.length() == 0) {
+    _goNdefGenerate();
+    return;
+  }
+
+  uint8_t* ndef = new uint8_t[MAX_NDEF_BYTES]();
+  if (!ndef) {
+    ShowStatusAction::show("Out of memory");
+    _goNdefGenerate();
+    return;
+  }
+  size_t ndefLen = 0;
+  if (!_buildGeneratedUriNdef(phone, 0x05, "tel:", ndef, ndefLen, MAX_NDEF_BYTES)) {
+    delete[] ndef;
+    ShowStatusAction::show("Phone too long");
+    _goNdefGenerate();
+    return;
+  }
+
+  String name = InputTextAction::popup("File name", "phone");
+  if (!InputTextAction::wasCancelled()) _saveGeneratedNdef(ndef, ndefLen, name);
+  delete[] ndef;
+  _goNdefGenerate();
+}
+
+void PN532I2cScreen::_doGenerateNdefEmail() {
+  String email = InputTextAction::popup("Email", "");
+  if (InputTextAction::wasCancelled() || email.length() == 0) {
+    _goNdefGenerate();
+    return;
+  }
+
+  uint8_t* ndef = new uint8_t[MAX_NDEF_BYTES]();
+  if (!ndef) {
+    ShowStatusAction::show("Out of memory");
+    _goNdefGenerate();
+    return;
+  }
+  size_t ndefLen = 0;
+  if (!_buildGeneratedUriNdef(email, 0x06, "mailto:", ndef, ndefLen, MAX_NDEF_BYTES)) {
+    delete[] ndef;
+    ShowStatusAction::show("Email too long");
+    _goNdefGenerate();
+    return;
+  }
+
+  String name = InputTextAction::popup("File name", "email");
+  if (!InputTextAction::wasCancelled()) _saveGeneratedNdef(ndef, ndefLen, name);
+  delete[] ndef;
+  _goNdefGenerate();
+}
+
+void PN532I2cScreen::_doGenerateNdefVcard() {
+  String contact = InputTextAction::popup("Contact name", "");
+  if (InputTextAction::wasCancelled() || contact.length() == 0) {
+    _goNdefGenerate();
+    return;
+  }
+
+  String company = InputTextAction::popup("Company", "");
+  if (InputTextAction::wasCancelled()) { _goNdefGenerate(); return; }
+
+  String address = InputTextAction::popup("Address", "");
+  if (InputTextAction::wasCancelled()) { _goNdefGenerate(); return; }
+
+  String phone = InputTextAction::popup("Phone", "", InputTextAction::INPUT_PHONE);
+  if (InputTextAction::wasCancelled()) { _goNdefGenerate(); return; }
+
+  String mail = InputTextAction::popup("Mail", "");
+  if (InputTextAction::wasCancelled()) { _goNdefGenerate(); return; }
+
+  String website = InputTextAction::popup("Website", "https://");
+  if (InputTextAction::wasCancelled()) { _goNdefGenerate(); return; }
+
+  auto escapeVcard = [](String s) -> String {
+    s.replace("\\", "\\\\");
+    s.replace("\r", "");
+    s.replace("\n", "\\n");
+    s.replace(";", "\\;");
+    s.replace(",", "\\,");
+    return s;
+  };
+
+  String card = "BEGIN:VCARD\r\nVERSION:3.0\r\n";
+  card += "FN:" + escapeVcard(contact) + "\r\n";
+  if (company.length()) card += "ORG:" + escapeVcard(company) + "\r\n";
+  if (address.length()) card += "ADR:;;" + escapeVcard(address) + ";;;;\r\n";
+  if (phone.length()) card += "TEL:" + escapeVcard(phone) + "\r\n";
+  if (mail.length()) card += "EMAIL:" + escapeVcard(mail) + "\r\n";
+  if (website.length() && website != "https://") {
+    card += "URL:" + escapeVcard(website) + "\r\n";
+  }
+  card += "END:VCARD\r\n";
+
+  const char* mime = "text/vcard";
+  const size_t typeLen = strlen(mime);
+  const size_t payloadLen = card.length();
+  const size_t ndefLen = 3 + typeLen + payloadLen;
+
+  if (payloadLen > 255 || ndefLen > MAX_NDEF_BYTES) {
+    ShowStatusAction::show("vCard too large");
+    _goNdefGenerate();
+    return;
+  }
+
+  uint8_t* ndef = new uint8_t[ndefLen]();
+  if (!ndef) {
+    ShowStatusAction::show("Out of memory");
+    _goNdefGenerate();
+    return;
+  }
+
+  ndef[0] = 0xD2; // MB | ME | SR | TNF=MIME Media
+  ndef[1] = (uint8_t)typeLen;
+  ndef[2] = (uint8_t)payloadLen;
+  memcpy(&ndef[3], mime, typeLen);
+  memcpy(&ndef[3 + typeLen], card.c_str(), payloadLen);
+
+  String name = InputTextAction::popup("File name", "contact");
+  if (!InputTextAction::wasCancelled()) _saveGeneratedNdef(ndef, ndefLen, name);
+  delete[] ndef;
+  _goNdefGenerate();
 }
 
 void PN532I2cScreen::_doWriteNdefText() {

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -133,7 +133,7 @@ void PN532I2cScreen::onUpdate() {
     if (Uni.Nav->wasPressed()) {
       auto dir = Uni.Nav->readDirection();
       if (dir == INavigation::DIR_BACK) {
-        _goUltralight();
+        _goNdefParent();
       } else if (dir == INavigation::DIR_PRESS && _hasNdef) {
         _showNdefActions();
       } else {
@@ -182,17 +182,38 @@ void PN532I2cScreen::onItemSelected(uint8_t index) {
       break;
     case STATE_MIFARE_MENU:
       switch (index) {
-        case 0: _doAuthenticate();     break;
-        case 1: _doDumpMemory();       break;
-        case 2: _doShowKeys();         break;
-        case 3: _doDictionaryPicker(); break;
+        case 0:
+          _ndefTarget = NDEF_TARGET_MIFARE_CLASSIC;
+          _doReadClassicNdef();
+          break;
+        case 1:
+          _ndefTarget = NDEF_TARGET_MIFARE_CLASSIC;
+          _goNdefWrite();
+          break;
+        case 2:
+          _ndefTarget = NDEF_TARGET_MIFARE_CLASSIC;
+          _doEraseClassicNdef();
+          break;
+        case 3: _doAuthenticate();     break;
+        case 4: _doDumpMemory();       break;
+        case 5: _doShowKeys();         break;
+        case 6: _doDictionaryPicker(); break;
       }
       break;
     case STATE_ULTRALIGHT_MENU:
       switch (index) {
-        case 0: _doReadNdef();        break;
-        case 1: _goNdefWrite();       break;
-        case 2: _doEraseNdef();       break;
+        case 0:
+          _ndefTarget = NDEF_TARGET_ULTRALIGHT;
+          _doReadNdef();
+          break;
+        case 1:
+          _ndefTarget = NDEF_TARGET_ULTRALIGHT;
+          _goNdefWrite();
+          break;
+        case 2:
+          _ndefTarget = NDEF_TARGET_ULTRALIGHT;
+          _doEraseNdef();
+          break;
         case 3: _doUltralightDump();  break;
         case 4: _doUltralightWrite(); break;
       }
@@ -248,10 +269,10 @@ void PN532I2cScreen::onBack() {
       _goMain();
       break;
     case STATE_NDEF_WRITE_MENU:
-      _goUltralight();
+      _goNdefParent();
       break;
     case STATE_NDEF_RESULT:
-      _goUltralight();
+      _goNdefParent();
       break;
     case STATE_NDEF_FILE_SELECT:
       if (_ndefPickDir == _dumpPath || _ndefPickDir.length() == 0) {
@@ -372,6 +393,11 @@ void PN532I2cScreen::_goNdefWrite() {
   _state = STATE_NDEF_WRITE_MENU;
   setItems(_ndefWriteItems, 3);
   render();
+}
+
+void PN532I2cScreen::_goNdefParent() {
+  if (_ndefTarget == NDEF_TARGET_MIFARE_CLASSIC) _goMifare();
+  else _goUltralight();
 }
 
 void PN532I2cScreen::_goMagic() {
@@ -495,12 +521,20 @@ bool PN532I2cScreen::_scanCardOrShow(uint32_t timeoutMs) {
     }
     uint8_t uid[7]; uint8_t uidLen;
     if (_nfc->readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLen, 200)) {
+      const bool sameCard =
+        _hasCard &&
+        uidLen == _uidLen &&
+        memcmp(uid, _uid, uidLen) == 0;
+
       memcpy(_uid, uid, uidLen);
       _uidLen  = uidLen;
       _atqa    = ((uint16_t)pn532_packetbuffer[9] << 8) | pn532_packetbuffer[10];
       _sak     = pn532_packetbuffer[11];
       _hasCard = true;
-      _mfKeys.fill({});
+
+      if (!sameCard) {
+        _mfKeys.fill({});
+      }
       return true;
     }
     delay(50);
@@ -894,6 +928,9 @@ void PN532I2cScreen::_doUltralightWrite() {
 
 
 void PN532I2cScreen::_doReadNdef() {
+  _ndefTarget = NDEF_TARGET_ULTRALIGHT;
+  _hasNdef = false;
+  _ndefLen = 0;
   ShowStatusAction::show("Place UL/NTAG on reader...", 0);
 
   uint8_t uid[7];
@@ -976,8 +1013,20 @@ void PN532I2cScreen::_doReadNdef() {
     pos += len;
   }
 
+  _showNdefResult(uid, uidLen, ndef, ndefLen);
+}
+
+
+void PN532I2cScreen::_showNdefResult(const uint8_t* uid, uint8_t uidLen,
+                                         const uint8_t* ndef, size_t ndefLen) {
   _state = STATE_NDEF_RESULT;
   _resetRows();
+
+  memcpy(_uid, uid, uidLen);
+  _uidLen = uidLen;
+  _hasNdef = false;
+  _ndefLen = 0;
+
   _pushRow("UID", _hexUid(uid, uidLen));
 
   if (!ndef) {
@@ -1128,8 +1177,422 @@ void PN532I2cScreen::_doReadNdef() {
   render();
 }
 
+// ── MIFARE Classic NDEF ─────────────────────────────────────────────────────
+//
+// NFC Forum formatted MIFARE Classic uses MAD AID 0x03E1 to mark NFC sectors.
+// MAD sectors are readable with public Key A A0:A1:A2:A3:A4:A5 and
+// non-proprietary NFC sectors use public Key A D3:F7:D3:F7:D3:F7.
+//
+// This first implementation intentionally operates on cards that are already
+// NFC/NDEF formatted. It never rewrites MAD entries, sector trailers, keys or
+// access bits.
+
+bool PN532I2cScreen::_classicAuthSector(uint8_t sector, const uint8_t key[6]) {
+  uint16_t block = (sector < 32)
+                     ? (uint16_t)sector * 4
+                     : (uint16_t)(128 + (sector - 32) * 16);
+
+  if (_nfc->mifareclassic_AuthenticateBlock(
+        _uid, _uidLen, block, 0, const_cast<uint8_t*>(key))) {
+    return true;
+  }
+
+  // A failed MIFARE authentication can leave the PICC halted. Re-select once.
+  uint8_t uid[7] = {};
+  uint8_t uidLen = 0;
+  if (!_nfc->readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLen, 250)) {
+    return false;
+  }
+  if (uidLen != _uidLen || memcmp(uid, _uid, uidLen) != 0) return false;
+
+  return _nfc->mifareclassic_AuthenticateBlock(
+      _uid, _uidLen, block, 0, const_cast<uint8_t*>(key));
+}
+
+bool PN532I2cScreen::_classicNdefSectors(uint8_t* sectors,
+                                         size_t maxSectors,
+                                         size_t& count) {
+  count = 0;
+  if (!sectors || maxSectors == 0) return false;
+
+  auto dims = _mfDims(_sak);
+  if (dims.first == 0) return false;
+
+  static const uint8_t MAD_KEY_A[6] = {
+    0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5
+  };
+
+  // MAD1 lives in sector 0. Block 1: CRC, Info, AIDs S1..S7.
+  // Block 2: AIDs S8..S15. AID bytes are stored low byte first.
+  if (!_classicAuthSector(0, MAD_KEY_A)) return false;
+
+  uint8_t b1[16] = {};
+  uint8_t b2[16] = {};
+  if (!_nfc->mifareclassic_ReadDataBlock(1, b1) ||
+      !_nfc->mifareclassic_ReadDataBlock(2, b2)) {
+    return false;
+  }
+
+  auto addIfNdef = [&](uint8_t sector, uint8_t lo, uint8_t hi) {
+    if (sector >= dims.first) return;
+    if (lo == 0x03 && hi == 0xE1 && count < maxSectors) {
+      sectors[count++] = sector;
+    }
+  };
+
+  for (uint8_t s = 1; s <= 7; s++) {
+    size_t off = 2 + (size_t)(s - 1) * 2;
+    addIfNdef(s, b1[off], b1[off + 1]);
+  }
+  for (uint8_t s = 8; s <= 15; s++) {
+    size_t off = (size_t)(s - 8) * 2;
+    addIfNdef(s, b2[off], b2[off + 1]);
+  }
+
+  // MAD2 uses sector 16 on Classic 4K and maps sectors 17..39.
+  if (dims.first > 16) {
+    if (_classicAuthSector(16, MAD_KEY_A)) {
+      uint8_t m0[16] = {};
+      uint8_t m1[16] = {};
+      uint8_t m2[16] = {};
+      if (_nfc->mifareclassic_ReadDataBlock(64, m0) &&
+          _nfc->mifareclassic_ReadDataBlock(65, m1) &&
+          _nfc->mifareclassic_ReadDataBlock(66, m2)) {
+        for (uint8_t s = 17; s <= 23; s++) {
+          size_t off = 2 + (size_t)(s - 17) * 2;
+          addIfNdef(s, m0[off], m0[off + 1]);
+        }
+        for (uint8_t s = 24; s <= 31; s++) {
+          size_t off = (size_t)(s - 24) * 2;
+          addIfNdef(s, m1[off], m1[off + 1]);
+        }
+        for (uint8_t s = 32; s <= 39; s++) {
+          size_t off = (size_t)(s - 32) * 2;
+          addIfNdef(s, m2[off], m2[off + 1]);
+        }
+      }
+    }
+  }
+
+  return count > 0;
+}
+
+bool PN532I2cScreen::_classicReadNdefArea(const uint8_t* sectors,
+                                           size_t sectorCount,
+                                           uint8_t*& area,
+                                           size_t& areaLen) {
+  area = nullptr;
+  areaLen = 0;
+  if (!sectors || sectorCount == 0) return false;
+
+  size_t capacity = 0;
+  for (size_t i = 0; i < sectorCount; i++) {
+    capacity += (sectors[i] < 32) ? 48 : 240;
+  }
+
+  area = new uint8_t[capacity];
+  if (!area) return false;
+
+  static const uint8_t NFC_KEY_A[6] = {
+    0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7
+  };
+
+  ProgressView::init();
+  size_t out = 0;
+
+  for (size_t si = 0; si < sectorCount; si++) {
+    uint8_t sector = sectors[si];
+    if (!_classicAuthSector(sector, NFC_KEY_A)) {
+      ProgressView::finish();
+      delete[] area;
+      area = nullptr;
+      areaLen = 0;
+      return false;
+    }
+
+    uint16_t firstBlock = (sector < 32)
+                            ? (uint16_t)sector * 4
+                            : (uint16_t)(128 + (sector - 32) * 16);
+    uint8_t dataBlocks = (sector < 32) ? 3 : 15;
+
+    for (uint8_t bi = 0; bi < dataBlocks; bi++) {
+      char msg[32];
+      snprintf(msg, sizeof(msg), "Reading S%u B%u",
+               (unsigned)sector, (unsigned)bi);
+      ProgressView::progress(msg, (int)(out * 100 / capacity));
+
+      uint8_t data[16] = {};
+      if (!_nfc->mifareclassic_ReadDataBlock((uint8_t)(firstBlock + bi), data)) {
+        ProgressView::finish();
+        delete[] area;
+        area = nullptr;
+        areaLen = 0;
+        return false;
+      }
+      memcpy(area + out, data, 16);
+      out += 16;
+    }
+  }
+
+  ProgressView::finish();
+  areaLen = out;
+  return true;
+}
+
+void PN532I2cScreen::_doReadClassicNdef() {
+  _ndefTarget = NDEF_TARGET_MIFARE_CLASSIC;
+  _hasNdef = false;
+  _ndefLen = 0;
+
+  if (!_scanCardOrShow(5000)) {
+    _goMifare();
+    return;
+  }
+
+  auto dims = _mfDims(_sak);
+  if (dims.first == 0) {
+    ShowStatusAction::show("Not MIFARE Classic");
+    _goMifare();
+    return;
+  }
+
+  uint8_t sectors[39] = {};
+  size_t sectorCount = 0;
+  if (!_classicNdefSectors(sectors, sizeof(sectors), sectorCount)) {
+    ShowStatusAction::show("No NDEF sectors in MAD");
+    _goMifare();
+    return;
+  }
+
+  uint8_t* area = nullptr;
+  size_t areaLen = 0;
+  if (!_classicReadNdefArea(sectors, sectorCount, area, areaLen)) {
+    ShowStatusAction::show("Failed to read NDEF sectors");
+    _goMifare();
+    return;
+  }
+
+  const uint8_t* ndef = nullptr;
+  size_t ndefLen = 0;
+  size_t pos = 0;
+
+  while (pos < areaLen) {
+    uint8_t tlv = area[pos++];
+    if (tlv == 0x00) continue;
+    if (tlv == 0xFE) break;
+    if (pos >= areaLen) break;
+
+    size_t len = area[pos++];
+    if (len == 0xFF) {
+      if (pos + 1 >= areaLen) break;
+      len = ((size_t)area[pos] << 8) | area[pos + 1];
+      pos += 2;
+    }
+    if (pos + len > areaLen) break;
+
+    if (tlv == 0x03) {
+      ndef = area + pos;
+      ndefLen = len;
+      break;
+    }
+    pos += len;
+  }
+
+  // _showNdefResult copies short NDEF data into _ndefBuf before area is freed.
+  _showNdefResult(_uid, _uidLen, ndef, ndefLen);
+  delete[] area;
+}
+
+bool PN532I2cScreen::_writeClassicNdefRecord(const uint8_t* ndef, size_t ndefLen) {
+  if (!ndef || ndefLen == 0 || ndefLen > MAX_NDEF_BYTES) {
+    ShowStatusAction::show("NDEF too large");
+    return false;
+  }
+
+  if (!_scanCardOrShow(5000)) return false;
+  if (_mfDims(_sak).first == 0) {
+    ShowStatusAction::show("Not MIFARE Classic");
+    return false;
+  }
+
+  uint8_t sectors[39] = {};
+  size_t sectorCount = 0;
+  if (!_classicNdefSectors(sectors, sizeof(sectors), sectorCount)) {
+    ShowStatusAction::show("Not NDEF formatted");
+    return false;
+  }
+
+  size_t capacity = 0;
+  for (size_t i = 0; i < sectorCount; i++) {
+    capacity += (sectors[i] < 32) ? 48 : 240;
+  }
+
+  // Initial implementation targets the NFC Forum Simple Configuration:
+  // mandatory NDEF Message TLV begins at byte 0 of the first NFC sector.
+  const size_t payloadLen = ndefLen + 3; // 03 LEN <NDEF> FE
+  if (payloadLen > capacity) {
+    ShowStatusAction::show("NDEF does not fit");
+    return false;
+  }
+
+  uint8_t* payload = new uint8_t[payloadLen];
+  if (!payload) {
+    ShowStatusAction::show("Out of memory");
+    return false;
+  }
+  payload[0] = 0x03;
+  payload[1] = (uint8_t)ndefLen;
+  memcpy(payload + 2, ndef, ndefLen);
+  payload[2 + ndefLen] = 0xFE;
+
+  static const uint8_t NFC_KEY_A[6] = {
+    0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7
+  };
+
+  // First block is committed last with the real length. Until then the tag
+  // advertises an empty NDEF TLV, reducing the chance of a torn write exposing
+  // a partially-written message.
+  uint8_t firstFinal[16] = {};
+  uint8_t firstStaged[16] = {};
+  bool firstPrepared = false;
+  bool success = true;
+  size_t offset = 0;
+
+  ProgressView::init();
+
+  for (size_t si = 0; si < sectorCount && offset < payloadLen; si++) {
+    uint8_t sector = sectors[si];
+    if (!_classicAuthSector(sector, NFC_KEY_A)) {
+      success = false;
+      break;
+    }
+
+    uint16_t firstBlock = (sector < 32)
+                            ? (uint16_t)sector * 4
+                            : (uint16_t)(128 + (sector - 32) * 16);
+    uint8_t dataBlocks = (sector < 32) ? 3 : 15;
+
+    for (uint8_t bi = 0; bi < dataBlocks && offset < payloadLen; bi++) {
+      uint8_t blockNo = (uint8_t)(firstBlock + bi);
+      uint8_t block[16] = {};
+      if (!_nfc->mifareclassic_ReadDataBlock(blockNo, block)) {
+        success = false;
+        break;
+      }
+
+      size_t take = payloadLen - offset;
+      if (take > 16) take = 16;
+      memcpy(block, payload + offset, take);
+
+      char msg[32];
+      snprintf(msg, sizeof(msg), "Writing S%u B%u",
+               (unsigned)sector, (unsigned)bi);
+      ProgressView::progress(msg, (int)(offset * 100 / payloadLen));
+
+      if (!firstPrepared) {
+        memcpy(firstFinal, block, 16);
+        memcpy(firstStaged, block, 16);
+        firstStaged[1] = 0x00;  // empty NDEF until final commit
+
+        if (!_nfc->mifareclassic_WriteDataBlock(blockNo, firstStaged)) {
+          success = false;
+          break;
+        }
+        firstPrepared = true;
+      } else {
+        if (!_nfc->mifareclassic_WriteDataBlock(blockNo, block)) {
+          success = false;
+          break;
+        }
+      }
+
+      offset += take;
+    }
+    if (!success) break;
+  }
+
+  // Re-authenticate first NFC sector and commit the real length last.
+  if (success && firstPrepared) {
+    if (!_classicAuthSector(sectors[0], NFC_KEY_A) ||
+        !_nfc->mifareclassic_WriteDataBlock(
+            (uint8_t)((sectors[0] < 32)
+                        ? sectors[0] * 4
+                        : 128 + (sectors[0] - 32) * 16),
+            firstFinal)) {
+      success = false;
+    }
+  }
+
+  ProgressView::finish();
+  delete[] payload;
+
+  ShowStatusAction::show(success ? "NDEF write OK" : "NDEF write failed");
+  return success;
+}
+
+void PN532I2cScreen::_doEraseClassicNdef() {
+  _ndefTarget = NDEF_TARGET_MIFARE_CLASSIC;
+
+  if (!_scanCardOrShow(5000)) {
+    _goMifare();
+    return;
+  }
+  if (_mfDims(_sak).first == 0) {
+    ShowStatusAction::show("Not MIFARE Classic");
+    _goMifare();
+    return;
+  }
+
+  uint8_t sectors[39] = {};
+  size_t sectorCount = 0;
+  if (!_classicNdefSectors(sectors, sizeof(sectors), sectorCount)) {
+    ShowStatusAction::show("Not NDEF formatted");
+    _goMifare();
+    return;
+  }
+
+  static const uint8_t NFC_KEY_A[6] = {
+    0xD3, 0xF7, 0xD3, 0xF7, 0xD3, 0xF7
+  };
+
+  if (!_classicAuthSector(sectors[0], NFC_KEY_A)) {
+    ShowStatusAction::show("NDEF sector locked");
+    _goMifare();
+    return;
+  }
+
+  uint8_t blockNo = (uint8_t)((sectors[0] < 32)
+                                ? sectors[0] * 4
+                                : 128 + (sectors[0] - 32) * 16);
+  uint8_t block[16] = {};
+  if (!_nfc->mifareclassic_ReadDataBlock(blockNo, block)) {
+    ShowStatusAction::show("Read failed");
+    _goMifare();
+    return;
+  }
+
+  // Logical erase defined for NDEF: empty NDEF Message TLV + Terminator TLV.
+  // Bytes after FE are intentionally left untouched; they are no longer active.
+  block[0] = 0x03;
+  block[1] = 0x00;
+  block[2] = 0xFE;
+
+  bool success = _nfc->mifareclassic_WriteDataBlock(blockNo, block);
+  _hasNdef = false;
+  _ndefLen = 0;
+  ShowStatusAction::show(success ? "NDEF erased" : "NDEF erase failed");
+  _goMifare();
+}
+
 
 bool PN532I2cScreen::_writeNdefRecord(const uint8_t* ndef, size_t ndefLen) {
+  if (_ndefTarget == NDEF_TARGET_MIFARE_CLASSIC) {
+    return _writeClassicNdefRecord(ndef, ndefLen);
+  }
+  return _writeUltralightNdefRecord(ndef, ndefLen);
+}
+
+bool PN532I2cScreen::_writeUltralightNdefRecord(const uint8_t* ndef, size_t ndefLen) {
   if (!ndef || ndefLen == 0 || ndefLen > 254) {
     ShowStatusAction::show("NDEF too large");
     return false;
@@ -1261,7 +1724,7 @@ void PN532I2cScreen::_doWriteNdefText() {
 
   _writeNdefRecord(ndef, ndefLen);
   delete[] ndef;
-  _goUltralight();
+  _goNdefParent();
 }
 
 void PN532I2cScreen::_doWriteNdefUrl() {
@@ -1305,7 +1768,7 @@ void PN532I2cScreen::_doWriteNdefUrl() {
 
   _writeNdefRecord(ndef, ndefLen);
   delete[] ndef;
-  _goUltralight();
+  _goNdefParent();
 }
 
 
@@ -1316,10 +1779,9 @@ void PN532I2cScreen::_showNdefActions() {
   static const InputSelectAction::Option opts[] = {
     {"Write to Tag", "write"},
     {"Save to File", "save"},
-    {"Emulate [TODO]", "emulate"},
   };
 
-  const char* choice = InputSelectAction::popup("NDEF Actions", opts, 3, nullptr);
+  const char* choice = InputSelectAction::popup("NDEF Actions", opts, 2, nullptr);
   if (!choice) {
     render();
     return;
@@ -1329,9 +1791,6 @@ void PN532I2cScreen::_showNdefActions() {
     _doWriteCurrentNdef();
   } else if (strcmp(choice, "save") == 0) {
     _doSaveNdef();
-  } else if (strcmp(choice, "emulate") == 0) {
-    ShowStatusAction::show("Not implemented yet");
-    render();
   }
 }
 
@@ -1470,11 +1929,12 @@ void PN532I2cScreen::_doWriteNdefFileSelected(uint8_t fileIndex) {
   bool ok = _writeNdefRecord(buf, len);
   _ndefPickDir = "";
 
-  if (ok) _goUltralight();
+  if (ok) _goNdefParent();
   else _goNdefWrite();
 }
 
 void PN532I2cScreen::_doEraseNdef() {
+  _ndefTarget = NDEF_TARGET_ULTRALIGHT;
   ShowStatusAction::show("Place UL/NTAG on reader...", 0);
 
   uint8_t uid[7];

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -6,6 +6,7 @@
 #include "ui/actions/ShowStatusAction.h"
 #include "ui/actions/InputTextAction.h"
 #include "ui/actions/InputNumberAction.h"
+#include "ui/actions/InputSelectAction.h"
 #include "ui/views/ProgressView.h"
 
 // ── raw I2C helpers for Gen1a / Gen3 ──────────────────────────────────────
@@ -85,7 +86,10 @@ const char* PN532I2cScreen::title() {
     case STATE_MAGIC_MENU:      return "Magic Card";
     case STATE_RAW_RESULT:      return "Result";
     case STATE_EMULATE:         return "Emulate Card";
-    case STATE_NTAG_MENU:       return "NTAG Emulate";
+    case STATE_NTAG_MENU:       return "Emulate NDEF";
+    case STATE_NDEF_WRITE_MENU: return "Write NDEF";
+    case STATE_NDEF_RESULT:     return "NDEF Result";
+    case STATE_NDEF_FILE_SELECT:return "NDEF Files";
   }
   return "PN532 I2C";
 }
@@ -125,6 +129,20 @@ void PN532I2cScreen::onUpdate() {
     }
     return;
   }
+  if (_state == STATE_NDEF_RESULT) {
+    if (Uni.Nav->wasPressed()) {
+      auto dir = Uni.Nav->readDirection();
+      if (dir == INavigation::DIR_BACK) {
+        _goUltralight();
+      } else if (dir == INavigation::DIR_PRESS && _hasNdef) {
+        _showNdefActions();
+      } else {
+        _scrollView.onNav(dir);
+      }
+    }
+    return;
+  }
+
   if (_state == STATE_INFO || _state == STATE_MIFARE_KEYS || _state == STATE_RAW_RESULT) {
     if (Uni.Nav->wasPressed()) {
       auto dir = Uni.Nav->readDirection();
@@ -143,7 +161,8 @@ void PN532I2cScreen::onUpdate() {
 void PN532I2cScreen::onRender() {
   if (_state == STATE_INFO || _state == STATE_SCAN_RESULT ||
       _state == STATE_MIFARE_DUMP || _state == STATE_MIFARE_KEYS ||
-      _state == STATE_RAW_RESULT || _state == STATE_EMULATE) {
+      _state == STATE_RAW_RESULT || _state == STATE_NDEF_RESULT ||
+      _state == STATE_EMULATE) {
     _scrollView.render(bodyX(), bodyY(), bodyW(), bodyH());
     return;
   }
@@ -154,12 +173,11 @@ void PN532I2cScreen::onItemSelected(uint8_t index) {
   switch (_state) {
     case STATE_MAIN_MENU:
       switch (index) {
-        case 0: _doScan14A();        break;
-        case 1: _goMifare();         break;
-        case 2: _goUltralight();     break;
-        case 3: _goMagic();          break;
-        case 4: _showFirmwareInfo(); break;
-        case 5: _doNtagMenu();       break;
+        case 0: _doScan14A();         break;
+        case 1: _goMifare();          break;
+        case 2: _goUltralight();      break;
+        case 3: _goMagic();           break;
+        case 4: _showFirmwareInfo();  break;
       }
       break;
     case STATE_MIFARE_MENU:
@@ -172,9 +190,20 @@ void PN532I2cScreen::onItemSelected(uint8_t index) {
       break;
     case STATE_ULTRALIGHT_MENU:
       switch (index) {
-        case 0: _doUltralightDump();  break;
-        case 1: _doUltralightWrite(); break;
+        case 0: _doReadNdef();        break;
+        case 1: _goNdefWrite();       break;
+        case 2: _doEraseNdef();       break;
+        case 3: _doUltralightDump();  break;
+        case 4: _doUltralightWrite(); break;
       }
+      break;
+    case STATE_NDEF_WRITE_MENU:
+      if (index == 0) _doWriteNdefText();
+      else if (index == 1) _doWriteNdefUrl();
+      else if (index == 2) _doWriteNdefFromFile();
+      break;
+    case STATE_NDEF_FILE_SELECT:
+      _doWriteNdefFileSelected(index);
       break;
     case STATE_MAGIC_MENU:
       switch (index) {
@@ -217,6 +246,22 @@ void PN532I2cScreen::onBack() {
       break;
     case STATE_NTAG_MENU:
       _goMain();
+      break;
+    case STATE_NDEF_WRITE_MENU:
+      _goUltralight();
+      break;
+    case STATE_NDEF_RESULT:
+      _goUltralight();
+      break;
+    case STATE_NDEF_FILE_SELECT:
+      if (_ndefPickDir == _dumpPath || _ndefPickDir.length() == 0) {
+        _ndefPickDir = "";
+        _goNdefWrite();
+      } else {
+        int slash = _ndefPickDir.lastIndexOf('/');
+        _ndefPickDir = (slash > 0) ? _ndefPickDir.substring(0, slash) : _dumpPath;
+        _doWriteNdefFromFile();
+      }
       break;
     default:
       _goMain();
@@ -307,7 +352,7 @@ void PN532I2cScreen::_cleanup() {
 
 void PN532I2cScreen::_goMain() {
   _state = STATE_MAIN_MENU;
-  setItems(_mainItems, 6);
+  setItems(_mainItems, 5);
   render();
 }
 
@@ -320,6 +365,12 @@ void PN532I2cScreen::_goMifare() {
 void PN532I2cScreen::_goUltralight() {
   _state = STATE_ULTRALIGHT_MENU;
   setItems(_ulItems);
+  render();
+}
+
+void PN532I2cScreen::_goNdefWrite() {
+  _state = STATE_NDEF_WRITE_MENU;
+  setItems(_ndefWriteItems, 3);
   render();
 }
 
@@ -347,6 +398,58 @@ String PN532I2cScreen::_hexBlock(const uint8_t* data, uint8_t len) const {
     char buf[4];
     sprintf(buf, "%s%02X", i == 0 ? "" : " ", data[i]);
     s += buf;
+  }
+  return s;
+}
+
+
+static String _ndefUriPrefix(uint8_t code) {
+  switch (code) {
+    case 0x00: return "";
+    case 0x01: return "http://www.";
+    case 0x02: return "https://www.";
+    case 0x03: return "http://";
+    case 0x04: return "https://";
+    case 0x05: return "tel:";
+    case 0x06: return "mailto:";
+    case 0x07: return "ftp://anonymous:anonymous@";
+    case 0x08: return "ftp://ftp.";
+    case 0x09: return "ftps://";
+    case 0x0A: return "sftp://";
+    case 0x0B: return "smb://";
+    case 0x0C: return "nfs://";
+    case 0x0D: return "ftp://";
+    case 0x0E: return "dav://";
+    case 0x0F: return "news:";
+    case 0x10: return "telnet://";
+    case 0x11: return "imap:";
+    case 0x12: return "rtsp://";
+    case 0x13: return "urn:";
+    case 0x14: return "pop:";
+    case 0x15: return "sip:";
+    case 0x16: return "sips:";
+    case 0x17: return "tftp:";
+    case 0x18: return "btspp://";
+    case 0x19: return "btl2cap://";
+    case 0x1A: return "btgoep://";
+    case 0x1B: return "tcpobex://";
+    case 0x1C: return "irdaobex://";
+    case 0x1D: return "file://";
+    case 0x1E: return "urn:epc:id:";
+    case 0x1F: return "urn:epc:tag:";
+    case 0x20: return "urn:epc:pat:";
+    case 0x21: return "urn:epc:raw:";
+    case 0x22: return "urn:epc:";
+    case 0x23: return "urn:nfc:";
+    default:   return "";
+  }
+}
+
+static String _bytesToPrintable(const uint8_t* data, size_t len) {
+  String s;
+  for (size_t i = 0; i < len; i++) {
+    char c = (char)data[i];
+    s += (c >= 32 && c <= 126) ? c : '.';
   }
   return s;
 }
@@ -726,9 +829,16 @@ void PN532I2cScreen::_doUltralightDump() {
   }
   if (!ok) { ShowStatusAction::show("No card"); _goUltralight(); return; }
 
-  _state = STATE_RAW_RESULT;
+  _state = STATE_NDEF_RESULT;
   _resetRows();
+  memcpy(_uid, uid, uidLen);
+  _uidLen = uidLen;
   _pushRow("UID", _hexUid(uid, uidLen));
+
+  memcpy(_uid, uid, uidLen);
+  _uidLen = uidLen;
+  _hasNdef = false;
+  _ndefLen = 0;
 
   ProgressView::init();
   for (uint8_t page = 0; page < 64; page++) {
@@ -779,6 +889,644 @@ void PN532I2cScreen::_doUltralightWrite() {
   } else {
     ShowStatusAction::show("Write failed");
   }
+  _goUltralight();
+}
+
+
+void PN532I2cScreen::_doReadNdef() {
+  ShowStatusAction::show("Place UL/NTAG on reader...", 0);
+
+  uint8_t uid[7];
+  uint8_t uidLen = 0;
+  uint32_t start = millis();
+  bool ok = false;
+
+  while (millis() - start < 5000) {
+    Uni.update();
+    if (Uni.Nav->wasPressed() &&
+        Uni.Nav->readDirection() == INavigation::DIR_BACK) {
+      _goUltralight();
+      return;
+    }
+
+    if (_nfc->readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLen, 200)) {
+      ok = true;
+      break;
+    }
+    delay(50);
+  }
+
+  if (!ok) {
+    ShowStatusAction::show("No card");
+    _goUltralight();
+    return;
+  }
+
+  // Type 2 Tag user memory starts at page 4. Read a conservative 60 pages
+  // (240 bytes), enough for common short NDEF records and matching the current
+  // UniGeek Ultralight page range.
+  static constexpr uint8_t FIRST_PAGE = 4;
+  static constexpr uint8_t LAST_PAGE  = 63;
+  static constexpr size_t USER_BYTES  = (LAST_PAGE - FIRST_PAGE + 1) * 4;
+
+  uint8_t user[USER_BYTES] = {};
+  size_t userLen = 0;
+
+  ProgressView::init();
+  for (uint8_t page = FIRST_PAGE; page <= LAST_PAGE; page++) {
+    char msg[24];
+    snprintf(msg, sizeof(msg), "Reading page %u", page);
+    ProgressView::progress(msg, (page - FIRST_PAGE) * 100 / (LAST_PAGE - FIRST_PAGE + 1));
+
+    uint8_t data[4];
+    if (!_nfc->mifareultralight_ReadPage(page, data)) break;
+
+    memcpy(&user[userLen], data, 4);
+    userLen += 4;
+  }
+  ProgressView::finish();
+
+  // Parse the Type 2 Tag TLV stream and locate the first NDEF Message TLV (0x03).
+  const uint8_t* ndef = nullptr;
+  size_t ndefLen = 0;
+  size_t pos = 0;
+
+  while (pos < userLen) {
+    uint8_t tlv = user[pos++];
+
+    if (tlv == 0x00) continue; // NULL TLV
+    if (tlv == 0xFE) break;    // Terminator TLV
+    if (pos >= userLen) break;
+
+    size_t len = user[pos++];
+    if (len == 0xFF) {
+      if (pos + 1 >= userLen) break;
+      len = ((size_t)user[pos] << 8) | user[pos + 1];
+      pos += 2;
+    }
+
+    if (pos + len > userLen) break;
+
+    if (tlv == 0x03) {
+      ndef = &user[pos];
+      ndefLen = len;
+      break;
+    }
+
+    pos += len;
+  }
+
+  _state = STATE_NDEF_RESULT;
+  _resetRows();
+  _pushRow("UID", _hexUid(uid, uidLen));
+
+  if (!ndef) {
+    _pushRow("NDEF", "Not found");
+    _scrollView.setRows(_rows, _rowCount);
+    render();
+    return;
+  }
+
+  if (ndefLen <= MAX_NDEF_BYTES) {
+    memcpy(_ndefBuf, ndef, ndefLen);
+    _ndefLen = ndefLen;
+    _hasNdef = true;
+  }
+
+  char lenBuf[24];
+  snprintf(lenBuf, sizeof(lenBuf), "%u bytes", (unsigned)ndefLen);
+  _pushRow("NDEF Size", lenBuf);
+
+  if (ndefLen == 0) {
+    _pushRow("NDEF", "Empty");
+    _pushRow("[Press]", "Actions");
+    _scrollView.setRows(_rows, _rowCount);
+    render();
+    return;
+  }
+
+  if (ndefLen < 3) {
+    _pushRow("NDEF", "Invalid record");
+    _scrollView.setRows(_rows, _rowCount);
+    render();
+    return;
+  }
+
+  // Decode the first NDEF record. Support both Short Record (SR) and normal
+  // payload-length encoding. Text and URI are decoded; other record types fall
+  // back to a compact generic view.
+  size_t p = 0;
+  uint8_t flagsTnf = ndef[p++];
+  bool sr = (flagsTnf & 0x10) != 0;
+  bool il = (flagsTnf & 0x08) != 0;
+  uint8_t tnf = flagsTnf & 0x07;
+
+  if (p >= ndefLen) {
+    _pushRow("NDEF", "Invalid record");
+    _scrollView.setRows(_rows, _rowCount);
+    render();
+    return;
+  }
+
+  uint8_t typeLen = ndef[p++];
+  uint32_t payloadLen = 0;
+
+  if (sr) {
+    if (p >= ndefLen) {
+      _pushRow("NDEF", "Invalid record");
+      _scrollView.setRows(_rows, _rowCount);
+      render();
+      return;
+    }
+    payloadLen = ndef[p++];
+  } else {
+    if (p + 3 >= ndefLen) {
+      _pushRow("NDEF", "Invalid record");
+      _scrollView.setRows(_rows, _rowCount);
+      render();
+      return;
+    }
+    payloadLen = ((uint32_t)ndef[p] << 24) |
+                 ((uint32_t)ndef[p + 1] << 16) |
+                 ((uint32_t)ndef[p + 2] << 8) |
+                 (uint32_t)ndef[p + 3];
+    p += 4;
+  }
+
+  uint8_t idLen = 0;
+  if (il) {
+    if (p >= ndefLen) {
+      _pushRow("NDEF", "Invalid record");
+      _scrollView.setRows(_rows, _rowCount);
+      render();
+      return;
+    }
+    idLen = ndef[p++];
+  }
+
+  if (p + typeLen + idLen + payloadLen > ndefLen) {
+    _pushRow("NDEF", "Truncated record");
+    _scrollView.setRows(_rows, _rowCount);
+    render();
+    return;
+  }
+
+  const uint8_t* type = &ndef[p];
+  p += typeLen;
+  p += idLen;
+  const uint8_t* payload = &ndef[p];
+
+  char tnfBuf[8];
+  snprintf(tnfBuf, sizeof(tnfBuf), "%u", tnf);
+  _pushRow("TNF", tnfBuf);
+
+  String typeStr = _bytesToPrintable(type, typeLen);
+  _pushRow("Type", typeStr.length() ? typeStr : "(empty)");
+
+  // NFC Forum Well Known Text record ("T").
+  if (tnf == 0x01 && typeLen == 1 && type[0] == 'T' && payloadLen >= 1) {
+    uint8_t status = payload[0];
+    bool utf16 = (status & 0x80) != 0;
+    uint8_t langLen = status & 0x3F;
+
+    if ((size_t)1 + langLen <= payloadLen) {
+      String lang;
+      for (uint8_t i = 0; i < langLen; i++) lang += (char)payload[1 + i];
+
+      _pushRow("Record", "Text");
+      _pushRow("Encoding", utf16 ? "UTF-16" : "UTF-8");
+      if (lang.length()) _pushRow("Language", lang);
+
+      if (!utf16) {
+        String text;
+        for (size_t i = 1 + langLen; i < payloadLen; i++) text += (char)payload[i];
+        _pushRow("Text", text);
+      } else {
+        _pushRow("Text", "(UTF-16 raw)");
+        uint8_t rawLen = (uint8_t)(payloadLen < 32 ? payloadLen : 32);
+        _pushRow("Raw", _hexBlock(payload, rawLen));
+      }
+    }
+  }
+  // NFC Forum Well Known URI record ("U").
+  else if (tnf == 0x01 && typeLen == 1 && type[0] == 'U' && payloadLen >= 1) {
+    String uri = _ndefUriPrefix(payload[0]);
+    for (size_t i = 1; i < payloadLen; i++) uri += (char)payload[i];
+
+    _pushRow("Record", "URI");
+    _pushRow("URI", uri);
+  }
+  else {
+    _pushRow("Record", "Unsupported");
+    uint8_t rawLen = (uint8_t)(payloadLen < 32 ? payloadLen : 32);
+    _pushRow("Payload", _hexBlock(payload, rawLen));
+  }
+
+  if (_hasNdef) _pushRow("[Press]", "Actions");
+
+  _scrollView.setRows(_rows, _rowCount);
+  render();
+}
+
+
+bool PN532I2cScreen::_writeNdefRecord(const uint8_t* ndef, size_t ndefLen) {
+  if (!ndef || ndefLen == 0 || ndefLen > 254) {
+    ShowStatusAction::show("NDEF too large");
+    return false;
+  }
+
+  ShowStatusAction::show("Place UL/NTAG on reader...", 0);
+
+  uint8_t uid[7];
+  uint8_t uidLen = 0;
+  uint32_t start = millis();
+  bool ok = false;
+
+  while (millis() - start < 5000) {
+    Uni.update();
+    if (Uni.Nav->wasPressed() &&
+        Uni.Nav->readDirection() == INavigation::DIR_BACK) {
+      return false;
+    }
+
+    if (_nfc->readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLen, 200)) {
+      ok = true;
+      break;
+    }
+    delay(50);
+  }
+
+  if (!ok) {
+    ShowStatusAction::show("No card");
+    return false;
+  }
+
+  // Read the NFC Forum Type 2 Capability Container from page 3.
+  // CC byte 2 gives the data area size in multiples of 8 bytes.
+  uint8_t cc[4] = {};
+  if (!_nfc->mifareultralight_ReadPage(3, cc)) {
+    ShowStatusAction::show("Failed to read CC");
+    return false;
+  }
+
+  if (cc[0] != 0xE1) {
+    ShowStatusAction::show("Not NDEF formatted");
+    return false;
+  }
+
+  size_t capacity = (size_t)cc[2] * 8;
+  if (capacity == 0) {
+    ShowStatusAction::show("Invalid NDEF capacity");
+    return false;
+  }
+
+  // Type 2 Tag memory layout:
+  // 03 <LEN> <NDEF message> FE
+  size_t tlvLen = ndefLen + 3;
+  size_t paddedLen = (tlvLen + 3) & ~((size_t)3);
+
+  if (paddedLen > capacity) {
+    ShowStatusAction::show("NDEF does not fit");
+    return false;
+  }
+
+  uint8_t* payload = new uint8_t[paddedLen];
+  if (!payload) {
+    ShowStatusAction::show("Out of memory");
+    return false;
+  }
+
+  memset(payload, 0x00, paddedLen);
+  payload[0] = 0x03;
+  payload[1] = (uint8_t)ndefLen;
+  memcpy(&payload[2], ndef, ndefLen);
+  payload[2 + ndefLen] = 0xFE;
+
+  ProgressView::init();
+  bool success = true;
+
+  for (size_t offset = 0; offset < paddedLen; offset += 4) {
+    uint8_t page = 4 + (offset / 4);
+
+    char msg[24];
+    snprintf(msg, sizeof(msg), "Writing page %u", page);
+    ProgressView::progress(msg, (int)(offset * 100 / paddedLen));
+
+    if (!_nfc->mifareultralight_WritePage(page, &payload[offset])) {
+      success = false;
+      break;
+    }
+  }
+
+  ProgressView::finish();
+  delete[] payload;
+
+  ShowStatusAction::show(success ? "NDEF write OK" : "NDEF write failed");
+  return success;
+}
+
+void PN532I2cScreen::_doWriteNdefText() {
+  String text = InputTextAction::popup("Enter text", "");
+  if (InputTextAction::wasCancelled() || text.length() == 0) {
+    _goNdefWrite();
+    return;
+  }
+
+  // Short-record NDEF Text:
+  // D1 01 <payloadLen> 54 02 'e' 'n' <text>
+  size_t payloadLen = 1 + 2 + text.length();
+  size_t ndefLen = 4 + payloadLen;
+
+  if (ndefLen > 254 || payloadLen > 255) {
+    ShowStatusAction::show("Text too long");
+    _goNdefWrite();
+    return;
+  }
+
+  uint8_t* ndef = new uint8_t[ndefLen];
+  if (!ndef) {
+    ShowStatusAction::show("Out of memory");
+    _goNdefWrite();
+    return;
+  }
+
+  ndef[0] = 0xD1;                    // MB | ME | SR | TNF=Well Known
+  ndef[1] = 0x01;                    // Type length
+  ndef[2] = (uint8_t)payloadLen;
+  ndef[3] = 'T';
+  ndef[4] = 0x02;                    // UTF-8, language code length 2
+  ndef[5] = 'e';
+  ndef[6] = 'n';
+  memcpy(&ndef[7], text.c_str(), text.length());
+
+  _writeNdefRecord(ndef, ndefLen);
+  delete[] ndef;
+  _goUltralight();
+}
+
+void PN532I2cScreen::_doWriteNdefUrl() {
+  String url = InputTextAction::popup("Enter URL", "https://");
+  if (InputTextAction::wasCancelled() || url.length() == 0) {
+    _goNdefWrite();
+    return;
+  }
+
+  uint8_t prefix = 0x00;
+  const char* body = url.c_str();
+
+  if      (url.startsWith("https://www.")) { prefix = 0x02; body += 12; }
+  else if (url.startsWith("http://www."))  { prefix = 0x01; body += 11; }
+  else if (url.startsWith("https://"))     { prefix = 0x04; body += 8; }
+  else if (url.startsWith("http://"))      { prefix = 0x03; body += 7; }
+
+  size_t bodyLen = strlen(body);
+  size_t payloadLen = 1 + bodyLen;
+  size_t ndefLen = 4 + payloadLen;
+
+  if (ndefLen > 254 || payloadLen > 255) {
+    ShowStatusAction::show("URL too long");
+    _goNdefWrite();
+    return;
+  }
+
+  uint8_t* ndef = new uint8_t[ndefLen];
+  if (!ndef) {
+    ShowStatusAction::show("Out of memory");
+    _goNdefWrite();
+    return;
+  }
+
+  ndef[0] = 0xD1;                    // MB | ME | SR | TNF=Well Known
+  ndef[1] = 0x01;                    // Type length
+  ndef[2] = (uint8_t)payloadLen;
+  ndef[3] = 'U';
+  ndef[4] = prefix;
+  memcpy(&ndef[5], body, bodyLen);
+
+  _writeNdefRecord(ndef, ndefLen);
+  delete[] ndef;
+  _goUltralight();
+}
+
+
+
+void PN532I2cScreen::_showNdefActions() {
+  if (!_hasNdef) return;
+
+  static const InputSelectAction::Option opts[] = {
+    {"Write to Tag", "write"},
+    {"Save to File", "save"},
+    {"Emulate [TODO]", "emulate"},
+  };
+
+  const char* choice = InputSelectAction::popup("NDEF Actions", opts, 3, nullptr);
+  if (!choice) {
+    render();
+    return;
+  }
+
+  if (strcmp(choice, "write") == 0) {
+    _doWriteCurrentNdef();
+  } else if (strcmp(choice, "save") == 0) {
+    _doSaveNdef();
+  } else if (strcmp(choice, "emulate") == 0) {
+    ShowStatusAction::show("Not implemented yet");
+    render();
+  }
+}
+
+void PN532I2cScreen::_doWriteCurrentNdef() {
+  if (!_hasNdef) {
+    ShowStatusAction::show("No NDEF in memory");
+    render();
+    return;
+  }
+
+  if (_ndefLen == 0) {
+    ShowStatusAction::show("NDEF is empty");
+    render();
+    return;
+  }
+
+  _writeNdefRecord(_ndefBuf, _ndefLen);
+  _state = STATE_NDEF_RESULT;
+  render();
+}
+
+void PN532I2cScreen::_doSaveNdef() {
+  if (!_hasNdef || _ndefLen == 0) {
+    ShowStatusAction::show(_hasNdef ? "NDEF is empty" : "No NDEF to save");
+    render();
+    return;
+  }
+
+  if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+    ShowStatusAction::show("Storage unavailable");
+    render();
+    return;
+  }
+
+  Uni.Storage->makeDir("/unigeek/nfc");
+  Uni.Storage->makeDir(_dumpPath);
+
+  String uid = _hexUid(_uid, _uidLen);
+  uid.replace(":", "");
+  if (uid.length() == 0) uid = "unknown";
+
+  // Follow the project's duplicate-name convention:
+  // <UID>.ndef, <UID>_(2).ndef, <UID>_(3).ndef, ...
+  String path = String(_dumpPath) + "/" + uid + ".ndef";
+  if (Uni.Storage->exists(path.c_str())) {
+    for (int n = 2; n < 1000; n++) {
+      String candidate = String(_dumpPath) + "/" + uid + "_(" + n + ").ndef";
+      if (!Uni.Storage->exists(candidate.c_str())) {
+        path = candidate;
+        break;
+      }
+    }
+  }
+
+  fs::File f = Uni.Storage->open(path.c_str(), "w");
+  if (!f) {
+    ShowStatusAction::show("Save failed");
+    render();
+    return;
+  }
+
+  size_t written = f.write(_ndefBuf, _ndefLen);
+  f.close();
+
+  if (written == _ndefLen) {
+    int slash = path.lastIndexOf('/');
+    String name = (slash >= 0) ? path.substring(slash + 1) : path;
+    ShowStatusAction::show(("Saved: " + name).c_str(), 1500);
+  } else {
+    ShowStatusAction::show("Save failed");
+  }
+  render();
+}
+
+void PN532I2cScreen::_doWriteNdefFromFile() {
+  if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+    ShowStatusAction::show("Storage unavailable");
+    _goNdefWrite();
+    return;
+  }
+
+  Uni.Storage->makeDir("/unigeek/nfc");
+  Uni.Storage->makeDir(_dumpPath);
+
+  _state = STATE_NDEF_FILE_SELECT;
+  if (_ndefPickDir.length() == 0) _ndefPickDir = _dumpPath;
+  _browser.root = _dumpPath;
+
+  uint8_t n = _browser.load(this, _ndefPickDir, ".ndef");
+  if (n == 0 && _ndefPickDir == _dumpPath) {
+    ShowStatusAction::show("No .ndef files");
+    _ndefPickDir = "";
+    _goNdefWrite();
+    return;
+  }
+
+  setItems(_browser.items(), n);
+  render();
+}
+
+void PN532I2cScreen::_doWriteNdefFileSelected(uint8_t fileIndex) {
+  if (fileIndex >= _browser.count()) return;
+
+  const auto& e = _browser.entry(fileIndex);
+  if (e.isDir) {
+    _ndefPickDir = e.path;
+    _doWriteNdefFromFile();
+    return;
+  }
+
+  fs::File f = Uni.Storage->open(e.path.c_str(), "r");
+  if (!f) {
+    ShowStatusAction::show("Read failed");
+    _doWriteNdefFromFile();
+    return;
+  }
+
+  size_t len = f.size();
+  if (len == 0 || len > MAX_NDEF_BYTES) {
+    f.close();
+    ShowStatusAction::show(len == 0 ? "Empty .ndef file" : "NDEF file too large");
+    _doWriteNdefFromFile();
+    return;
+  }
+
+  uint8_t buf[MAX_NDEF_BYTES];
+  size_t got = f.read(buf, len);
+  f.close();
+
+  if (got != len) {
+    ShowStatusAction::show("Read failed");
+    _doWriteNdefFromFile();
+    return;
+  }
+
+  bool ok = _writeNdefRecord(buf, len);
+  _ndefPickDir = "";
+
+  if (ok) _goUltralight();
+  else _goNdefWrite();
+}
+
+void PN532I2cScreen::_doEraseNdef() {
+  ShowStatusAction::show("Place UL/NTAG on reader...", 0);
+
+  uint8_t uid[7];
+  uint8_t uidLen = 0;
+  uint32_t start = millis();
+  bool ok = false;
+
+  while (millis() - start < 5000) {
+    Uni.update();
+    if (Uni.Nav->wasPressed() &&
+        Uni.Nav->readDirection() == INavigation::DIR_BACK) {
+      _goUltralight();
+      return;
+    }
+
+    if (_nfc->readPassiveTargetID(PN532_MIFARE_ISO14443A, uid, &uidLen, 200)) {
+      ok = true;
+      break;
+    }
+    delay(50);
+  }
+
+  if (!ok) {
+    ShowStatusAction::show("No card");
+    _goUltralight();
+    return;
+  }
+
+  // Read NFC Forum Type 2 Capability Container from page 3.
+  uint8_t cc[4] = {};
+  if (!_nfc->mifareultralight_ReadPage(3, cc)) {
+    ShowStatusAction::show("Failed to read CC");
+    _goUltralight();
+    return;
+  }
+
+  if (cc[0] != 0xE1) {
+    ShowStatusAction::show("Not NDEF formatted");
+    _goUltralight();
+    return;
+  }
+
+  // Logical NDEF erase:
+  // 03 = NDEF Message TLV
+  // 00 = zero-length NDEF message
+  // FE = Terminator TLV
+  // The previous bytes after the terminator are no longer part of the active NDEF.
+  uint8_t emptyNdef[4] = {0x03, 0x00, 0xFE, 0x00};
+
+  bool success = _nfc->mifareultralight_WritePage(4, emptyNdef);
+
+  ShowStatusAction::show(success ? "NDEF erased" : "NDEF erase failed");
   _goUltralight();
 }
 

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -230,9 +230,9 @@ void PN532I2cScreen::onItemSelected(uint8_t index) {
     case STATE_NDEF_GENERATE_MENU:
       if (index == 0) _doGenerateNdefText();
       else if (index == 1) _doGenerateNdefUrl();
-      else if (index == 2) _doGenerateNdefVcard();
-      else if (index == 3) _doGenerateNdefPhone();
-      else if (index == 4) _doGenerateNdefEmail();
+      else if (index == 2) _doGenerateNdefPhone();
+      else if (index == 3) _doGenerateNdefEmail();
+      else if (index == 4) _doGenerateNdefVcard();
       break;
     case STATE_NDEF_FILE_SELECT:
       _doWriteNdefFileSelected(index);
@@ -289,12 +289,14 @@ void PN532I2cScreen::onBack() {
       _goNdefParent();
       break;
     case STATE_NDEF_FILE_SELECT:
-      if (_ndefPickDir == "/" || _ndefPickDir.length() == 0) {
+      if (_ndefPickDir == _nfcPath || _ndefPickDir.length() == 0) {
         _ndefPickDir = "";
         _goNdefWrite();
       } else {
         int slash = _ndefPickDir.lastIndexOf('/');
-        _ndefPickDir = (slash > 0) ? _ndefPickDir.substring(0, slash) : "/";
+        String parent = (slash > 0) ? _ndefPickDir.substring(0, slash) : String(_nfcPath);
+        if (!parent.startsWith(_nfcPath)) parent = _nfcPath;
+        _ndefPickDir = parent;
         _doWriteNdefFromFile();
       }
       break;
@@ -1926,17 +1928,16 @@ bool PN532I2cScreen::_saveGeneratedNdef(const uint8_t* ndef, size_t ndefLen,
     return false;
   }
 
-  static constexpr const char* NDEF_DIR = "/unigeek/nfc/ndefs";
-  Uni.Storage->makeDir("/unigeek/nfc");
-  Uni.Storage->makeDir(NDEF_DIR);
+  Uni.Storage->makeDir(_nfcPath);
+  Uni.Storage->makeDir(_ndefPath);
 
   const String base = _sanitizeGeneratedNdefName(suggestedName);
-  String path = String(NDEF_DIR) + "/" + base + ".ndef";
+  String path = String(_ndefPath) + "/" + base + ".ndef";
 
   if (Uni.Storage->exists(path.c_str())) {
     for (int n = 2; n < 1000; n++) {
       String candidate =
-          String(NDEF_DIR) + "/" + base + "_(" + n + ").ndef";
+          String(_ndefPath) + "/" + base + "_(" + n + ").ndef";
       if (!Uni.Storage->exists(candidate.c_str())) {
         path = candidate;
         break;
@@ -2466,12 +2467,13 @@ void PN532I2cScreen::_doWriteNdefFromFile() {
     return;
   }
 
-  Uni.Storage->makeDir("/unigeek/nfc");
+  Uni.Storage->makeDir(_nfcPath);
+  Uni.Storage->makeDir(_ndefPath);
   Uni.Storage->makeDir(_dumpPath);
 
   _state = STATE_NDEF_FILE_SELECT;
-  if (_ndefPickDir.length() == 0) _ndefPickDir = _dumpPath;
-  _browser.root = "/";
+  if (_ndefPickDir.length() == 0) _ndefPickDir = _nfcPath;
+  _browser.root = _nfcPath;
 
   uint8_t n = _browser.load(this, _ndefPickDir, ".ndef");
   setItems(_browser.items(), n);

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -223,9 +223,10 @@ void PN532I2cScreen::onItemSelected(uint8_t index) {
     case STATE_NDEF_WRITE_MENU:
       if (index == 0) _doWriteNdefText();
       else if (index == 1) _doWriteNdefUrl();
-      else if (index == 2) _doWriteNdefEmail();
-      else if (index == 3) _doWriteNdefPhone();
-      else if (index == 4) _doWriteNdefFromFile();
+      else if (index == 2) _doWriteNdefPhone();
+      else if (index == 3) _doWriteNdefEmail();
+      else if (index == 4) _doWriteNdefVcard();
+      else if (index == 5) _doWriteNdefFromFile();
       break;
     case STATE_NDEF_GENERATE_MENU:
       if (index == 0) _doGenerateNdefText();
@@ -407,7 +408,7 @@ void PN532I2cScreen::_goUltralight() {
 
 void PN532I2cScreen::_goNdefWrite() {
   _state = STATE_NDEF_WRITE_MENU;
-  setItems(_ndefWriteItems, 5);
+  setItems(_ndefWriteItems, 6);
   render();
 }
 
@@ -2113,6 +2114,77 @@ void PN532I2cScreen::_doGenerateNdefEmail() {
   _goNdefGenerate();
 }
 
+void PN532I2cScreen::_doWriteNdefVcard() {
+  String contact = InputTextAction::popup("Contact name", "");
+  if (InputTextAction::wasCancelled() || contact.length() == 0) {
+    _goNdefWrite();
+    return;
+  }
+
+  String company = InputTextAction::popup("Company", "");
+  if (InputTextAction::wasCancelled()) { _goNdefWrite(); return; }
+
+  String address = InputTextAction::popup("Address", "");
+  if (InputTextAction::wasCancelled()) { _goNdefWrite(); return; }
+
+  String phone = InputTextAction::popup("Phone", "", InputTextAction::INPUT_PHONE);
+  if (InputTextAction::wasCancelled()) { _goNdefWrite(); return; }
+
+  String mail = InputTextAction::popup("Mail", "");
+  if (InputTextAction::wasCancelled()) { _goNdefWrite(); return; }
+
+  String website = InputTextAction::popup("Website", "https://");
+  if (InputTextAction::wasCancelled()) { _goNdefWrite(); return; }
+
+  auto escapeVcard = [](String s) -> String {
+    s.replace("\\", "\\\\");
+    s.replace("\r", "");
+    s.replace("\n", "\\n");
+    s.replace(";", "\\;");
+    s.replace(",", "\\,");
+    return s;
+  };
+
+  String card = "BEGIN:VCARD\r\nVERSION:3.0\r\n";
+  card += "FN:" + escapeVcard(contact) + "\r\n";
+  if (company.length()) card += "ORG:" + escapeVcard(company) + "\r\n";
+  if (address.length()) card += "ADR:;;" + escapeVcard(address) + ";;;;\r\n";
+  if (phone.length()) card += "TEL:" + escapeVcard(phone) + "\r\n";
+  if (mail.length()) card += "EMAIL:" + escapeVcard(mail) + "\r\n";
+  if (website.length() && website != "https://") {
+    card += "URL:" + escapeVcard(website) + "\r\n";
+  }
+  card += "END:VCARD\r\n";
+
+  const char* mime = "text/vcard";
+  const size_t typeLen = strlen(mime);
+  const size_t payloadLen = card.length();
+  const size_t ndefLen = 3 + typeLen + payloadLen;
+
+  if (payloadLen > 255 || ndefLen > MAX_NDEF_BYTES) {
+    ShowStatusAction::show("vCard too large");
+    _goNdefWrite();
+    return;
+  }
+
+  uint8_t* ndef = new uint8_t[ndefLen]();
+  if (!ndef) {
+    ShowStatusAction::show("Out of memory");
+    _goNdefWrite();
+    return;
+  }
+
+  ndef[0] = 0xD2; // MB | ME | SR | TNF=MIME Media
+  ndef[1] = (uint8_t)typeLen;
+  ndef[2] = (uint8_t)payloadLen;
+  memcpy(&ndef[3], mime, typeLen);
+  memcpy(&ndef[3 + typeLen], card.c_str(), payloadLen);
+
+  _writeNdefRecord(ndef, ndefLen);
+  delete[] ndef;
+  _goNdefParent();
+}
+
 void PN532I2cScreen::_doGenerateNdefVcard() {
   String contact = InputTextAction::popup("Contact name", "");
   if (InputTextAction::wasCancelled() || contact.length() == 0) {
@@ -2179,7 +2251,7 @@ void PN532I2cScreen::_doGenerateNdefVcard() {
   memcpy(&ndef[3], mime, typeLen);
   memcpy(&ndef[3 + typeLen], card.c_str(), payloadLen);
 
-  String name = InputTextAction::popup("File name", "contact");
+  String name = InputTextAction::popup("File name", "vcard");
   if (!InputTextAction::wasCancelled()) _saveGeneratedNdef(ndef, ndefLen, name);
   delete[] ndef;
   _goNdefGenerate();

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -960,6 +960,13 @@ void PN532I2cScreen::_doReadNdef() {
     return;
   }
 
+  // NFC Forum Type 2 Capability Container (page 3).
+  // Byte 2 gives the data-area capacity in units of 8 bytes.
+  uint8_t cc[4] = {};
+  if (_nfc->mifareultralight_ReadPage(3, cc) && cc[0] == 0xE1) {
+    _ndefCapacity = (size_t)cc[2] * 8;
+  }
+
   // Type 2 Tag user memory starts at page 4. Read a conservative 60 pages
   // (240 bytes), enough for common short NDEF records and matching the current
   // UniGeek Ultralight page range.
@@ -1044,15 +1051,19 @@ void PN532I2cScreen::_showNdefResult(const uint8_t* uid, uint8_t uidLen,
   }
 
   char lenBuf[24];
+  char capBuf[24];
+  char freeBuf[24];
+
   snprintf(lenBuf, sizeof(lenBuf), "%u bytes", (unsigned)ndefLen);
   _pushRow("NDEF Size", lenBuf);
 
   if (_ndefCapacity > 0) {
-    char capBuf[24];
-    char freeBuf[24];
+    const size_t freeBytes =
+        (_ndefCapacity > ndefLen) ? (_ndefCapacity - ndefLen) : 0;
+
     snprintf(capBuf, sizeof(capBuf), "%u bytes", (unsigned)_ndefCapacity);
-    size_t freeBytes = (_ndefCapacity > ndefLen) ? (_ndefCapacity - ndefLen) : 0;
     snprintf(freeBuf, sizeof(freeBuf), "%u bytes", (unsigned)freeBytes);
+
     _pushRow("Capacity", capBuf);
     _pushRow("Free", freeBuf);
   }
@@ -2011,7 +2022,6 @@ void PN532I2cScreen::_doEraseNdef() {
     return;
   }
 
-  _ndefCapacity = (size_t)cc[2] * 8;
 
   // Logical NDEF erase:
   // 03 = NDEF Message TLV

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -221,7 +221,9 @@ void PN532I2cScreen::onItemSelected(uint8_t index) {
     case STATE_NDEF_WRITE_MENU:
       if (index == 0) _doWriteNdefText();
       else if (index == 1) _doWriteNdefUrl();
-      else if (index == 2) _doWriteNdefFromFile();
+      else if (index == 2) _doWriteNdefEmail();
+      else if (index == 3) _doWriteNdefPhone();
+      else if (index == 4) _doWriteNdefFromFile();
       break;
     case STATE_NDEF_FILE_SELECT:
       _doWriteNdefFileSelected(index);
@@ -391,7 +393,7 @@ void PN532I2cScreen::_goUltralight() {
 
 void PN532I2cScreen::_goNdefWrite() {
   _state = STATE_NDEF_WRITE_MENU;
-  setItems(_ndefWriteItems, 3);
+  setItems(_ndefWriteItems, 5);
   render();
 }
 
@@ -488,6 +490,71 @@ void PN532I2cScreen::_pushRow(const String& label, const String& value) {
   _rowValues[_rowCount] = value;
   _rows[_rowCount] = { _rowLabels[_rowCount].c_str(), _rowValues[_rowCount] };
   _rowCount++;
+}
+
+
+void PN532I2cScreen::_pushWrappedRow(const String& label, const String& value) {
+  if (value.length() == 0) {
+    _pushRow(label, "");
+    return;
+  }
+
+  // ScrollListView uses the built-in size-1 font. Keep enough room for the
+  // label on the first row; continuation rows can use almost the full width.
+  // Using conservative character widths avoids overlap/clipping without
+  // changing ScrollListView globally.
+  int totalChars = (bodyW() - 10) / 6;
+  if (totalChars < 12) totalChars = 12;
+
+  int firstChars = totalChars - (int)label.length() - 2;
+  if (firstChars < 8) firstChars = 8;
+
+  int pos = 0;
+  bool first = true;
+
+  while (pos < (int)value.length() && _rowCount < MAX_ROWS) {
+    while (pos < (int)value.length() &&
+           (value[pos] == ' ' || value[pos] == '\n' || value[pos] == '\r' || value[pos] == '\t')) {
+      pos++;
+    }
+    if (pos >= (int)value.length()) break;
+
+    const int maxChars = first ? firstChars : totalChars;
+    int end = pos + maxChars;
+    if (end > (int)value.length()) end = value.length();
+
+    // Respect explicit newlines.
+    int newline = value.indexOf('\n', pos);
+    if (newline >= pos && newline < end) {
+      end = newline;
+    } else if (end < (int)value.length()) {
+      // Prefer a word boundary. For URLs / very long tokens there may be no
+      // spaces, in which case the hard character boundary is used.
+      int split = -1;
+      for (int i = end; i > pos; --i) {
+        if (value[i - 1] == ' ' || value[i - 1] == '\t') {
+          split = i - 1;
+          break;
+        }
+      }
+      if (split > pos) end = split;
+    }
+
+    if (end <= pos) end = min(pos + maxChars, (int)value.length());
+
+    String part = value.substring(pos, end);
+    part.trim();
+    _pushRow(first ? label : "", part);
+
+    pos = end;
+    first = false;
+
+    // Skip whitespace/newline consumed at the wrap point.
+    while (pos < (int)value.length() &&
+           (value[pos] == ' ' || value[pos] == '\n' || value[pos] == '\r' || value[pos] == '\t')) {
+      pos++;
+    }
+  }
 }
 
 std::pair<size_t, size_t> PN532I2cScreen::_mfDims(uint8_t sak) const {
@@ -1171,7 +1238,7 @@ void PN532I2cScreen::_showNdefResult(const uint8_t* uid, uint8_t uidLen,
       if (!utf16) {
         String text;
         for (size_t i = 1 + langLen; i < payloadLen; i++) text += (char)payload[i];
-        _pushRow("Text", text);
+        _pushWrappedRow("Text", text);
       } else {
         _pushRow("Text", "(UTF-16 raw)");
         uint8_t rawLen = (uint8_t)(payloadLen < 32 ? payloadLen : 32);
@@ -1185,7 +1252,7 @@ void PN532I2cScreen::_showNdefResult(const uint8_t* uid, uint8_t uidLen,
     for (size_t i = 1; i < payloadLen; i++) uri += (char)payload[i];
 
     _pushRow("Record", "URI");
-    _pushRow("URI", uri);
+    _pushWrappedRow("URI", uri);
   }
   else {
     _pushRow("Record", "Unsupported");
@@ -1798,6 +1865,87 @@ void PN532I2cScreen::_doWriteNdefUrl() {
   delete[] ndef;
   _goNdefParent();
 }
+
+void PN532I2cScreen::_doWriteNdefEmail() {
+  String email = InputTextAction::popup("Enter email", "");
+  if (InputTextAction::wasCancelled() || email.length() == 0) {
+    _goNdefWrite();
+    return;
+  }
+
+  String uri = email.startsWith("mailto:") ? email : ("mailto:" + email);
+
+  uint8_t prefix = 0x06;  // "mailto:"
+  const char* body = uri.c_str() + 7;
+  size_t bodyLen = strlen(body);
+  size_t payloadLen = 1 + bodyLen;
+  size_t ndefLen = 4 + payloadLen;
+
+  if (ndefLen > MAX_NDEF_BYTES || payloadLen > 255) {
+    ShowStatusAction::show("Email too long");
+    _goNdefWrite();
+    return;
+  }
+
+  uint8_t* ndef = new uint8_t[ndefLen];
+  if (!ndef) {
+    ShowStatusAction::show("Out of memory");
+    _goNdefWrite();
+    return;
+  }
+
+  ndef[0] = 0xD1;                  // MB | ME | SR | TNF=Well Known
+  ndef[1] = 0x01;                  // Type length
+  ndef[2] = (uint8_t)payloadLen;
+  ndef[3] = 'U';                   // URI record
+  ndef[4] = prefix;
+  memcpy(&ndef[5], body, bodyLen);
+
+  _writeNdefRecord(ndef, ndefLen);
+  delete[] ndef;
+  _goNdefParent();
+}
+
+void PN532I2cScreen::_doWriteNdefPhone() {
+  String phone = InputTextAction::popup("Enter phone", "");
+  if (InputTextAction::wasCancelled() || phone.length() == 0) {
+    _goNdefWrite();
+    return;
+  }
+
+  String uri = phone.startsWith("tel:") ? phone : ("tel:" + phone);
+
+  uint8_t prefix = 0x05;  // "tel:"
+  const char* body = uri.c_str() + 4;
+  size_t bodyLen = strlen(body);
+  size_t payloadLen = 1 + bodyLen;
+  size_t ndefLen = 4 + payloadLen;
+
+  if (ndefLen > MAX_NDEF_BYTES || payloadLen > 255) {
+    ShowStatusAction::show("Phone too long");
+    _goNdefWrite();
+    return;
+  }
+
+  uint8_t* ndef = new uint8_t[ndefLen];
+  if (!ndef) {
+    ShowStatusAction::show("Out of memory");
+    _goNdefWrite();
+    return;
+  }
+
+  ndef[0] = 0xD1;                  // MB | ME | SR | TNF=Well Known
+  ndef[1] = 0x01;                  // Type length
+  ndef[2] = (uint8_t)payloadLen;
+  ndef[3] = 'U';                   // URI record
+  ndef[4] = prefix;
+  memcpy(&ndef[5], body, bodyLen);
+
+  _writeNdefRecord(ndef, ndefLen);
+  delete[] ndef;
+  _goNdefParent();
+}
+
 
 
 

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -1795,20 +1795,33 @@ void PN532I2cScreen::_showNdefActions() {
 }
 
 void PN532I2cScreen::_doWriteCurrentNdef() {
-  if (!_hasNdef) {
-    ShowStatusAction::show("No NDEF in memory");
+  if (!_hasNdef || _ndefLen == 0) {
+    ShowStatusAction::show("No NDEF loaded");
     render();
     return;
   }
 
-  if (_ndefLen == 0) {
-    ShowStatusAction::show("NDEF is empty");
+  static const InputSelectAction::Option targets[] = {
+    {"Ultralight / NTAG", "ul"},
+    {"MIFARE Classic",    "mfc"},
+  };
+
+  const char* choice =
+      InputSelectAction::popup("Write to Tag", targets, 2, nullptr);
+
+  if (!choice) {
     render();
     return;
   }
 
-  _writeNdefRecord(_ndefBuf, _ndefLen);
-  _state = STATE_NDEF_RESULT;
+  if (strcmp(choice, "ul") == 0) {
+    _writeUltralightNdefRecord(_ndefBuf, _ndefLen);
+  } else if (strcmp(choice, "mfc") == 0) {
+    _writeClassicNdefRecord(_ndefBuf, _ndefLen);
+  }
+
+  // Keep the NDEF result/action context tied to the source tag.
+  // The selected write target is deliberately independent of _ndefTarget.
   render();
 }
 

--- a/firmware/src/screens/module/PN532I2cScreen.cpp
+++ b/firmware/src/screens/module/PN532I2cScreen.cpp
@@ -277,12 +277,12 @@ void PN532I2cScreen::onBack() {
       _goNdefParent();
       break;
     case STATE_NDEF_FILE_SELECT:
-      if (_ndefPickDir == _dumpPath || _ndefPickDir.length() == 0) {
+      if (_ndefPickDir == "/" || _ndefPickDir.length() == 0) {
         _ndefPickDir = "";
         _goNdefWrite();
       } else {
         int slash = _ndefPickDir.lastIndexOf('/');
-        _ndefPickDir = (slash > 0) ? _ndefPickDir.substring(0, slash) : _dumpPath;
+        _ndefPickDir = (slash > 0) ? _ndefPickDir.substring(0, slash) : "/";
         _doWriteNdefFromFile();
       }
       break;
@@ -2070,16 +2070,9 @@ void PN532I2cScreen::_doWriteNdefFromFile() {
 
   _state = STATE_NDEF_FILE_SELECT;
   if (_ndefPickDir.length() == 0) _ndefPickDir = _dumpPath;
-  _browser.root = _dumpPath;
+  _browser.root = "/";
 
   uint8_t n = _browser.load(this, _ndefPickDir, ".ndef");
-  if (n == 0 && _ndefPickDir == _dumpPath) {
-    ShowStatusAction::show("No .ndef files");
-    _ndefPickDir = "";
-    _goNdefWrite();
-    return;
-  }
-
   setItems(_browser.items(), n);
   render();
 }

--- a/firmware/src/screens/module/PN532I2cScreen.h
+++ b/firmware/src/screens/module/PN532I2cScreen.h
@@ -104,9 +104,11 @@ private:
     {"URL Record"},
   };
 
-  ListItem _ndefWriteItems[3] = {
+  ListItem _ndefWriteItems[5] = {
     {"Text"},
     {"URL"},
+    {"Email"},
+    {"Phone"},
     {"From File"},
   };
 
@@ -158,6 +160,8 @@ private:
   void _goNdefParent();
   void _doWriteNdefText();
   void _doWriteNdefUrl();
+  void _doWriteNdefEmail();
+  void _doWriteNdefPhone();
   void _doWriteNdefFromFile();
   void _doWriteNdefFileSelected(uint8_t fileIndex);
   void _showNdefActions();
@@ -185,5 +189,6 @@ private:
   const char* _inferType(uint8_t sak, uint16_t atqa) const;
   bool _scanCardOrShow(uint32_t timeoutMs);
   void _pushRow(const String& label, const String& value);
+  void _pushWrappedRow(const String& label, const String& value);
   void _resetRows();
 };

--- a/firmware/src/screens/module/PN532I2cScreen.h
+++ b/firmware/src/screens/module/PN532I2cScreen.h
@@ -37,6 +37,7 @@ private:
     STATE_NDEF_WRITE_MENU,
     STATE_NDEF_RESULT,
     STATE_NDEF_FILE_SELECT,
+    STATE_NDEF_GENERATE_MENU,
   };
 
   State_e      _state    = STATE_MAIN_MENU;
@@ -67,12 +68,13 @@ private:
   String _rowValues[MAX_ROWS];
   uint16_t _rowCount = 0;
 
-  ListItem _mainItems[5] = {
+  ListItem _mainItems[6] = {
     {"Scan ISO14443A"},
     {"MIFARE Classic"},
     {"MIFARE Ultralight"},
     {"Magic Card"},
     {"Firmware Info"},
+    {"Generate NDEF Record"},
   };
 
   ListItem _mfItems[7] = {
@@ -110,6 +112,14 @@ private:
     {"Email"},
     {"Phone"},
     {"From File"},
+  };
+
+  ListItem _ndefGenerateItems[5] = {
+    {"Text"},
+    {"URL"},
+    {"vCard"},
+    {"Phone"},
+    {"Email"},
   };
 
   // MIFARE dump image — filled by _doDumpMemory(), saved by _doSaveDump()
@@ -157,11 +167,18 @@ private:
   void _showNdefResult(const uint8_t* uid, uint8_t uidLen,
                        const uint8_t* ndef, size_t ndefLen);
   void _goNdefWrite();
+  void _goNdefGenerate();
   void _goNdefParent();
   void _doWriteNdefText();
   void _doWriteNdefUrl();
   void _doWriteNdefEmail();
   void _doWriteNdefPhone();
+  void _doGenerateNdefText();
+  void _doGenerateNdefUrl();
+  void _doGenerateNdefVcard();
+  void _doGenerateNdefPhone();
+  void _doGenerateNdefEmail();
+  bool _saveGeneratedNdef(const uint8_t* ndef, size_t ndefLen, const String& suggestedName);
   void _doWriteNdefFromFile();
   void _doWriteNdefFileSelected(uint8_t fileIndex);
   void _showNdefActions();

--- a/firmware/src/screens/module/PN532I2cScreen.h
+++ b/firmware/src/screens/module/PN532I2cScreen.h
@@ -106,11 +106,12 @@ private:
     {"URL Record"},
   };
 
-  ListItem _ndefWriteItems[5] = {
+  ListItem _ndefWriteItems[6] = {
     {"Text"},
     {"URL"},
-    {"Email"},
     {"Phone"},
+    {"Email"},
+    {"vCard"},
     {"From File"},
   };
 
@@ -175,6 +176,7 @@ private:
   void _doWriteNdefUrl();
   void _doWriteNdefEmail();
   void _doWriteNdefPhone();
+  void _doWriteNdefVcard();
   void _doGenerateNdefText();
   void _doGenerateNdefUrl();
   void _doGenerateNdefVcard();

--- a/firmware/src/screens/module/PN532I2cScreen.h
+++ b/firmware/src/screens/module/PN532I2cScreen.h
@@ -34,6 +34,9 @@ private:
     STATE_RAW_RESULT,
     STATE_EMULATE,
     STATE_NTAG_MENU,
+    STATE_NDEF_WRITE_MENU,
+    STATE_NDEF_RESULT,
+    STATE_NDEF_FILE_SELECT,
   };
 
   State_e      _state    = STATE_MAIN_MENU;
@@ -64,13 +67,12 @@ private:
   String _rowValues[MAX_ROWS];
   uint16_t _rowCount = 0;
 
-  ListItem _mainItems[6] = {
+  ListItem _mainItems[5] = {
     {"Scan ISO14443A"},
     {"MIFARE Classic"},
     {"MIFARE Ultralight"},
     {"Magic Card"},
     {"Firmware Info"},
-    {"NTAG Emulate"},
   };
 
   ListItem _mfItems[4] = {
@@ -80,7 +82,10 @@ private:
     {"Dictionary Attack"},
   };
 
-  ListItem _ulItems[2] = {
+  ListItem _ulItems[5] = {
+    {"Read NDEF"},
+    {"Write NDEF"},
+    {"Erase NDEF"},
     {"Read All Pages"},
     {"Write Page"},
   };
@@ -96,10 +101,23 @@ private:
     {"URL Record"},
   };
 
+  ListItem _ndefWriteItems[3] = {
+    {"Text"},
+    {"URL"},
+    {"From File"},
+  };
+
   // MIFARE dump image — filled by _doDumpMemory(), saved by _doSaveDump()
   static constexpr const char* _dumpPath = "/unigeek/nfc/dumps";
   uint8_t  _dumpImg[1024] = {};
   bool     _hasDump = false;
+
+  // Raw NDEF message retained after Read NDEF (without the Type 2 TLV wrapper).
+  static constexpr size_t MAX_NDEF_BYTES = 254;
+  uint8_t  _ndefBuf[MAX_NDEF_BYTES] = {};
+  size_t   _ndefLen = 0;
+  bool     _hasNdef = false;
+  String   _ndefPickDir;
 
   static constexpr const char* _dictPath = "/unigeek/nfc/dictionaries";
   BrowseFileView _browser;
@@ -122,6 +140,17 @@ private:
   void _doDictionaryAttackWithFile(uint8_t fileIndex);
   void _doUltralightDump();
   void _doUltralightWrite();
+  void _doReadNdef();
+  void _goNdefWrite();
+  void _doWriteNdefText();
+  void _doWriteNdefUrl();
+  void _doWriteNdefFromFile();
+  void _doWriteNdefFileSelected(uint8_t fileIndex);
+  void _showNdefActions();
+  void _doSaveNdef();
+  void _doWriteCurrentNdef();
+  void _doEraseNdef();
+  bool _writeNdefRecord(const uint8_t* ndef, size_t ndefLen);
   void _doDetectGen1a();
   void _doGen3SetUid();
   void _doGen3LockUid();

--- a/firmware/src/screens/module/PN532I2cScreen.h
+++ b/firmware/src/screens/module/PN532I2cScreen.h
@@ -125,6 +125,7 @@ private:
   static constexpr size_t MAX_NDEF_BYTES = 254;
   uint8_t  _ndefBuf[MAX_NDEF_BYTES] = {};
   size_t   _ndefLen = 0;
+  size_t   _ndefCapacity = 0;
   bool     _hasNdef = false;
   String   _ndefPickDir;
 

--- a/firmware/src/screens/module/PN532I2cScreen.h
+++ b/firmware/src/screens/module/PN532I2cScreen.h
@@ -142,6 +142,7 @@ private:
   size_t   _ndefLen = 0;
   size_t   _ndefCapacity = 0;
   bool     _hasNdef = false;
+  bool     _ndefFilePreview = false;
   String   _ndefPickDir;
 
   static constexpr const char* _dictPath = "/unigeek/nfc/dictionaries";

--- a/firmware/src/screens/module/PN532I2cScreen.h
+++ b/firmware/src/screens/module/PN532I2cScreen.h
@@ -75,7 +75,10 @@ private:
     {"Firmware Info"},
   };
 
-  ListItem _mfItems[4] = {
+  ListItem _mfItems[7] = {
+    {"Read NDEF"},
+    {"Write NDEF"},
+    {"Erase NDEF"},
     {"Authenticate"},
     {"Dump Memory"},
     {"Discovered Keys"},
@@ -112,7 +115,13 @@ private:
   uint8_t  _dumpImg[1024] = {};
   bool     _hasDump = false;
 
-  // Raw NDEF message retained after Read NDEF (without the Type 2 TLV wrapper).
+  enum NdefTarget_e {
+    NDEF_TARGET_ULTRALIGHT,
+    NDEF_TARGET_MIFARE_CLASSIC,
+  };
+  NdefTarget_e _ndefTarget = NDEF_TARGET_ULTRALIGHT;
+
+  // Raw NDEF message retained after Read NDEF (without the tag-specific TLV wrapper).
   static constexpr size_t MAX_NDEF_BYTES = 254;
   uint8_t  _ndefBuf[MAX_NDEF_BYTES] = {};
   size_t   _ndefLen = 0;
@@ -141,7 +150,11 @@ private:
   void _doUltralightDump();
   void _doUltralightWrite();
   void _doReadNdef();
+  void _doReadClassicNdef();
+  void _showNdefResult(const uint8_t* uid, uint8_t uidLen,
+                       const uint8_t* ndef, size_t ndefLen);
   void _goNdefWrite();
+  void _goNdefParent();
   void _doWriteNdefText();
   void _doWriteNdefUrl();
   void _doWriteNdefFromFile();
@@ -150,7 +163,14 @@ private:
   void _doSaveNdef();
   void _doWriteCurrentNdef();
   void _doEraseNdef();
+  void _doEraseClassicNdef();
   bool _writeNdefRecord(const uint8_t* ndef, size_t ndefLen);
+  bool _writeUltralightNdefRecord(const uint8_t* ndef, size_t ndefLen);
+  bool _writeClassicNdefRecord(const uint8_t* ndef, size_t ndefLen);
+  bool _classicNdefSectors(uint8_t* sectors, size_t maxSectors, size_t& count);
+  bool _classicAuthSector(uint8_t sector, const uint8_t key[6]);
+  bool _classicReadNdefArea(const uint8_t* sectors, size_t sectorCount,
+                            uint8_t*& area, size_t& areaLen);
   void _doDetectGen1a();
   void _doGen3SetUid();
   void _doGen3LockUid();

--- a/firmware/src/screens/module/PN532I2cScreen.h
+++ b/firmware/src/screens/module/PN532I2cScreen.h
@@ -117,12 +117,14 @@ private:
   ListItem _ndefGenerateItems[5] = {
     {"Text"},
     {"URL"},
-    {"vCard"},
     {"Phone"},
     {"Email"},
+    {"vCard"},
   };
 
   // MIFARE dump image — filled by _doDumpMemory(), saved by _doSaveDump()
+  static constexpr const char* _nfcPath  = "/unigeek/nfc";
+  static constexpr const char* _ndefPath = "/unigeek/nfc/ndefs";
   static constexpr const char* _dumpPath = "/unigeek/nfc/dumps";
   uint8_t  _dumpImg[1024] = {};
   bool     _hasDump = false;

--- a/firmware/src/ui/actions/InputNumberAction.h
+++ b/firmware/src/ui/actions/InputNumberAction.h
@@ -74,7 +74,7 @@ private:
 
   void _buildSets() {
     // 3 cols × 5 rows = 15 items
-    // rows 0-2: 1-9  row 3: dummy 0 dummy  row 4: CNCL DEL SAVE
+    // rows 0-2: 1-9  row 3: dummy 0 dummy  row 4: BKSP SAVE EXIT
     static constexpr const char* d[] = { "1","2","3","4","5","6","7","8","9" };
     _setCount = 0;
     for (int i = 0; i < 9; i++)
@@ -82,9 +82,9 @@ private:
     _sets[_setCount++] = { "",     false, DigitSet::ACT_DEL    };  // dummy
     _sets[_setCount++] = { "0",    false, DigitSet::ACT_DEL    };
     _sets[_setCount++] = { "",     false, DigitSet::ACT_DEL    };  // dummy
-    _sets[_setCount++] = { "CNCL", true,  DigitSet::ACT_CANCEL };
-    _sets[_setCount++] = { "DEL",  true,  DigitSet::ACT_DEL    };
+    _sets[_setCount++] = { "BKSP", true,  DigitSet::ACT_DEL    };
     _sets[_setCount++] = { "SAVE", true,  DigitSet::ACT_SAVE   };
+    _sets[_setCount++] = { "EXIT", true,  DigitSet::ACT_CANCEL };
   }
 
   bool _validate() {
@@ -324,7 +324,7 @@ private:
       sp.setTextColor(TFT_WHITE, theme);
     } else {
       sp.drawRoundRect(1, 1, cW - 2, cH - 2, 3, 0x2104);
-      sp.setTextColor(s.isAction ? TFT_CYAN : TFT_LIGHTGREY, TFT_BLACK);
+      sp.setTextColor(s.isAction ? TFT_WHITE : TFT_LIGHTGREY, TFT_BLACK);
     }
     sp.drawString(s.label, cW / 2, cH / 2);
     sp.pushSprite(col * cW, hdr + row * cH);

--- a/firmware/src/ui/actions/InputTextAction.h
+++ b/firmware/src/ui/actions/InputTextAction.h
@@ -33,6 +33,12 @@ private:
     SP_COUNT
   };
 
+  enum TextPage : uint8_t {
+    PAGE_ABC = 0,
+    PAGE_SYM1,
+    PAGE_SYM2
+  };
+
   enum SpecialNum {
     SPN_SAVE = 0,
     SPN_DELETE,
@@ -40,7 +46,7 @@ private:
     SPN_COUNT
   };
 
-  static constexpr int      MAX_SETS   = 20;
+  static constexpr int      MAX_SETS   = 60;
   static constexpr uint32_t COMMIT_MS  = 1000;
   static constexpr uint32_t BLINK_MS   = 500;
   static constexpr int      PAD        = 4;
@@ -64,6 +70,8 @@ private:
   String      _pendingChar;
 
   CharSet     _sets[MAX_SETS];
+  char        _keyChars[30][3]  = {};
+  char        _keyLabels[30][2] = {};
   int         _setCount    = 0;
   int         _scrollPos   = 0;
 
@@ -73,6 +81,7 @@ private:
   Mode        _mode        = INPUT_TEXT;
   bool        _capsLock    = false;
   bool        _symbolMode  = false;
+  TextPage    _page        = PAGE_ABC;
   bool        _done        = false;
   bool        _cancelled   = false;
 
@@ -115,27 +124,70 @@ private:
       _sets[_setCount++] = { nullptr, "",     false, SP_SAVE   };  // spacer
       _sets[_setCount++] = { nullptr, "SAVE", true,  SP_SAVE   };
     } else {
-      static constexpr const char* charLabels[] = {
-        " 0",    ",.1",   "abc2",  "def3",  "ghi4",
-        "jkl5",  "mno6",  "pqrs7", "tuv8",  "wxyz9",
-      };
-      static constexpr const char* symbolLabels[] = {
-        " ",     ",.'- ", "*/\\@", "+-=_",  ":;?",
-        "!$#",   "\"&%|", "()[]",  "<>{}",  "^~`",
+      // Compact 6x5 grid optimized for small displays.
+      // Three ASCII pages: ABC -> SYM1 -> SYM2 -> ABC.
+      struct KeyPair {
+        char normal;
+        char shifted;
       };
 
-      const char* const* sets = _symbolMode ? symbolLabels : charLabels;
-      for (int i = 0; i < 10; i++) {
-        _sets[_setCount++] = { sets[i], sets[i], false, SP_SAVE };
+      static constexpr KeyPair alphaKeys[30] = {
+        {'a','A'}, {'b','B'}, {'c','C'}, {'d','D'}, {'e','E'}, {'f','F'},
+        {'g','G'}, {'h','H'}, {'i','I'}, {'j','J'}, {'k','K'}, {'l','L'},
+        {'m','M'}, {'n','N'}, {'o','O'}, {'p','P'}, {'q','Q'}, {'r','R'},
+        {'s','S'}, {'t','T'}, {'u','U'}, {'v','V'}, {'w','W'}, {'x','X'},
+        {'y','Y'}, {'z','Z'}, {'.','.'}, {':',':'}, {'/','/'}, {'-','-'},
+      };
+
+      static constexpr KeyPair sym1Keys[30] = {
+        {'1','1'}, {'2','2'}, {'3','3'}, {'4','4'}, {'5','5'}, {'6','6'},
+        {'7','7'}, {'8','8'}, {'9','9'}, {'0','0'}, {'@','@'}, {'_','_'},
+        {'!','!'}, {'?','?'}, {',',','}, {';',';'}, {'+','+'}, {'=','='},
+        {'*','*'}, {'#','#'}, {'$','$'}, {'%','%'}, {'&','&'}, {'|','|'},
+        {'\\','\\'}, {'\'','\''}, {'"','"'}, {'`','`'}, {'~','~'}, {'^','^'},
+      };
+
+      // SYM2 intentionally contains only delimiter pairs; unused cells remain blank.
+      static constexpr KeyPair sym2Keys[8] = {
+        {'(', '('}, {')', ')'}, {'[', '['}, {']', ']'}, {'{', '{'}, {'}', '}'},
+        {'<', '<'}, {'>', '>'},
+      };
+
+      const KeyPair* keys = alphaKeys;
+      int keyCount = 30;
+      if (_page == PAGE_SYM1) {
+        keys = sym1Keys;
+      } else if (_page == PAGE_SYM2) {
+        keys = sym2Keys;
+        keyCount = 8;
       }
 
-      static constexpr const char* specialLabels[SP_COUNT] = {
-        "CNCL", "DEL", "CAPS", "SYM", "SAVE"
+      // Always reserve the full 6x5 character grid. Blank cells on SYM2 are
+      // represented by null character sets and are skipped by selection.
+      for (int i = 0; i < 30; i++) {
+        if (i < keyCount) {
+          _keyChars[i][0] = keys[i].normal;
+          _keyChars[i][1] = keys[i].shifted;
+          _keyChars[i][2] = '\0';
+
+          _keyLabels[i][0] = keys[i].normal;
+          _keyLabels[i][1] = '\0';
+
+          _sets[_setCount++] = { _keyChars[i], _keyLabels[i], false, SP_SAVE };
+        } else {
+          _sets[_setCount++] = { nullptr, "", false, SP_SAVE };
+        }
+      }
+
+      // Six footer actions. The page button label is rendered dynamically.
+      static constexpr const char* specialLabels[6] = {
+        "SYM1", "CAPS", "SPACE", "DEL", "SAVE", "EXIT"
       };
-      static constexpr Special specialMap[SP_COUNT] = {
-        SP_CANCEL, SP_DELETE, SP_CAPS, SP_SYMBOL, SP_SAVE
+      static constexpr Special specialMap[6] = {
+        SP_SYMBOL, SP_CAPS, SP_SYMBOL, SP_DELETE, SP_SAVE, SP_CANCEL
       };
-      for (int i = 0; i < SP_COUNT; i++) {
+
+      for (int i = 0; i < 6; i++) {
         _sets[_setCount++] = { nullptr, specialLabels[i], true, specialMap[i] };
       }
     }
@@ -173,10 +225,35 @@ private:
 
   // ── grid scroll mode ────────────────────────────────────────────────────────
 
-  int _gridCols()  const { return 5; }
-  int _gridRows()  const { return (_setCount + _gridCols() - 1) / _gridCols(); }
-  int _gridCellW() const { return Uni.Lcd.width() / _gridCols(); }
-  int _gridCellH() const { return (Uni.Lcd.height() - HDR_H) / _gridRows(); }
+  int _gridCols() const { return _mode == INPUT_TEXT ? 6 : 5; }
+
+  int _charCount() const {
+    return _mode == INPUT_TEXT ? 30 : _setCount;
+  }
+
+  int _charRows() const {
+    return (_charCount() + _gridCols() - 1) / _gridCols();
+  }
+
+  int _actionCount() const {
+    return _mode == INPUT_TEXT ? 6 : 0;
+  }
+
+  int _gridRows() const {
+    return _charRows() + (_actionCount() > 0 ? 1 : 0);
+  }
+
+  int _gridCellW() const {
+    return Uni.Lcd.width() / _gridCols();
+  }
+
+  int _gridCellH() const {
+    return (Uni.Lcd.height() - HDR_H) / _gridRows();
+  }
+
+  int _actionCellW() const {
+    return _actionCount() > 0 ? Uni.Lcd.width() / _actionCount() : Uni.Lcd.width();
+  }
 
   String _runScroll() {
     _lastBlinkTime = millis();
@@ -207,7 +284,18 @@ private:
         int16_t tx = Uni.Nav->lastTouchX();
         int16_t ty = Uni.Nav->lastTouchY();
         if (tx >= 0 && ty >= HDR_H) {
-          int idx = (int)(ty - HDR_H) / _gridCellH() * _gridCols() + (int)tx / _gridCellW();
+          int relY = ty - HDR_H;
+          int row = relY / _gridCellH();
+          int idx = -1;
+
+          if (_mode == INPUT_TEXT && row >= _charRows()) {
+            int action = tx / _actionCellW();
+            if (action >= 6) action = 5;
+            idx = 30 + action;
+          } else {
+            idx = row * _gridCols() + tx / _gridCellW();
+          }
+
           if (idx >= 0 && idx < _setCount) {
             const CharSet& hit = _sets[idx];
             if (!hit.isSpecial && hit.chars == nullptr) { delay(10); continue; }
@@ -217,9 +305,10 @@ private:
               _scrollPos = idx;
             }
             bool pc = _capsLock, ps = _symbolMode;
+            TextPage pp = _page;
             _handleSelect();
             if (!_done && !_cancelled) {
-              if (pc != _capsLock || ps != _symbolMode) _drawFullGrid();
+              if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
               else { _drawGridCell(prev); _drawGridCell(_scrollPos); }
               _cursorVisible = true; _lastBlinkTime = millis();
               _drawGridInput();
@@ -231,27 +320,80 @@ private:
 #endif
 
       const bool nav4 = Uni.Nav->is4Way();
-      if (nav4 && dir == INavigation::DIR_UP) {
+
+      if (_mode == INPUT_TEXT && nav4 &&
+          (dir == INavigation::DIR_UP || dir == INavigation::DIR_DOWN)) {
+        _commitTap();
+
+        if (_scrollPos < 30) {
+          int col = _scrollPos % _gridCols();
+          int row = _scrollPos / _gridCols();
+
+          if (dir == INavigation::DIR_UP) {
+            if (row == 0) {
+              // Jump to the closest action button in the bottom row.
+              int a = (col * 6) / _gridCols();
+              if (a >= 6) a = 5;
+              _scrollPos = 30 + a;
+            } else {
+              _scrollPos -= _gridCols();
+            }
+          } else {
+            if (row == _charRows() - 1) {
+              int a = (col * 6) / _gridCols();
+              if (a >= 6) a = 5;
+              _scrollPos = 30 + a;
+            } else {
+              _scrollPos += _gridCols();
+            }
+          }
+        } else {
+          // From the action row, UP/DOWN returns to the bottom character row.
+          int a = _scrollPos - 30;
+          int col = (a * _gridCols()) / 6;
+          if (col >= _gridCols()) col = _gridCols() - 1;
+          _scrollPos = (_charRows() - 1) * _gridCols() + col;
+        }
+
+        // SYM2 has intentionally blank cells. If vertical navigation lands on
+        // one, move to the nearest valid character/action instead.
+        if (_scrollPos < 30 && _sets[_scrollPos].chars == nullptr) {
+          int col = _scrollPos % _gridCols();
+          if (_page == PAGE_SYM2 && col < 2) {
+            _scrollPos = 6 + col;  // < or >
+          } else {
+            _scrollPos = 30 + min(col, 5);
+          }
+        }
+
+      } else if (nav4 && dir == INavigation::DIR_UP) {
         _commitTap();
         do { _scrollPos = (_scrollPos - _gridCols() + _setCount) % _setCount; }
         while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+
       } else if (nav4 && dir == INavigation::DIR_DOWN) {
         _commitTap();
         do { _scrollPos = (_scrollPos + _gridCols()) % _setCount; }
         while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+
       } else if (dir == INavigation::DIR_LEFT || dir == INavigation::DIR_UP) {
         _commitTap();
-        do { _scrollPos = (_scrollPos - 1 + _setCount) % _setCount; }
-        while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+        do {
+          _scrollPos = (_scrollPos - 1 + _setCount) % _setCount;
+        } while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+
       } else if (dir == INavigation::DIR_RIGHT || dir == INavigation::DIR_DOWN) {
         _commitTap();
-        do { _scrollPos = (_scrollPos + 1) % _setCount; }
-        while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+        do {
+          _scrollPos = (_scrollPos + 1) % _setCount;
+        } while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+
       } else if (dir == INavigation::DIR_PRESS) {
         bool pc = _capsLock, ps = _symbolMode;
+        TextPage pp = _page;
         _handleSelect();
         if (!_done && !_cancelled) {
-          if (pc != _capsLock || ps != _symbolMode) _drawFullGrid();
+          if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
           else _drawGridCell(prev);
           _cursorVisible = true; _lastBlinkTime = millis();
           _drawGridInput();
@@ -302,13 +444,23 @@ private:
             _input.remove(_input.length() - 1);
           }
           break;
-        case SP_CAPS:   _capsLock = !_capsLock;         break;
+        case SP_CAPS:
+          _capsLock = !_capsLock;
+          break;
         case SP_SYMBOL:
-          _symbolMode  = !_symbolMode;
-          _buildSets();
-          _scrollPos   = 0;
-          _tapCount    = 0;
-          _pendingChar = "";
+          if (_mode == INPUT_TEXT && _scrollPos == 30) {
+            // Cycle text pages: ABC -> SYM1 -> SYM2 -> ABC.
+            if (_page == PAGE_ABC)       _page = PAGE_SYM1;
+            else if (_page == PAGE_SYM1) _page = PAGE_SYM2;
+            else                         _page = PAGE_ABC;
+
+            _symbolMode = (_page != PAGE_ABC);
+            _buildSets();
+            _scrollPos = 30;
+          } else {
+            // SPACE
+            _input += ' ';
+          }
           break;
         case SP_CANCEL: _cancelled = true;              break;
         default: break;
@@ -316,35 +468,70 @@ private:
     } else {
       const char* chars = s.chars;
       if (!chars || chars[0] == '\0') return;
-      int  len = strlen(chars);
-      if (len == 1) {
-        char c = chars[0];
-        if (_capsLock && isalpha(c)) c = toupper(c);
-        _input      += c;
+
+      if (_mode == INPUT_TEXT) {
+        // QWERTY keys insert immediately. chars[0] is normal, chars[1] shifted.
+        char c = (_page == PAGE_ABC && _capsLock && chars[1] != '\0')
+                   ? chars[1] : chars[0];
+        _input += c;
         _pendingChar = "";
-        _tapCount    = 0;
+        _tapCount = 0;
         _lastTapTime = 0;
       } else {
-        char c = chars[_tapCount % len];
-        if (_capsLock && isalpha(c)) c = toupper(c);
-        _pendingChar = String(c);
-        _tapCount++;
-        _lastTapTime = millis();
+        int len = strlen(chars);
+        if (len == 1) {
+          char c = chars[0];
+          if (_capsLock && isalpha(c)) c = toupper(c);
+          _input += c;
+          _pendingChar = "";
+          _tapCount = 0;
+          _lastTapTime = 0;
+        } else {
+          char c = chars[_tapCount % len];
+          if (_capsLock && isalpha(c)) c = toupper(c);
+          _pendingChar = String(c);
+          _tapCount++;
+          _lastTapTime = millis();
+        }
       }
     }
   }
 
   void _drawFullGrid() {
     auto& lcd = Uni.Lcd;
+    uint16_t theme = Config.getThemeColor();
+
     lcd.fillScreen(TFT_BLACK);
     lcd.setTextSize(1);
     lcd.setTextDatum(TL_DATUM);
-    lcd.setTextColor(TFT_YELLOW, TFT_BLACK);
+
+    // Match the rest of UniGeek: black canvas + current primary/theme colour
+    // for the active screen accent.
+    lcd.setTextColor(theme, TFT_BLACK);
     lcd.drawString(_title, PAD, PAD);
+
     int ix = PAD + lcd.textWidth(_title) + PAD;
-    if (_capsLock)   { lcd.setTextColor(TFT_GREEN, TFT_BLACK); lcd.drawString("CAPS", ix, PAD); ix += lcd.textWidth("CAPS") + PAD; }
-    if (_symbolMode) { lcd.setTextColor(TFT_CYAN,  TFT_BLACK); lcd.drawString("SYM",  ix, PAD); }
+    lcd.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+    if (_capsLock) {
+      lcd.drawString("CAPS", ix, PAD);
+      ix += lcd.textWidth("CAPS") + PAD;
+    }
+    if (_page == PAGE_SYM1) {
+      lcd.drawString("SYM1", ix, PAD);
+    } else if (_page == PAGE_SYM2) {
+      lcd.drawString("SYM2", ix, PAD);
+    }
+
+    // Thin theme separator, echoing the normal UniGeek screen chrome.
+    lcd.drawFastHLine(PAD, PAD + 10, lcd.width() - PAD * 2, theme);
+
     _drawGridInput();
+
+    if (_mode == INPUT_TEXT) {
+      int footerY = HDR_H + _charRows() * _gridCellH();
+      lcd.drawFastHLine(PAD, footerY, lcd.width() - PAD * 2, TFT_DARKGREY);
+    }
+
     for (int i = 0; i < _setCount; i++) _drawGridCell(i);
   }
 
@@ -354,7 +541,7 @@ private:
     Sprite sp(&lcd);
     sp.createSprite(iW, INP_H);
     sp.fillSprite(TFT_BLACK);
-    sp.drawRoundRect(0, 0, iW, INP_H, 2, TFT_DARKGREY);
+    sp.drawRoundRect(0, 0, iW, INP_H, 2, Config.getThemeColor());
     sp.setTextColor(TFT_WHITE, TFT_BLACK);
     sp.setTextDatum(TL_DATUM);
     String display = _input + _pendingChar;
@@ -369,8 +556,21 @@ private:
     if (idx < 0 || idx >= _setCount) return;
     auto&    lcd   = Uni.Lcd;
     uint16_t theme = Config.getThemeColor();
-    int cW  = _gridCellW(), cH = _gridCellH();
-    int col = idx % _gridCols(), row = idx / _gridCols();
+    int cH = _gridCellH();
+    int cW;
+    int col;
+    int row;
+
+    if (_mode == INPUT_TEXT && idx >= 30) {
+      cW = _actionCellW();
+      col = idx - 30;
+      row = _charRows();
+    } else {
+      cW = _gridCellW();
+      col = idx % _gridCols();
+      row = idx / _gridCols();
+    }
+
     bool sel = (idx == _scrollPos);
     const CharSet& s = _sets[idx];
 
@@ -386,17 +586,35 @@ private:
     Sprite sp(&lcd);
     sp.createSprite(cW, cH);
     sp.fillSprite(TFT_BLACK);
-    sp.setTextSize(1);
+
+    // Character cells have plenty of horizontal room in the 6-column layout.
+    // Draw them at 2x for legibility; keep footer/action labels at 1x so
+    // SAVE/CAPS/SPACE/DEL/EXIT continue to fit comfortably.
+    const bool largeKey = (_mode == INPUT_TEXT && !s.isSpecial);
+    sp.setTextSize(largeKey ? 2 : 1);
     sp.setTextDatum(MC_DATUM);
+
     if (sel) {
-      sp.fillRoundRect(1, 1, cW - 2, cH - 2, 3, theme);
+      sp.fillRoundRect(2, 2, cW - 4, cH - 4, 3, theme);
       sp.setTextColor(TFT_WHITE, theme);
     } else {
-      sp.drawRoundRect(1, 1, cW - 2, cH - 2, 3, 0x2104);
-      sp.setTextColor(s.isSpecial ? TFT_CYAN : TFT_LIGHTGREY, TFT_BLACK);
+      sp.drawRoundRect(2, 2, cW - 4, cH - 4, 3, TFT_DARKGREY);
+      sp.setTextColor(s.isSpecial ? TFT_WHITE : TFT_LIGHTGREY, TFT_BLACK);
     }
-    String lbl = String(s.label);
-    if (!s.isSpecial && _capsLock && _mode == INPUT_TEXT) lbl.toUpperCase();
+
+    String lbl;
+    if (!s.isSpecial && _mode == INPUT_TEXT && s.chars) {
+      char shown = (_page == PAGE_ABC && _capsLock && s.chars[1] != '\0')
+                     ? s.chars[1] : s.chars[0];
+      lbl = String(shown);
+    } else if (_mode == INPUT_TEXT && idx == 30) {
+      if (_page == PAGE_ABC)       lbl = "SYM1";
+      else if (_page == PAGE_SYM1) lbl = "SYM2";
+      else                         lbl = "ABC";
+    } else {
+      lbl = String(s.label);
+    }
+
     sp.drawString(lbl.c_str(), cW / 2, cH / 2);
     sp.pushSprite(col * cW, HDR_H + row * cH);
     sp.deleteSprite();

--- a/firmware/src/ui/actions/InputTextAction.h
+++ b/firmware/src/ui/actions/InputTextAction.h
@@ -11,7 +11,7 @@
 class InputTextAction
 {
 public:
-  enum Mode : uint8_t { INPUT_TEXT = 0, INPUT_IP_ADDRESS = 1, INPUT_HEX = 2 };
+  enum Mode : uint8_t { INPUT_TEXT = 0, INPUT_IP_ADDRESS = 1, INPUT_HEX = 2, INPUT_PHONE = 3 };
 
   static String popup(const char* title, const String& defaultValue = "", Mode mode = INPUT_TEXT) {
     InputTextAction action(title, defaultValue, mode);
@@ -29,6 +29,7 @@ private:
     SP_DELETE,
     SP_CAPS,
     SP_SYMBOL,
+    SP_SPACE,
     SP_CANCEL,
     SP_COUNT
   };
@@ -91,22 +92,23 @@ private:
     _setCount = 0;
 
     if (_mode == INPUT_HEX) {
-      // rows 0-2: 0-9, A-E  row 3: CNCL F · DEL SAVE
+      // rows 0-2: 0-9, A-E  row 3: F SPC BKSP SAVE EXIT
       static constexpr const char* hexDigits[] = {
         "0","1","2","3","4","5","6","7","8","9","A","B","C","D","E",
       };
       for (int i = 0; i < 15; i++)
         _sets[_setCount++] = { hexDigits[i], hexDigits[i], false, SP_SAVE };
-      _sets[_setCount++] = { nullptr, "CNCL", true,  SP_CANCEL };
       _sets[_setCount++] = { "F",     "F",    false, SP_SAVE   };
-      _sets[_setCount++] = { " ",     " ",    false, SP_SAVE   };
-      _sets[_setCount++] = { nullptr, "DEL",  true,  SP_DELETE };
+      _sets[_setCount++] = { nullptr, "SPC",  true,  SP_SPACE  };
+      _sets[_setCount++] = { nullptr, "BKSP", true,  SP_DELETE };
       _sets[_setCount++] = { nullptr, "SAVE", true,  SP_SAVE   };
+      _sets[_setCount++] = { nullptr, "EXIT", true,  SP_CANCEL };
     } else if (_mode == INPUT_IP_ADDRESS) {
       // rows 0-1: 0-9  row 2: CNCL · DEL SAVE
       static constexpr const char* ipDigits[] = {
         "0","1","2","3","4","5","6","7","8","9",
       };
+
       for (int i = 0; i < 10; i++)
         _sets[_setCount++] = { ipDigits[i], ipDigits[i], false, SP_SAVE };
       _sets[_setCount++] = { nullptr, "CNCL", true,  SP_CANCEL };
@@ -114,6 +116,23 @@ private:
       _sets[_setCount++] = { nullptr, "DEL",  true,  SP_DELETE };
       _sets[_setCount++] = { nullptr, "",     false, SP_SAVE   };  // spacer
       _sets[_setCount++] = { nullptr, "SAVE", true,  SP_SAVE   };
+    } else if (_mode == INPUT_PHONE) {
+      // rows 0-1: 0-9
+      // row 2: + - . * #
+      // row 3: ( ) BKSP SAVE EXIT
+      static constexpr const char* phoneChars[] = {
+        "0","1","2","3","4",
+        "5","6","7","8","9",
+        "+","-",".","*","#",
+        "(",")",
+      };
+
+      for (int i = 0; i < 17; i++)
+        _sets[_setCount++] = { phoneChars[i], phoneChars[i], false, SP_SAVE };
+
+      _sets[_setCount++] = { nullptr, "BKSP", true,  SP_DELETE };
+      _sets[_setCount++] = { nullptr, "SAVE", true,  SP_SAVE   };
+      _sets[_setCount++] = { nullptr, "EXIT", true,  SP_CANCEL };
     } else {
       static constexpr const char* charLabels[] = {
         " 0",    ",.1",   "abc2",  "def3",  "ghi4",
@@ -310,6 +329,9 @@ private:
           _tapCount    = 0;
           _pendingChar = "";
           break;
+        case SP_SPACE:
+          _input += ' ';
+          break;
         case SP_CANCEL: _cancelled = true;              break;
         default: break;
       }
@@ -393,7 +415,7 @@ private:
       sp.setTextColor(TFT_WHITE, theme);
     } else {
       sp.drawRoundRect(1, 1, cW - 2, cH - 2, 3, 0x2104);
-      sp.setTextColor(s.isSpecial ? TFT_CYAN : TFT_LIGHTGREY, TFT_BLACK);
+      sp.setTextColor(s.isSpecial ? TFT_WHITE : TFT_LIGHTGREY, TFT_BLACK);
     }
     String lbl = String(s.label);
     if (!s.isSpecial && _capsLock && _mode == INPUT_TEXT) lbl.toUpperCase();
@@ -438,6 +460,9 @@ private:
         } else if (c != '\0') {
           bool allow = _mode == INPUT_HEX    ? (isxdigit(c) || c == ' ')
                      : _mode == INPUT_IP_ADDRESS ? (isdigit(c) || c == '.')
+                     : _mode == INPUT_PHONE      ? (isdigit(c) || c == '+' || c == '-' ||
+                                                    c == '.' || c == '*' || c == '#' ||
+                                                    c == '(' || c == ')')
                      : true;
           if (allow) {
             if (_mode == INPUT_HEX && isalpha(c)) c = toupper(c);
@@ -475,7 +500,8 @@ private:
     lcd.setCursor(x + PAD, y + KB_H - PAD - 8);
     lcd.print(_mode == INPUT_HEX    ? "0-9 A-F SPACE + ENTER"
             : _mode == INPUT_IP_ADDRESS ? "0-9 . + ENTER to confirm"
-            :                         "Type + ENTER to confirm");
+            : _mode == INPUT_PHONE      ? "0-9 + - . * # ( ) + ENTER"
+            :                             "Type + ENTER to confirm");
   }
 
   void _drawInputKeyboard(bool cursorOn) {

--- a/firmware/src/ui/actions/InputTextAction.h
+++ b/firmware/src/ui/actions/InputTextAction.h
@@ -155,12 +155,12 @@ private:
         {'g','G'}, {'h','H'}, {'i','I'}, {'j','J'}, {'k','K'}, {'l','L'},
         {'m','M'}, {'n','N'}, {'o','O'}, {'p','P'}, {'q','Q'}, {'r','R'},
         {'s','S'}, {'t','T'}, {'u','U'}, {'v','V'}, {'w','W'}, {'x','X'},
-        {'y','Y'}, {'z','Z'}, {'.',':'}, {'/','\\'}, {'-','_'}, {'?','@'},
+        {'y','Y'}, {'z','Z'}, {'.',':'}, {',',';'}, {'-','_'}, {'/','?'},
       };
 
       static constexpr KeyPair symbolKeys[21] = {
-        {'1','!'}, {'2','|'}, {'3','#'}, {'4','$'}, {'5','%'}, {'6','^'},
-        {'7','&'}, {'8','*'}, {'9','+'}, {'0','='}, {',',';'}, {'\'','"'},
+        {'1','!'}, {'2','@'}, {'3','#'}, {'4','$'}, {'5','%'}, {'6','^'},
+        {'7','&'}, {'8','*'}, {'9','+'}, {'0','='}, {'\'','"'}, {'\\','|'},
         {'(', '('}, {')', ')'}, {'[', '['}, {']', ']'}, {'{', '{'}, {'}', '}'},
         {'<', '<'}, {'>', '>'}, {'`','~'},
       };
@@ -428,20 +428,27 @@ private:
         }
         delay(10); continue;
       } else if (dir == INavigation::DIR_BACK) {
-        // Mirror DEL: drop a pending multi-tap first, then chip away at the
-        // committed input, and only cancel once everything is empty.
-        if (_pendingChar.length() > 0) {
-          _pendingChar = "";
-          _tapCount    = 0;
-          _lastTapTime = 0;
-          _cursorVisible = true; _lastBlinkTime = millis();
+        if (_mode == INPUT_TEXT) {
+          // Physical Back toggles ABC <-> 123 on the standard keyboard.
+          // Other keyboard modes intentionally ignore Back.
+          _commitTap();
+
+          _page = (_page == PAGE_ABC) ? PAGE_SYM : PAGE_ABC;
+          _symbolMode = (_page == PAGE_SYM);
+          _buildSets();
+
+          // Keep the current cell when it exists on both pages.
+          // If it points to a blank SYM cell, move focus to ABC/123.
+          if (_scrollPos < 30 && _sets[_scrollPos].chars == nullptr) {
+            _scrollPos = 30;
+          } else if (_scrollPos >= _setCount) {
+            _scrollPos = 30;
+          }
+
+          _drawFullGrid();
+          _cursorVisible = true;
+          _lastBlinkTime = millis();
           _drawGridInput();
-        } else if (_input.length() > 0) {
-          _input.remove(_input.length() - 1);
-          _cursorVisible = true; _lastBlinkTime = millis();
-          _drawGridInput();
-        } else {
-          _cancelled = true;
         }
       }
 

--- a/firmware/src/ui/actions/InputTextAction.h
+++ b/firmware/src/ui/actions/InputTextAction.h
@@ -100,9 +100,9 @@ private:
     _setCount = 0;
 
     if (_mode == INPUT_HEX) {
-      // rows 0-2: 0-9, A-E  row 3: F SPACE BKSP SAVE EXIT
+      // rows 0-2: 1-9, 0, A-E  row 3: F SPACE BKSP SAVE EXIT
       static constexpr const char* hexDigits[] = {
-        "0","1","2","3","4","5","6","7","8","9","A","B","C","D","E",
+        "1","2","3","4","5","6","7","8","9","0","A","B","C","D","E",
       };
       for (int i = 0; i < 15; i++)
         _sets[_setCount++] = { hexDigits[i], hexDigits[i], false, SP_SAVE };
@@ -124,12 +124,12 @@ private:
       _sets[_setCount++] = { nullptr, "",     false, SP_SAVE   };  // spacer
       _sets[_setCount++] = { nullptr, "SAVE", true,  SP_SAVE   };
     } else if (_mode == INPUT_PHONE) {
-      // rows 0-1: 0-9
+      // rows 0-1: 1-9, 0
       // row 2: + - . * #
       // row 3: ( ) BKSP SAVE EXIT
       static constexpr const char* phoneChars[] = {
-        "0","1","2","3","4",
-        "5","6","7","8","9",
+        "1","2","3","4","5",
+        "6","7","8","9","0",
         "+","-",".","*","#",
         "(",")",
       };

--- a/firmware/src/ui/actions/InputTextAction.h
+++ b/firmware/src/ui/actions/InputTextAction.h
@@ -92,14 +92,14 @@ private:
     _setCount = 0;
 
     if (_mode == INPUT_HEX) {
-      // rows 0-2: 0-9, A-E  row 3: F SPC BKSP SAVE EXIT
+      // rows 0-2: 0-9, A-E  row 3: F SPACE BKSP SAVE EXIT
       static constexpr const char* hexDigits[] = {
         "0","1","2","3","4","5","6","7","8","9","A","B","C","D","E",
       };
       for (int i = 0; i < 15; i++)
         _sets[_setCount++] = { hexDigits[i], hexDigits[i], false, SP_SAVE };
       _sets[_setCount++] = { "F",     "F",    false, SP_SAVE   };
-      _sets[_setCount++] = { nullptr, "SPC",  true,  SP_SPACE  };
+      _sets[_setCount++] = { nullptr, "SPACE",  true,  SP_SPACE  };
       _sets[_setCount++] = { nullptr, "BKSP", true,  SP_DELETE };
       _sets[_setCount++] = { nullptr, "SAVE", true,  SP_SAVE   };
       _sets[_setCount++] = { nullptr, "EXIT", true,  SP_CANCEL };

--- a/firmware/src/ui/actions/InputTextAction.h
+++ b/firmware/src/ui/actions/InputTextAction.h
@@ -34,6 +34,11 @@ private:
     SP_COUNT
   };
 
+  enum TextPage : uint8_t {
+    PAGE_ABC = 0,
+    PAGE_SYM
+  };
+
   enum SpecialNum {
     SPN_SAVE = 0,
     SPN_DELETE,
@@ -41,7 +46,7 @@ private:
     SPN_COUNT
   };
 
-  static constexpr int      MAX_SETS   = 20;
+  static constexpr int      MAX_SETS   = 60;
   static constexpr uint32_t COMMIT_MS  = 1000;
   static constexpr uint32_t BLINK_MS   = 500;
   static constexpr int      PAD        = 4;
@@ -65,6 +70,8 @@ private:
   String      _pendingChar;
 
   CharSet     _sets[MAX_SETS];
+  char        _keyChars[36][3]  = {};
+  char        _keyLabels[36][2] = {};
   int         _setCount    = 0;
   int         _scrollPos   = 0;
 
@@ -74,6 +81,7 @@ private:
   Mode        _mode        = INPUT_TEXT;
   bool        _capsLock    = false;
   bool        _symbolMode  = false;
+  TextPage    _page        = PAGE_ABC;
   bool        _done        = false;
   bool        _cancelled   = false;
 
@@ -108,7 +116,6 @@ private:
       static constexpr const char* ipDigits[] = {
         "0","1","2","3","4","5","6","7","8","9",
       };
-
       for (int i = 0; i < 10; i++)
         _sets[_setCount++] = { ipDigits[i], ipDigits[i], false, SP_SAVE };
       _sets[_setCount++] = { nullptr, "CNCL", true,  SP_CANCEL };
@@ -134,27 +141,54 @@ private:
       _sets[_setCount++] = { nullptr, "SAVE", true,  SP_SAVE   };
       _sets[_setCount++] = { nullptr, "EXIT", true,  SP_CANCEL };
     } else {
-      static constexpr const char* charLabels[] = {
-        " 0",    ",.1",   "abc2",  "def3",  "ghi4",
-        "jkl5",  "mno6",  "pqrs7", "tuv8",  "wxyz9",
-      };
-      static constexpr const char* symbolLabels[] = {
-        " ",     ",.'- ", "*/\\@", "+-=_",  ":;?",
-        "!$#",   "\"&%|", "()[]",  "<>{}",  "^~`",
+      // Compact 6x6 grid optimized for small displays.
+      // Two ASCII pages: ABC <-> SYM.
+      struct KeyPair {
+        char normal;
+        char shifted;
       };
 
-      const char* const* sets = _symbolMode ? symbolLabels : charLabels;
-      for (int i = 0; i < 10; i++) {
-        _sets[_setCount++] = { sets[i], sets[i], false, SP_SAVE };
+      static constexpr KeyPair alphaKeys[36] = {
+        {'a','A'}, {'b','B'}, {'c','C'}, {'d','D'}, {'e','E'}, {'f','F'},
+        {'g','G'}, {'h','H'}, {'i','I'}, {'j','J'}, {'k','K'}, {'l','L'},
+        {'m','M'}, {'n','N'}, {'o','O'}, {'p','P'}, {'q','Q'}, {'r','R'},
+        {'s','S'}, {'t','T'}, {'u','U'}, {'v','V'}, {'w','W'}, {'x','X'},
+        {'y','Y'}, {'z','Z'}, {'.','.'}, {',',','}, {':',':'}, {';',';'},
+        {'?','?'}, {'!','!'}, {'-','-'}, {'_','_'}, {'/','/'}, {'\\','\\'},
+      };
+
+      static constexpr KeyPair symbolKeys[32] = {
+        {'1','1'}, {'2','2'}, {'3','3'}, {'4','4'}, {'5','5'}, {'6','6'},
+        {'7','7'}, {'8','8'}, {'9','9'}, {'0','0'}, {'@','@'}, {'#','#'},
+        {'$','$'}, {'%','%'}, {'^','^'}, {'&','&'}, {'*','*'}, {'|','|'},
+        {'+','+'}, {'=','='}, {'\'','\''}, {'"','"'}, {'`','`'}, {'~','~'},
+        {'(', '('}, {')', ')'}, {'[', '['}, {']', ']'}, {'{', '{'}, {'}', '}'},
+        {'<', '<'}, {'>', '>'},
+      };
+
+      const KeyPair* keys = (_page == PAGE_SYM) ? symbolKeys : alphaKeys;
+      const int keyCount = (_page == PAGE_SYM) ? 32 : 36;
+
+      for (int i = 0; i < 36; i++) {
+        if (i < keyCount) {
+          _keyChars[i][0] = keys[i].normal;
+          _keyChars[i][1] = keys[i].shifted;
+          _keyChars[i][2] = '\0';
+          _keyLabels[i][0] = keys[i].normal;
+          _keyLabels[i][1] = '\0';
+          _sets[_setCount++] = { _keyChars[i], _keyLabels[i], false, SP_SAVE };
+        } else {
+          _sets[_setCount++] = { nullptr, "", false, SP_SAVE };
+        }
       }
 
-      static constexpr const char* specialLabels[SP_COUNT] = {
-        "CNCL", "DEL", "CAPS", "SYM", "SAVE"
+      static constexpr const char* specialLabels[6] = {
+        "123", "CAPS", "SPACE", "BKSP", "SAVE", "EXIT"
       };
-      static constexpr Special specialMap[SP_COUNT] = {
-        SP_CANCEL, SP_DELETE, SP_CAPS, SP_SYMBOL, SP_SAVE
+      static constexpr Special specialMap[6] = {
+        SP_SYMBOL, SP_CAPS, SP_SYMBOL, SP_DELETE, SP_SAVE, SP_CANCEL
       };
-      for (int i = 0; i < SP_COUNT; i++) {
+      for (int i = 0; i < 6; i++) {
         _sets[_setCount++] = { nullptr, specialLabels[i], true, specialMap[i] };
       }
     }
@@ -192,10 +226,35 @@ private:
 
   // ── grid scroll mode ────────────────────────────────────────────────────────
 
-  int _gridCols()  const { return 5; }
-  int _gridRows()  const { return (_setCount + _gridCols() - 1) / _gridCols(); }
-  int _gridCellW() const { return Uni.Lcd.width() / _gridCols(); }
-  int _gridCellH() const { return (Uni.Lcd.height() - HDR_H) / _gridRows(); }
+  int _gridCols() const { return _mode == INPUT_TEXT ? 6 : 5; }
+
+  int _charCount() const {
+    return _mode == INPUT_TEXT ? 36 : _setCount;
+  }
+
+  int _charRows() const {
+    return (_charCount() + _gridCols() - 1) / _gridCols();
+  }
+
+  int _actionCount() const {
+    return _mode == INPUT_TEXT ? 6 : 0;
+  }
+
+  int _gridRows() const {
+    return _charRows() + (_actionCount() > 0 ? 1 : 0);
+  }
+
+  int _gridCellW() const {
+    return Uni.Lcd.width() / _gridCols();
+  }
+
+  int _gridCellH() const {
+    return (Uni.Lcd.height() - HDR_H) / _gridRows();
+  }
+
+  int _actionCellW() const {
+    return _actionCount() > 0 ? Uni.Lcd.width() / _actionCount() : Uni.Lcd.width();
+  }
 
   String _runScroll() {
     _lastBlinkTime = millis();
@@ -226,7 +285,18 @@ private:
         int16_t tx = Uni.Nav->lastTouchX();
         int16_t ty = Uni.Nav->lastTouchY();
         if (tx >= 0 && ty >= HDR_H) {
-          int idx = (int)(ty - HDR_H) / _gridCellH() * _gridCols() + (int)tx / _gridCellW();
+          int relY = ty - HDR_H;
+          int row = relY / _gridCellH();
+          int idx = -1;
+
+          if (_mode == INPUT_TEXT && row >= _charRows()) {
+            int action = tx / _actionCellW();
+            if (action >= 6) action = 5;
+            idx = 36 + action;
+          } else {
+            idx = row * _gridCols() + tx / _gridCellW();
+          }
+
           if (idx >= 0 && idx < _setCount) {
             const CharSet& hit = _sets[idx];
             if (!hit.isSpecial && hit.chars == nullptr) { delay(10); continue; }
@@ -236,9 +306,10 @@ private:
               _scrollPos = idx;
             }
             bool pc = _capsLock, ps = _symbolMode;
+            TextPage pp = _page;
             _handleSelect();
             if (!_done && !_cancelled) {
-              if (pc != _capsLock || ps != _symbolMode) _drawFullGrid();
+              if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
               else { _drawGridCell(prev); _drawGridCell(_scrollPos); }
               _cursorVisible = true; _lastBlinkTime = millis();
               _drawGridInput();
@@ -250,27 +321,75 @@ private:
 #endif
 
       const bool nav4 = Uni.Nav->is4Way();
-      if (nav4 && dir == INavigation::DIR_UP) {
+
+      if (_mode == INPUT_TEXT && nav4 &&
+          (dir == INavigation::DIR_UP || dir == INavigation::DIR_DOWN)) {
+        _commitTap();
+
+        if (_scrollPos < 36) {
+          int col = _scrollPos % _gridCols();
+          int row = _scrollPos / _gridCols();
+
+          if (dir == INavigation::DIR_UP) {
+            if (row == 0) {
+              // Jump to the closest action button in the bottom row.
+              int a = (col * 6) / _gridCols();
+              if (a >= 6) a = 5;
+              _scrollPos = 36 + a;
+            } else {
+              _scrollPos -= _gridCols();
+            }
+          } else {
+            if (row == _charRows() - 1) {
+              int a = (col * 6) / _gridCols();
+              if (a >= 6) a = 5;
+              _scrollPos = 36 + a;
+            } else {
+              _scrollPos += _gridCols();
+            }
+          }
+        } else {
+          // From the action row, UP/DOWN returns to the bottom character row.
+          int a = _scrollPos - 36;
+          int col = (a * _gridCols()) / 6;
+          if (col >= _gridCols()) col = _gridCols() - 1;
+          _scrollPos = (_charRows() - 1) * _gridCols() + col;
+        }
+
+        // SYM has four intentionally blank tail cells.
+        if (_scrollPos < 36 && _sets[_scrollPos].chars == nullptr) {
+          int col = _scrollPos % _gridCols();
+          _scrollPos = 36 + min(col, 5);
+        }
+
+      } else if (nav4 && dir == INavigation::DIR_UP) {
         _commitTap();
         do { _scrollPos = (_scrollPos - _gridCols() + _setCount) % _setCount; }
         while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+
       } else if (nav4 && dir == INavigation::DIR_DOWN) {
         _commitTap();
         do { _scrollPos = (_scrollPos + _gridCols()) % _setCount; }
         while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+
       } else if (dir == INavigation::DIR_LEFT || dir == INavigation::DIR_UP) {
         _commitTap();
-        do { _scrollPos = (_scrollPos - 1 + _setCount) % _setCount; }
-        while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+        do {
+          _scrollPos = (_scrollPos - 1 + _setCount) % _setCount;
+        } while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+
       } else if (dir == INavigation::DIR_RIGHT || dir == INavigation::DIR_DOWN) {
         _commitTap();
-        do { _scrollPos = (_scrollPos + 1) % _setCount; }
-        while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+        do {
+          _scrollPos = (_scrollPos + 1) % _setCount;
+        } while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+
       } else if (dir == INavigation::DIR_PRESS) {
         bool pc = _capsLock, ps = _symbolMode;
+        TextPage pp = _page;
         _handleSelect();
         if (!_done && !_cancelled) {
-          if (pc != _capsLock || ps != _symbolMode) _drawFullGrid();
+          if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
           else _drawGridCell(prev);
           _cursorVisible = true; _lastBlinkTime = millis();
           _drawGridInput();
@@ -321,13 +440,18 @@ private:
             _input.remove(_input.length() - 1);
           }
           break;
-        case SP_CAPS:   _capsLock = !_capsLock;         break;
+        case SP_CAPS:
+          _capsLock = !_capsLock;
+          break;
         case SP_SYMBOL:
-          _symbolMode  = !_symbolMode;
-          _buildSets();
-          _scrollPos   = 0;
-          _tapCount    = 0;
-          _pendingChar = "";
+          if (_mode == INPUT_TEXT && _scrollPos == 36) {
+            _page = (_page == PAGE_ABC) ? PAGE_SYM : PAGE_ABC;
+            _symbolMode = (_page == PAGE_SYM);
+            _buildSets();
+            _scrollPos = 36;
+          } else {
+            _input += ' ';
+          }
           break;
         case SP_SPACE:
           _input += ' ';
@@ -338,35 +462,68 @@ private:
     } else {
       const char* chars = s.chars;
       if (!chars || chars[0] == '\0') return;
-      int  len = strlen(chars);
-      if (len == 1) {
-        char c = chars[0];
-        if (_capsLock && isalpha(c)) c = toupper(c);
-        _input      += c;
+
+      if (_mode == INPUT_TEXT) {
+        // QWERTY keys insert immediately. chars[0] is normal, chars[1] shifted.
+        char c = (_page == PAGE_ABC && _capsLock && chars[1] != '\0')
+                   ? chars[1] : chars[0];
+        _input += c;
         _pendingChar = "";
-        _tapCount    = 0;
+        _tapCount = 0;
         _lastTapTime = 0;
       } else {
-        char c = chars[_tapCount % len];
-        if (_capsLock && isalpha(c)) c = toupper(c);
-        _pendingChar = String(c);
-        _tapCount++;
-        _lastTapTime = millis();
+        int len = strlen(chars);
+        if (len == 1) {
+          char c = chars[0];
+          if (_capsLock && isalpha(c)) c = toupper(c);
+          _input += c;
+          _pendingChar = "";
+          _tapCount = 0;
+          _lastTapTime = 0;
+        } else {
+          char c = chars[_tapCount % len];
+          if (_capsLock && isalpha(c)) c = toupper(c);
+          _pendingChar = String(c);
+          _tapCount++;
+          _lastTapTime = millis();
+        }
       }
     }
   }
 
   void _drawFullGrid() {
     auto& lcd = Uni.Lcd;
+    uint16_t theme = Config.getThemeColor();
+
     lcd.fillScreen(TFT_BLACK);
     lcd.setTextSize(1);
     lcd.setTextDatum(TL_DATUM);
-    lcd.setTextColor(TFT_YELLOW, TFT_BLACK);
+
+    // Match the rest of UniGeek: black canvas + current primary/theme colour
+    // for the active screen accent.
+    lcd.setTextColor(theme, TFT_BLACK);
     lcd.drawString(_title, PAD, PAD);
+
     int ix = PAD + lcd.textWidth(_title) + PAD;
-    if (_capsLock)   { lcd.setTextColor(TFT_GREEN, TFT_BLACK); lcd.drawString("CAPS", ix, PAD); ix += lcd.textWidth("CAPS") + PAD; }
-    if (_symbolMode) { lcd.setTextColor(TFT_CYAN,  TFT_BLACK); lcd.drawString("SYM",  ix, PAD); }
+    lcd.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+    if (_capsLock) {
+      lcd.drawString("CAPS", ix, PAD);
+      ix += lcd.textWidth("CAPS") + PAD;
+    }
+    if (_page == PAGE_SYM) {
+      lcd.drawString("123", ix, PAD);
+    }
+
+    // Thin theme separator, echoing the normal UniGeek screen chrome.
+    lcd.drawFastHLine(PAD, PAD + 10, lcd.width() - PAD * 2, theme);
+
     _drawGridInput();
+
+    if (_mode == INPUT_TEXT) {
+      int footerY = HDR_H + _charRows() * _gridCellH();
+      lcd.drawFastHLine(PAD, footerY, lcd.width() - PAD * 2, TFT_DARKGREY);
+    }
+
     for (int i = 0; i < _setCount; i++) _drawGridCell(i);
   }
 
@@ -376,7 +533,7 @@ private:
     Sprite sp(&lcd);
     sp.createSprite(iW, INP_H);
     sp.fillSprite(TFT_BLACK);
-    sp.drawRoundRect(0, 0, iW, INP_H, 2, TFT_DARKGREY);
+    sp.drawRoundRect(0, 0, iW, INP_H, 2, Config.getThemeColor());
     sp.setTextColor(TFT_WHITE, TFT_BLACK);
     sp.setTextDatum(TL_DATUM);
     String display = _input + _pendingChar;
@@ -391,8 +548,21 @@ private:
     if (idx < 0 || idx >= _setCount) return;
     auto&    lcd   = Uni.Lcd;
     uint16_t theme = Config.getThemeColor();
-    int cW  = _gridCellW(), cH = _gridCellH();
-    int col = idx % _gridCols(), row = idx / _gridCols();
+    int cH = _gridCellH();
+    int cW;
+    int col;
+    int row;
+
+    if (_mode == INPUT_TEXT && idx >= 36) {
+      cW = _actionCellW();
+      col = idx - 36;
+      row = _charRows();
+    } else {
+      cW = _gridCellW();
+      col = idx % _gridCols();
+      row = idx / _gridCols();
+    }
+
     bool sel = (idx == _scrollPos);
     const CharSet& s = _sets[idx];
 
@@ -408,17 +578,35 @@ private:
     Sprite sp(&lcd);
     sp.createSprite(cW, cH);
     sp.fillSprite(TFT_BLACK);
+
+    // Character cells have plenty of horizontal room in the 6-column layout.
+    // Draw them at 2x for legibility; keep footer/action labels at 1x so
+    // SAVE/CAPS/SPACE/DEL/EXIT continue to fit comfortably.
+    // Use UniGeek's standard built-in UI font/size for maximum consistency
+    // and compatibility across display backends.
+    sp.setTextFont(1);
     sp.setTextSize(1);
     sp.setTextDatum(MC_DATUM);
+
     if (sel) {
-      sp.fillRoundRect(1, 1, cW - 2, cH - 2, 3, theme);
+      sp.fillRoundRect(2, 2, cW - 4, cH - 4, 3, theme);
       sp.setTextColor(TFT_WHITE, theme);
     } else {
-      sp.drawRoundRect(1, 1, cW - 2, cH - 2, 3, 0x2104);
+      sp.drawRoundRect(2, 2, cW - 4, cH - 4, 3, TFT_DARKGREY);
       sp.setTextColor(s.isSpecial ? TFT_WHITE : TFT_LIGHTGREY, TFT_BLACK);
     }
-    String lbl = String(s.label);
-    if (!s.isSpecial && _capsLock && _mode == INPUT_TEXT) lbl.toUpperCase();
+
+    String lbl;
+    if (!s.isSpecial && _mode == INPUT_TEXT && s.chars) {
+      char shown = (_page == PAGE_ABC && _capsLock && s.chars[1] != '\0')
+                     ? s.chars[1] : s.chars[0];
+      lbl = String(shown);
+    } else if (_mode == INPUT_TEXT && idx == 36) {
+      lbl = (_page == PAGE_ABC) ? "123" : "ABC";
+    } else {
+      lbl = String(s.label);
+    }
+
     sp.drawString(lbl.c_str(), cW / 2, cH / 2);
     sp.pushSprite(col * cW, HDR_H + row * cH);
     sp.deleteSprite();

--- a/firmware/src/ui/actions/InputTextAction.h
+++ b/firmware/src/ui/actions/InputTextAction.h
@@ -48,6 +48,7 @@ private:
   static constexpr int      MAX_SETS   = 60;
   static constexpr uint32_t COMMIT_MS  = 1000;
   static constexpr uint32_t BLINK_MS   = 500;
+  static constexpr uint32_t LONG_PRESS_MS = 600;
   static constexpr int      PAD        = 4;
 
   // keyboard mode overlay
@@ -69,8 +70,8 @@ private:
   String      _pendingChar;
 
   CharSet     _sets[MAX_SETS];
-  char        _keyChars[36][3]  = {};
-  char        _keyLabels[36][2] = {};
+  char        _keyChars[30][3]  = {};
+  char        _keyLabels[30][2] = {};
   int         _setCount    = 0;
   int         _scrollPos   = 0;
 
@@ -83,6 +84,7 @@ private:
   TextPage    _page        = PAGE_ABC;
   bool        _done        = false;
   bool        _cancelled   = false;
+  bool        _longPressHandled = false;
 
   bool        _cursorVisible  = true;
   uint32_t    _lastBlinkTime  = 0;
@@ -123,35 +125,32 @@ private:
       _sets[_setCount++] = { nullptr, "",     false, SP_SAVE   };  // spacer
       _sets[_setCount++] = { nullptr, "SAVE", true,  SP_SAVE   };
     } else {
-      // Compact 6x6 grid optimized for small displays.
+      // Compact 6x5 grid optimized for small displays.
       // Two ASCII pages: ABC <-> SYM.
       struct KeyPair {
         char normal;
         char shifted;
       };
 
-      static constexpr KeyPair alphaKeys[36] = {
+      static constexpr KeyPair alphaKeys[30] = {
         {'a','A'}, {'b','B'}, {'c','C'}, {'d','D'}, {'e','E'}, {'f','F'},
         {'g','G'}, {'h','H'}, {'i','I'}, {'j','J'}, {'k','K'}, {'l','L'},
         {'m','M'}, {'n','N'}, {'o','O'}, {'p','P'}, {'q','Q'}, {'r','R'},
         {'s','S'}, {'t','T'}, {'u','U'}, {'v','V'}, {'w','W'}, {'x','X'},
-        {'y','Y'}, {'z','Z'}, {'.','.'}, {',',','}, {':',':'}, {';',';'},
-        {'?','?'}, {'!','!'}, {'-','-'}, {'_','_'}, {'/','/'}, {'\\','\\'},
+        {'y','Y'}, {'z','Z'}, {'.',':'}, {'/','\\'}, {'-','_'}, {'?','@'},
       };
 
-      static constexpr KeyPair symbolKeys[32] = {
-        {'1','1'}, {'2','2'}, {'3','3'}, {'4','4'}, {'5','5'}, {'6','6'},
-        {'7','7'}, {'8','8'}, {'9','9'}, {'0','0'}, {'@','@'}, {'#','#'},
-        {'$','$'}, {'%','%'}, {'^','^'}, {'&','&'}, {'*','*'}, {'|','|'},
-        {'+','+'}, {'=','='}, {'\'','\''}, {'"','"'}, {'`','`'}, {'~','~'},
+      static constexpr KeyPair symbolKeys[21] = {
+        {'1','!'}, {'2','|'}, {'3','#'}, {'4','$'}, {'5','%'}, {'6','^'},
+        {'7','&'}, {'8','*'}, {'9','+'}, {'0','='}, {',',';'}, {'\'','"'},
         {'(', '('}, {')', ')'}, {'[', '['}, {']', ']'}, {'{', '{'}, {'}', '}'},
-        {'<', '<'}, {'>', '>'},
+        {'<', '<'}, {'>', '>'}, {'`','~'},
       };
 
       const KeyPair* keys = (_page == PAGE_SYM) ? symbolKeys : alphaKeys;
-      const int keyCount = (_page == PAGE_SYM) ? 32 : 36;
+      const int keyCount = (_page == PAGE_SYM) ? 21 : 30;
 
-      for (int i = 0; i < 36; i++) {
+      for (int i = 0; i < 30; i++) {
         if (i < keyCount) {
           _keyChars[i][0] = keys[i].normal;
           _keyChars[i][1] = keys[i].shifted;
@@ -211,7 +210,7 @@ private:
   int _gridCols() const { return _mode == INPUT_TEXT ? 6 : 5; }
 
   int _charCount() const {
-    return _mode == INPUT_TEXT ? 36 : _setCount;
+    return _mode == INPUT_TEXT ? 30 : _setCount;
   }
 
   int _charRows() const {
@@ -248,6 +247,39 @@ private:
       UartFM.poll(); // read remote input so nav works in this dialog
       if (Mirror.dirty()) Mirror.pump(); // flush only when this overlay redrew
 
+      // Fire character Shift as soon as Select crosses the long-press threshold.
+      // Do not wait for release. Special/action keys keep their normal release
+      // behaviour so holding CAPS/SAVE/etc. cannot trigger them accidentally.
+      if (Uni.Nav->isPressed() &&
+          Uni.Nav->currentDirection() == INavigation::DIR_PRESS) {
+        if (!_longPressHandled &&
+            Uni.Nav->heldDuration() >= LONG_PRESS_MS &&
+            _scrollPos < _setCount &&
+            !_sets[_scrollPos].isSpecial &&
+            _sets[_scrollPos].chars != nullptr) {
+          bool pc = _capsLock, ps = _symbolMode;
+          TextPage pp = _page;
+
+          _handleSelect(true);
+          _longPressHandled = true;
+
+          // The shifted character has already been emitted. Drop the future
+          // release event so it cannot also insert the normal character.
+          Uni.Nav->suppressCurrentPress();
+
+          if (!_done && !_cancelled) {
+            if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
+            else _drawGridCell(_scrollPos);
+            _cursorVisible = true;
+            _lastBlinkTime = millis();
+            _drawGridInput();
+          }
+        }
+      } else {
+        // Ready for the next physical Select press.
+        _longPressHandled = false;
+      }
+
       if (_tapCount > 0 && millis() - _lastTapTime >= COMMIT_MS) {
         _commitTap();
         _cursorVisible = true; _lastBlinkTime = millis();
@@ -274,7 +306,7 @@ private:
           if (_mode == INPUT_TEXT && row >= _charRows()) {
             int action = tx / _actionCellW();
             if (action >= 6) action = 5;
-            idx = 36 + action;
+            idx = 30 + action;
           } else {
             idx = row * _gridCols() + tx / _gridCellW();
           }
@@ -289,7 +321,7 @@ private:
             }
             bool pc = _capsLock, ps = _symbolMode;
             TextPage pp = _page;
-            _handleSelect();
+            _handleSelect(false);
             if (!_done && !_cancelled) {
               if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
               else { _drawGridCell(prev); _drawGridCell(_scrollPos); }
@@ -308,7 +340,7 @@ private:
           (dir == INavigation::DIR_UP || dir == INavigation::DIR_DOWN)) {
         _commitTap();
 
-        if (_scrollPos < 36) {
+        if (_scrollPos < 30) {
           int col = _scrollPos % _gridCols();
           int row = _scrollPos / _gridCols();
 
@@ -317,7 +349,7 @@ private:
               // Jump to the closest action button in the bottom row.
               int a = (col * 6) / _gridCols();
               if (a >= 6) a = 5;
-              _scrollPos = 36 + a;
+              _scrollPos = 30 + a;
             } else {
               _scrollPos -= _gridCols();
             }
@@ -325,23 +357,23 @@ private:
             if (row == _charRows() - 1) {
               int a = (col * 6) / _gridCols();
               if (a >= 6) a = 5;
-              _scrollPos = 36 + a;
+              _scrollPos = 30 + a;
             } else {
               _scrollPos += _gridCols();
             }
           }
         } else {
           // From the action row, UP/DOWN returns to the bottom character row.
-          int a = _scrollPos - 36;
+          int a = _scrollPos - 30;
           int col = (a * _gridCols()) / 6;
           if (col >= _gridCols()) col = _gridCols() - 1;
           _scrollPos = (_charRows() - 1) * _gridCols() + col;
         }
 
-        // SYM has four intentionally blank tail cells.
-        if (_scrollPos < 36 && _sets[_scrollPos].chars == nullptr) {
+        // SYM has intentionally blank tail cells.
+        if (_scrollPos < 30 && _sets[_scrollPos].chars == nullptr) {
           int col = _scrollPos % _gridCols();
-          _scrollPos = 36 + min(col, 5);
+          _scrollPos = 30 + min(col, 5);
         }
 
       } else if (nav4 && dir == INavigation::DIR_UP) {
@@ -369,7 +401,7 @@ private:
       } else if (dir == INavigation::DIR_PRESS) {
         bool pc = _capsLock, ps = _symbolMode;
         TextPage pp = _page;
-        _handleSelect();
+        _handleSelect(false);
         if (!_done && !_cancelled) {
           if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
           else _drawGridCell(prev);
@@ -406,7 +438,7 @@ private:
     return _cancelled ? "" : _input;
   }
 
-  void _handleSelect() {
+  void _handleSelect(bool shifted = false) {
     const CharSet& s = _sets[_scrollPos];
 
     if (s.isSpecial) {
@@ -426,11 +458,11 @@ private:
           _capsLock = !_capsLock;
           break;
         case SP_SYMBOL:
-          if (_mode == INPUT_TEXT && _scrollPos == 36) {
+          if (_mode == INPUT_TEXT && _scrollPos == 30) {
             _page = (_page == PAGE_ABC) ? PAGE_SYM : PAGE_ABC;
             _symbolMode = (_page == PAGE_SYM);
             _buildSets();
-            _scrollPos = 36;
+            _scrollPos = 30;
           } else {
             _input += ' ';
           }
@@ -443,9 +475,16 @@ private:
       if (!chars || chars[0] == '\0') return;
 
       if (_mode == INPUT_TEXT) {
-        // QWERTY keys insert immediately. chars[0] is normal, chars[1] shifted.
-        char c = (_page == PAGE_ABC && _capsLock && chars[1] != '\0')
-                   ? chars[1] : chars[0];
+        // Short press inserts chars[0]; long press inserts chars[1].
+        // CAPS remains persistent for alphabetic keys. Holding Select
+        // temporarily inverts CAPS for letters, like a momentary Shift.
+        char c = chars[0];
+        if (isalpha(chars[0])) {
+          bool upper = _capsLock ^ shifted;
+          c = upper ? toupper(chars[0]) : tolower(chars[0]);
+        } else if (shifted && chars[1] != '\0') {
+          c = chars[1];
+        }
         _input += c;
         _pendingChar = "";
         _tapCount = 0;
@@ -483,15 +522,20 @@ private:
     lcd.setTextColor(theme, TFT_BLACK);
     lcd.drawString(_title, PAD, PAD);
 
-    int ix = PAD + lcd.textWidth(_title) + PAD;
+    // Active keyboard-mode indicators live in the upper-right corner.
+    // Keep the title area uncluttered; when both are active, show "CAPS 123".
     lcd.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
-    if (_capsLock) {
-      lcd.drawString("CAPS", ix, PAD);
-      ix += lcd.textWidth("CAPS") + PAD;
-    }
+    lcd.setTextDatum(TR_DATUM);
+    String modeLabel;
+    if (_capsLock) modeLabel = "CAPS";
     if (_page == PAGE_SYM) {
-      lcd.drawString("123", ix, PAD);
+      if (modeLabel.length() > 0) modeLabel += " ";
+      modeLabel += "123";
     }
+    if (modeLabel.length() > 0) {
+      lcd.drawString(modeLabel.c_str(), lcd.width() - PAD, PAD);
+    }
+    lcd.setTextDatum(TL_DATUM);
 
     // Thin theme separator, echoing the normal UniGeek screen chrome.
     lcd.drawFastHLine(PAD, PAD + 10, lcd.width() - PAD * 2, theme);
@@ -532,9 +576,9 @@ private:
     int col;
     int row;
 
-    if (_mode == INPUT_TEXT && idx >= 36) {
+    if (_mode == INPUT_TEXT && idx >= 30) {
       cW = _actionCellW();
-      col = idx - 36;
+      col = idx - 30;
       row = _charRows();
     } else {
       cW = _gridCellW();
@@ -576,17 +620,37 @@ private:
     }
 
     String lbl;
+    bool drawShiftHint = false;
+    char shiftHint = '\0';
     if (!s.isSpecial && _mode == INPUT_TEXT && s.chars) {
-      char shown = (_page == PAGE_ABC && _capsLock && s.chars[1] != '\0')
-                     ? s.chars[1] : s.chars[0];
+      char shown = s.chars[0];
+
+      if (isalpha(s.chars[0])) {
+        // CAPS changes the primary character; long Select temporarily inverts it.
+        shown = _capsLock ? toupper(s.chars[0]) : tolower(s.chars[0]);
+        shiftHint = _capsLock ? tolower(s.chars[0]) : toupper(s.chars[0]);
+        drawShiftHint = true;
+      } else if (s.chars[1] != '\0' && s.chars[1] != s.chars[0]) {
+        shiftHint = s.chars[1];
+        drawShiftHint = true;
+      }
+
       lbl = String(shown);
-    } else if (_mode == INPUT_TEXT && idx == 36) {
+    } else if (_mode == INPUT_TEXT && idx == 30) {
       lbl = (_page == PAGE_ABC) ? "123" : "ABC";
     } else {
       lbl = String(s.label);
     }
 
     sp.drawString(lbl.c_str(), cW / 2, cH / 2);
+
+    if (drawShiftHint) {
+      sp.setTextDatum(TR_DATUM);
+      sp.setTextSize(1);
+      sp.setTextColor(sel ? TFT_WHITE : TFT_DARKGREY, sel ? theme : TFT_BLACK);
+      char hint[2] = { shiftHint, '\0' };
+      sp.drawString(hint, cW - 5, 3);
+    }
     sp.pushSprite(col * cW, HDR_H + row * cH);
     sp.deleteSprite();
   }

--- a/firmware/src/ui/actions/InputTextAction.h
+++ b/firmware/src/ui/actions/InputTextAction.h
@@ -35,8 +35,7 @@ private:
 
   enum TextPage : uint8_t {
     PAGE_ABC = 0,
-    PAGE_SYM1,
-    PAGE_SYM2
+    PAGE_SYM
   };
 
   enum SpecialNum {
@@ -70,8 +69,8 @@ private:
   String      _pendingChar;
 
   CharSet     _sets[MAX_SETS];
-  char        _keyChars[30][3]  = {};
-  char        _keyLabels[30][2] = {};
+  char        _keyChars[36][3]  = {};
+  char        _keyLabels[36][2] = {};
   int         _setCount    = 0;
   int         _scrollPos   = 0;
 
@@ -124,69 +123,53 @@ private:
       _sets[_setCount++] = { nullptr, "",     false, SP_SAVE   };  // spacer
       _sets[_setCount++] = { nullptr, "SAVE", true,  SP_SAVE   };
     } else {
-      // Compact 6x5 grid optimized for small displays.
-      // Three ASCII pages: ABC -> SYM1 -> SYM2 -> ABC.
+      // Compact 6x6 grid optimized for small displays.
+      // Two ASCII pages: ABC <-> SYM.
       struct KeyPair {
         char normal;
         char shifted;
       };
 
-      static constexpr KeyPair alphaKeys[30] = {
+      static constexpr KeyPair alphaKeys[36] = {
         {'a','A'}, {'b','B'}, {'c','C'}, {'d','D'}, {'e','E'}, {'f','F'},
         {'g','G'}, {'h','H'}, {'i','I'}, {'j','J'}, {'k','K'}, {'l','L'},
         {'m','M'}, {'n','N'}, {'o','O'}, {'p','P'}, {'q','Q'}, {'r','R'},
         {'s','S'}, {'t','T'}, {'u','U'}, {'v','V'}, {'w','W'}, {'x','X'},
-        {'y','Y'}, {'z','Z'}, {'.','.'}, {':',':'}, {'/','/'}, {'-','-'},
+        {'y','Y'}, {'z','Z'}, {'.','.'}, {',',','}, {':',':'}, {';',';'},
+        {'?','?'}, {'!','!'}, {'-','-'}, {'_','_'}, {'/','/'}, {'\\','\\'},
       };
 
-      static constexpr KeyPair sym1Keys[30] = {
+      static constexpr KeyPair symbolKeys[32] = {
         {'1','1'}, {'2','2'}, {'3','3'}, {'4','4'}, {'5','5'}, {'6','6'},
-        {'7','7'}, {'8','8'}, {'9','9'}, {'0','0'}, {'@','@'}, {'_','_'},
-        {'!','!'}, {'?','?'}, {',',','}, {';',';'}, {'+','+'}, {'=','='},
-        {'*','*'}, {'#','#'}, {'$','$'}, {'%','%'}, {'&','&'}, {'|','|'},
-        {'\\','\\'}, {'\'','\''}, {'"','"'}, {'`','`'}, {'~','~'}, {'^','^'},
-      };
-
-      // SYM2 intentionally contains only delimiter pairs; unused cells remain blank.
-      static constexpr KeyPair sym2Keys[8] = {
+        {'7','7'}, {'8','8'}, {'9','9'}, {'0','0'}, {'@','@'}, {'#','#'},
+        {'$','$'}, {'%','%'}, {'^','^'}, {'&','&'}, {'*','*'}, {'|','|'},
+        {'+','+'}, {'=','='}, {'\'','\''}, {'"','"'}, {'`','`'}, {'~','~'},
         {'(', '('}, {')', ')'}, {'[', '['}, {']', ']'}, {'{', '{'}, {'}', '}'},
         {'<', '<'}, {'>', '>'},
       };
 
-      const KeyPair* keys = alphaKeys;
-      int keyCount = 30;
-      if (_page == PAGE_SYM1) {
-        keys = sym1Keys;
-      } else if (_page == PAGE_SYM2) {
-        keys = sym2Keys;
-        keyCount = 8;
-      }
+      const KeyPair* keys = (_page == PAGE_SYM) ? symbolKeys : alphaKeys;
+      const int keyCount = (_page == PAGE_SYM) ? 32 : 36;
 
-      // Always reserve the full 6x5 character grid. Blank cells on SYM2 are
-      // represented by null character sets and are skipped by selection.
-      for (int i = 0; i < 30; i++) {
+      for (int i = 0; i < 36; i++) {
         if (i < keyCount) {
           _keyChars[i][0] = keys[i].normal;
           _keyChars[i][1] = keys[i].shifted;
           _keyChars[i][2] = '\0';
-
           _keyLabels[i][0] = keys[i].normal;
           _keyLabels[i][1] = '\0';
-
           _sets[_setCount++] = { _keyChars[i], _keyLabels[i], false, SP_SAVE };
         } else {
           _sets[_setCount++] = { nullptr, "", false, SP_SAVE };
         }
       }
 
-      // Six footer actions. The page button label is rendered dynamically.
       static constexpr const char* specialLabels[6] = {
-        "SYM1", "CAPS", "SPACE", "DEL", "SAVE", "EXIT"
+        "123", "CAPS", "SPACE", "BKSP", "SAVE", "EXIT"
       };
       static constexpr Special specialMap[6] = {
         SP_SYMBOL, SP_CAPS, SP_SYMBOL, SP_DELETE, SP_SAVE, SP_CANCEL
       };
-
       for (int i = 0; i < 6; i++) {
         _sets[_setCount++] = { nullptr, specialLabels[i], true, specialMap[i] };
       }
@@ -228,7 +211,7 @@ private:
   int _gridCols() const { return _mode == INPUT_TEXT ? 6 : 5; }
 
   int _charCount() const {
-    return _mode == INPUT_TEXT ? 30 : _setCount;
+    return _mode == INPUT_TEXT ? 36 : _setCount;
   }
 
   int _charRows() const {
@@ -291,7 +274,7 @@ private:
           if (_mode == INPUT_TEXT && row >= _charRows()) {
             int action = tx / _actionCellW();
             if (action >= 6) action = 5;
-            idx = 30 + action;
+            idx = 36 + action;
           } else {
             idx = row * _gridCols() + tx / _gridCellW();
           }
@@ -325,7 +308,7 @@ private:
           (dir == INavigation::DIR_UP || dir == INavigation::DIR_DOWN)) {
         _commitTap();
 
-        if (_scrollPos < 30) {
+        if (_scrollPos < 36) {
           int col = _scrollPos % _gridCols();
           int row = _scrollPos / _gridCols();
 
@@ -334,7 +317,7 @@ private:
               // Jump to the closest action button in the bottom row.
               int a = (col * 6) / _gridCols();
               if (a >= 6) a = 5;
-              _scrollPos = 30 + a;
+              _scrollPos = 36 + a;
             } else {
               _scrollPos -= _gridCols();
             }
@@ -342,28 +325,23 @@ private:
             if (row == _charRows() - 1) {
               int a = (col * 6) / _gridCols();
               if (a >= 6) a = 5;
-              _scrollPos = 30 + a;
+              _scrollPos = 36 + a;
             } else {
               _scrollPos += _gridCols();
             }
           }
         } else {
           // From the action row, UP/DOWN returns to the bottom character row.
-          int a = _scrollPos - 30;
+          int a = _scrollPos - 36;
           int col = (a * _gridCols()) / 6;
           if (col >= _gridCols()) col = _gridCols() - 1;
           _scrollPos = (_charRows() - 1) * _gridCols() + col;
         }
 
-        // SYM2 has intentionally blank cells. If vertical navigation lands on
-        // one, move to the nearest valid character/action instead.
-        if (_scrollPos < 30 && _sets[_scrollPos].chars == nullptr) {
+        // SYM has four intentionally blank tail cells.
+        if (_scrollPos < 36 && _sets[_scrollPos].chars == nullptr) {
           int col = _scrollPos % _gridCols();
-          if (_page == PAGE_SYM2 && col < 2) {
-            _scrollPos = 6 + col;  // < or >
-          } else {
-            _scrollPos = 30 + min(col, 5);
-          }
+          _scrollPos = 36 + min(col, 5);
         }
 
       } else if (nav4 && dir == INavigation::DIR_UP) {
@@ -448,17 +426,12 @@ private:
           _capsLock = !_capsLock;
           break;
         case SP_SYMBOL:
-          if (_mode == INPUT_TEXT && _scrollPos == 30) {
-            // Cycle text pages: ABC -> SYM1 -> SYM2 -> ABC.
-            if (_page == PAGE_ABC)       _page = PAGE_SYM1;
-            else if (_page == PAGE_SYM1) _page = PAGE_SYM2;
-            else                         _page = PAGE_ABC;
-
-            _symbolMode = (_page != PAGE_ABC);
+          if (_mode == INPUT_TEXT && _scrollPos == 36) {
+            _page = (_page == PAGE_ABC) ? PAGE_SYM : PAGE_ABC;
+            _symbolMode = (_page == PAGE_SYM);
             _buildSets();
-            _scrollPos = 30;
+            _scrollPos = 36;
           } else {
-            // SPACE
             _input += ' ';
           }
           break;
@@ -516,10 +489,8 @@ private:
       lcd.drawString("CAPS", ix, PAD);
       ix += lcd.textWidth("CAPS") + PAD;
     }
-    if (_page == PAGE_SYM1) {
-      lcd.drawString("SYM1", ix, PAD);
-    } else if (_page == PAGE_SYM2) {
-      lcd.drawString("SYM2", ix, PAD);
+    if (_page == PAGE_SYM) {
+      lcd.drawString("123", ix, PAD);
     }
 
     // Thin theme separator, echoing the normal UniGeek screen chrome.
@@ -561,9 +532,9 @@ private:
     int col;
     int row;
 
-    if (_mode == INPUT_TEXT && idx >= 30) {
+    if (_mode == INPUT_TEXT && idx >= 36) {
       cW = _actionCellW();
-      col = idx - 30;
+      col = idx - 36;
       row = _charRows();
     } else {
       cW = _gridCellW();
@@ -590,8 +561,10 @@ private:
     // Character cells have plenty of horizontal room in the 6-column layout.
     // Draw them at 2x for legibility; keep footer/action labels at 1x so
     // SAVE/CAPS/SPACE/DEL/EXIT continue to fit comfortably.
-    const bool largeKey = (_mode == INPUT_TEXT && !s.isSpecial);
-    sp.setTextSize(largeKey ? 2 : 1);
+    // Use UniGeek's standard built-in UI font/size for maximum consistency
+    // and compatibility across display backends.
+    sp.setTextFont(1);
+    sp.setTextSize(1);
     sp.setTextDatum(MC_DATUM);
 
     if (sel) {
@@ -607,10 +580,8 @@ private:
       char shown = (_page == PAGE_ABC && _capsLock && s.chars[1] != '\0')
                      ? s.chars[1] : s.chars[0];
       lbl = String(shown);
-    } else if (_mode == INPUT_TEXT && idx == 30) {
-      if (_page == PAGE_ABC)       lbl = "SYM1";
-      else if (_page == PAGE_SYM1) lbl = "SYM2";
-      else                         lbl = "ABC";
+    } else if (_mode == INPUT_TEXT && idx == 36) {
+      lbl = (_page == PAGE_ABC) ? "123" : "ABC";
     } else {
       lbl = String(s.label);
     }

--- a/firmware/src/ui/actions/InputTextAction.h
+++ b/firmware/src/ui/actions/InputTextAction.h
@@ -437,13 +437,9 @@ private:
           _symbolMode = (_page == PAGE_SYM);
           _buildSets();
 
-          // Keep the current cell when it exists on both pages.
-          // If it points to a blank SYM cell, move focus to ABC/123.
-          if (_scrollPos < 30 && _sets[_scrollPos].chars == nullptr) {
-            _scrollPos = 30;
-          } else if (_scrollPos >= _setCount) {
-            _scrollPos = 30;
-          }
+          // Back always opens the new page at its first character:
+          // ABC -> 'a', 123 -> '1'.
+          _scrollPos = 0;
 
           _drawFullGrid();
           _cursorVisible = true;


### PR DESCRIPTION
## Summary

This PR adds NDEF support to the PN532 I2C interface for Ultralight / NTAG tags.

## Changes

- Add **Read NDEF** support.
- Add **Write NDEF** support for Text and URI records.
- Add support for writing NDEF data from saved `.ndef` files.
- Add support for saving read NDEF records to `.ndef` files.
- Add **Erase NDEF** support.
- Decode and display NDEF Text and URI records.
- Add the new NDEF actions to the **Ultralight / NTAG** submenu.

## Testing

The NDEF read, write, and erase functionality was tested on the T-Embed CC1101 Plus using its onboard PN532 over I2C.

## Current limitations

- **NDEF emulation is not implemented in this PR.** I experimented with PN532 Type 4 Tag emulation, but it is considerably more complex and is intentionally left out of this PR.
- **The new NDEF functionality has not been ported to PN532 over UART.** I currently do not have the required UART PN532 hardware to properly test such an implementation, so this PR is limited to the tested I2C implementation.

---

**Note about InputTextAction.h:**

While working on the PN532 NDEF features, I also made the virtual keyboards used by the PN532 consistent with the new grid-based keyboard introduced in the Chameleon Ultra work.

The idea was to adopt the same UI conventions across the device: grid-based layouts, consistent action keys (SPC, BKSP, SAVE, EXIT), the same behavior for the BACK button (backspace when there is input, cancel when the input is empty), and the same visual treatment for regular and special keys.

For the PN532, this required changes to InputTextAction.h: I added a dedicated INPUT_PHONE layout for NDEF Phone records and adjusted INPUT_HEX to use the same keyboard conventions. The HEX keyboard now uses F | SPC | BKSP | SAVE | EXIT on its last row, while the Phone keyboard provides the characters commonly needed for phone numbers together with the same BKSP | SAVE | EXIT actions.

Because feature/grid_keyboard also substantially changes InputTextAction.h, the two branches overlap and produce a merge conflict in that file. I have already integrated and tested both locally. The conflict itself is straightforward: the grid keyboard implementation/geometry should be preserved, while the PN532-specific input modes and layouts (INPUT_PHONE, SP_SPACE, and the updated INPUT_HEX) should be retained.

The combined version builds successfully and the PN532 I2C functionality has been tested with the integrated keyboard changes.

---

**Here are the virtual keyboad layouts adopted:**

### Regular — ABC page

```text
┌───────┬───────┬───────┬───────┬───────┬───────┐
│   a   │   b   │   c   │   d   │   e   │   f   │
├───────┼───────┼───────┼───────┼───────┼───────┤
│   g   │   h   │   i   │   j   │   k   │   l   │
├───────┼───────┼───────┼───────┼───────┼───────┤
│   m   │   n   │   o   │   p   │   q   │   r   │
├───────┼───────┼───────┼───────┼───────┼───────┤
│   s   │   t   │   u   │   v   │   w   │   x   │
├───────┼───────┼───────┼───────┼───────┼───────┤
│   y   │   z   │   .   │   ,   │   :   │   ;   │
├───────┼───────┼───────┼───────┼───────┼───────┤
│   ?   │   !   │   -   │   _   │   /   │   \   │
├───────┼───────┼───────┼───────┼───────┼───────┤
│  123  │ CAPS  │ SPACE │ BKSP  │ SAVE  │ EXIT  │
└───────┴───────┴───────┴───────┴───────┴───────┘
```

`CAPS` switches `a-z` to `A-Z`.

### Regular — SYM/123 page

```text
┌───────┬───────┬───────┬───────┬───────┬───────┐
│   1   │   2   │   3   │   4   │   5   │   6   │
├───────┼───────┼───────┼───────┼───────┼───────┤
│   7   │   8   │   9   │   0   │   @   │   #   │
├───────┼───────┼───────┼───────┼───────┼───────┤
│   $   │   %   │   ^   │   &   │   *   │   |   │
├───────┼───────┼───────┼───────┼───────┼───────┤
│   +   │   =   │   '   │   "   │   `   │   ~   │
├───────┼───────┼───────┼───────┼───────┼───────┤
│   (   │   )   │   [   │   ]   │   {   │   }   │
├───────┼───────┼───────┼───────┼───────┼───────┤
│   <   │   >   │       │       │       │       │
├───────┼───────┼───────┼───────┼───────┼───────┤
│  ABC  │ CAPS  │ SPACE │ BKSP  │ SAVE  │ EXIT  │
└───────┴───────┴───────┴───────┴───────┴───────┘
```

### Number

```text
┌────────┬────────┬────────┐
│   1    │   2    │   3    │
├────────┼────────┼────────┤
│   4    │   5    │   6    │
├────────┼────────┼────────┤
│   7    │   8    │   9    │
├────────┼────────┼────────┤
│        │   0    │        │
├────────┼────────┼────────┤
│  BKSP  │  SAVE  │  EXIT  │
└────────┴────────┴────────┘
```

### Phone

```text
┌──────┬──────┬──────┬──────┬──────┐
│  0   │  1   │  2   │  3   │  4   │
├──────┼──────┼──────┼──────┼──────┤
│  5   │  6   │  7   │  8   │  9   │
├──────┼──────┼──────┼──────┼──────┤
│  +   │  -   │  .   │  *   │  #   │
├──────┼──────┼──────┼──────┼──────┤
│  (   │  )   │ BKSP │ SAVE │ EXIT │
└──────┴──────┴──────┴──────┴──────┘
```

### HEX

```text
┌───────┬───────┬───────┬───────┬───────┐
│   0   │   1   │   2   │   3   │   4   │
├───────┼───────┼───────┼───────┼───────┤
│   5   │   6   │   7   │   8   │   9   │
├───────┼───────┼───────┼───────┼───────┤
│   A   │   B   │   C   │   D   │   E   │
├───────┼───────┼───────┼───────┼───────┤
│   F   │ SPACE │ BKSP  │ SAVE  │ EXIT  │
└───────┴───────┴───────┴───────┴───────┘
```