### PR TITLE
Improve Network WiFi scan results

### DIFF
--- a/firmware/src/screens/wifi/network/NetworkMenuScreen.cpp
+++ b/firmware/src/screens/wifi/network/NetworkMenuScreen.cpp
@@ -51,7 +51,13 @@ void NetworkMenuScreen::onUpdate() {
 
 void NetworkMenuScreen::onItemSelected(uint8_t index) {
   if (_state == STATE_SELECT_WIFI) {
-    _connectToSelected(index);
+    if (index == 0) {
+      _showWifiList();
+      return;
+    }
+
+    const uint8_t wifiIndex = index - 1;
+    _connectToSelected(wifiIndex);
   } else if (_state == STATE_MENU) {
     switch (index) {
       case 0: _showInformation(); break;
@@ -84,12 +90,16 @@ void NetworkMenuScreen::_showWifiList() {
   int ns = Achievement.inc("wifi_first_scan");
   if (ns == 1) Achievement.unlock("wifi_first_scan");
 
+  _scannedItems[0] = {"Rescan"};
+
   for (int i = 0; i < _scannedCount; i++) {
-    _scannedItems[i] = { _scanned[i].label };
+    _scannedItems[i + 1]         = {_scanned[i].ssid, _scanned[i].bssid};
+    _scannedItems[i + 1].rssi    = _scanned[i].rssi;
+    _scannedItems[i + 1].hasRssi = true;
   }
 
   _scanning = false;
-  setItems(_scannedItems, _scannedCount);
+  setItems(_scannedItems, _scannedCount + 1);
 }
 
 void NetworkMenuScreen::_connectToSelected(uint8_t index) {

--- a/firmware/src/screens/wifi/network/NetworkMenuScreen.h
+++ b/firmware/src/screens/wifi/network/NetworkMenuScreen.h
@@ -36,7 +36,7 @@ private:
 
   WifiUtility::ScannedWifi _scanned[WifiUtility::MAX_WIFI];
   uint8_t     _scannedCount = 0;
-  ListItem    _scannedItems[WifiUtility::MAX_WIFI];
+  ListItem    _scannedItems[WifiUtility::MAX_WIFI + 1];
 
   // Tools live in category submenus (see Network*Screen). Only the two entries
   // that describe *this connection* stay at the top level — burying them would

--- a/firmware/src/utils/network/WifiUtility.cpp
+++ b/firmware/src/utils/network/WifiUtility.cpp
@@ -13,10 +13,13 @@ uint8_t WifiUtility::scan(ScannedWifi* out, uint8_t maxCount)
   if (total > maxCount) total = maxCount;
 
   for (int i = 0; i < total; i++) {
+    const int rssi = WiFi.RSSI(i);
+
     snprintf(out[i].label, sizeof(out[i].label),
-             "[%d] %s", WiFi.RSSI(i), WiFi.SSID(i).c_str());
+             "[%d] %s", rssi, WiFi.SSID(i).c_str());
     strncpy(out[i].bssid, WiFi.BSSIDstr(i).c_str(), sizeof(out[i].bssid));
     strncpy(out[i].ssid,  WiFi.SSID(i).c_str(),     sizeof(out[i].ssid));
+    out[i].rssi = (int16_t)rssi;
   }
 
   return (uint8_t)total;

--- a/firmware/src/utils/network/WifiUtility.h
+++ b/firmware/src/utils/network/WifiUtility.h
@@ -10,6 +10,7 @@ public:
     char label[52];
     char bssid[18];
     char ssid[33];
+    int16_t rssi = 0;
   };
 
   // Scan


### PR DESCRIPTION
## Summary

This PR improves the WiFi scan interface in the Network menu and makes it consistent with the WiFi Analyzer.

### Changes

- Add Rescan as the first item in the scan results
- Display AP signal strength using RSSI-based colors
- Display the AP BSSID/MAC address
- Improve scan result navigation and presentation

The changes are limited to the Network WiFi scan interface.