### PR TITLE
Improve Chameleon slot management and content loading

### DIFF
--- a/firmware/src/screens/ble/chameleon/ChameleonHFScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonHFScreen.cpp
@@ -5,6 +5,7 @@
 #include "core/ScreenManager.h"
 #include "core/AchievementManager.h"
 #include "core/ConfigManager.h"
+#include "ui/actions/ShowStatusAction.h"
 
 const char* ChameleonHFScreen::_inferType(uint8_t sak, const uint8_t atqa[2]) {
   if (sak == 0x01) return "MF Classic Mini";
@@ -32,27 +33,13 @@ void ChameleonHFScreen::_draw() {
   sp.fillSprite(TFT_BLACK);
   sp.setTextDatum(MC_DATUM);
 
-  if (_state == STATE_IDLE) {
-    sp.setTextColor(TFT_CYAN, TFT_BLACK);
-    sp.drawString("HF Card Reader", bw / 2, bh / 2 - 28);
-    sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-    sp.drawString("Place ISO14443 card near", bw / 2, bh / 2 - 10);
-    sp.drawString("Chameleon reader face", bw / 2, bh / 2 + 6);
-    sp.setTextColor(TFT_WHITE, TFT_BLACK);
-    sp.drawString("[Press] Scan", bw / 2, bh / 2 + 24);
-  } else if (_state == STATE_CLONED) {
-    sp.setTextColor(TFT_GREEN, TFT_BLACK);
-    sp.drawString("Clone success!", bw / 2, bh / 2 - 18);
-    sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-    sp.drawString("Card cloned to active slot", bw / 2, bh / 2);
-    sp.setTextColor(TFT_WHITE, TFT_BLACK);
-    sp.drawString("[Press] Rescan", bw / 2, bh / 2 + 18);
-  } else { // STATE_ERROR
-    sp.setTextColor(TFT_RED, TFT_BLACK);
-    sp.drawString("No card found", bw / 2, bh / 2 - 10);
-    sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-    sp.drawString("[Press] Retry", bw / 2, bh / 2 + 8);
-  }
+  sp.setTextColor(TFT_CYAN, TFT_BLACK);
+  sp.drawString("HF Card Reader", bw / 2, bh / 2 - 28);
+  sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
+  sp.drawString("Place ISO14443 card near", bw / 2, bh / 2 - 10);
+  sp.drawString("Chameleon reader face", bw / 2, bh / 2 + 6);
+  sp.setTextColor(TFT_WHITE, TFT_BLACK);
+  sp.drawString("[Press] Scan", bw / 2, bh / 2 + 24);
 
   sp.pushSprite(bx, by);
   sp.deleteSprite();
@@ -137,7 +124,12 @@ void ChameleonHFScreen::_doScan() {
     if (n == 5)  Achievement.unlock("chameleon_hf_read_5");
     if (n == 10) Achievement.unlock("chameleon_hf_read_10");
   } else {
-    _state = STATE_ERROR;
+    _state = STATE_IDLE;
+    _needsDraw = true;
+    render();
+    ShowStatusAction::show("No card found", 1200);
+    render();
+    return;
   }
 
   _needsDraw = true;
@@ -160,16 +152,19 @@ void ChameleonHFScreen::_doClone() {
   uint16_t tagType = ChameleonClient::inferHFTagType(_sak, _atqa);
   bool ok = c.cloneHF(_activeSlot, tagType, _uid, _uidLen, _atqa, _sak);
 
+  _state = STATE_RESULT;
+  _needsDraw = true;
+  render();
+
   if (ok) {
-    _state = STATE_CLONED;
     int n = Achievement.inc("chameleon_clone");
     if (n == 1)  Achievement.unlock("chameleon_clone");
     if (n == 3)  Achievement.unlock("chameleon_clone_3");
     if (n == 10) Achievement.unlock("chameleon_clone_10");
+    ShowStatusAction::show("Clone OK", 1200);
   } else {
-    _state = STATE_ERROR;
+    ShowStatusAction::show("Clone failed", 1200);
   }
-  _needsDraw = true;
   render();
 }
 

--- a/firmware/src/screens/ble/chameleon/ChameleonHIDProxScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonHIDProxScreen.cpp
@@ -6,6 +6,7 @@
 #include "core/AchievementManager.h"
 #include "core/ConfigManager.h"
 #include "ui/actions/InputSelectAction.h"
+#include "ui/actions/ShowStatusAction.h"
 
 void ChameleonHIDProxScreen::_draw() {
   _needsDraw = false;
@@ -17,14 +18,14 @@ void ChameleonHIDProxScreen::_draw() {
   sp.fillSprite(TFT_BLACK);
   sp.setTextDatum(MC_DATUM);
 
-  if (_state == STATE_IDLE) {
+  if (_state == STATE_IDLE || _state == STATE_ERROR) {
     sp.setTextColor(TFT_CYAN, TFT_BLACK);
     sp.drawString("HID Prox Scanner", bw / 2, bh / 2 - 20);
     sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
     sp.drawString("Place HID Prox card", bw / 2, bh / 2);
     sp.setTextColor(TFT_WHITE, TFT_BLACK);
     sp.drawString("[OK] Scan  [Hold] Back", bw / 2, bh / 2 + 20);
-  } else if (_state == STATE_RESULT) {
+  } else if (_state == STATE_RESULT || _state == STATE_CLONED) {
     sp.setTextColor(TFT_GREEN, TFT_BLACK);
     sp.drawString("HID Prox detected", bw / 2, bh / 2 - 30);
     char hex[40] = {};
@@ -35,16 +36,6 @@ void ChameleonHIDProxScreen::_draw() {
     sp.drawString(hex, bw / 2, bh / 2 - 10);
     sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
     sp.drawString("[OK] Action  [Hold] Back", bw / 2, bh / 2 + 20);
-  } else if (_state == STATE_CLONED) {
-    sp.setTextColor(TFT_GREEN, TFT_BLACK);
-    sp.drawString("Success!", bw / 2, bh / 2 - 10);
-    sp.setTextColor(TFT_WHITE, TFT_BLACK);
-    sp.drawString("[Back] Menu", bw / 2, bh / 2 + 14);
-  } else {
-    sp.setTextColor(TFT_RED, TFT_BLACK);
-    sp.drawString("No card / failed", bw / 2, bh / 2 - 4);
-    sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-    sp.drawString("[OK] Retry", bw / 2, bh / 2 + 14);
   }
   sp.pushSprite(bx, by);
   sp.deleteSprite();
@@ -72,7 +63,7 @@ void ChameleonHIDProxScreen::_doScan() {
   c.setMode(1);
   bool ok = c.scanHIDProx(_payload, &_payloadLen);
   _scanning = false;
-  _state = ok ? STATE_RESULT : STATE_ERROR;
+  _state = ok ? STATE_RESULT : STATE_IDLE;
 
   if (ok) {
     int n = Achievement.inc("chameleon_hid_scan");
@@ -80,6 +71,10 @@ void ChameleonHIDProxScreen::_doScan() {
   }
   _needsDraw = true;
   render();
+  if (!ok) {
+    ShowStatusAction::show("No card found", 1200);
+    render();
+  }
 }
 
 void ChameleonHIDProxScreen::_doCloneSlot() {
@@ -92,8 +87,10 @@ void ChameleonHIDProxScreen::_doCloneSlot() {
     if (n == 3) Achievement.unlock("chameleon_clone_3");
     if (n == 10) Achievement.unlock("chameleon_clone_10");
   }
-  _state = ok ? STATE_CLONED : STATE_ERROR;
+  _state = STATE_RESULT;
   _needsDraw = true;
+  render();
+  ShowStatusAction::show(ok ? "Clone OK" : "Clone failed", 1200);
   render();
 }
 
@@ -111,8 +108,10 @@ void ChameleonHIDProxScreen::_doT5577() {
     int n = Achievement.inc("chameleon_t5577_write");
     if (n == 1) Achievement.unlock("chameleon_t5577_write");
   }
-  _state = ok ? STATE_CLONED : STATE_ERROR;
+  _state = STATE_RESULT;
   _needsDraw = true;
+  render();
+  ShowStatusAction::show(ok ? "T5577 write OK" : "T5577 write failed", 1200);
   render();
 }
 

--- a/firmware/src/screens/ble/chameleon/ChameleonLFScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonLFScreen.cpp
@@ -5,6 +5,7 @@
 #include "core/ScreenManager.h"
 #include "core/AchievementManager.h"
 #include "core/ConfigManager.h"
+#include "ui/actions/ShowStatusAction.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -18,36 +19,13 @@ void ChameleonLFScreen::_draw() {
   sp.fillSprite(TFT_BLACK);
   sp.setTextDatum(MC_DATUM);
 
-  switch (_state) {
-    case STATE_IDLE:
-      sp.setTextColor(TFT_CYAN, TFT_BLACK);
-      sp.drawString("LF Card Reader", bw / 2, bh / 2 - 28);
-      sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-      sp.drawString("Place EM410X card near", bw / 2, bh / 2 - 10);
-      sp.drawString("Chameleon reader", bw / 2, bh / 2 + 6);
-      sp.setTextColor(TFT_WHITE, TFT_BLACK);
-      sp.drawString("[Press] Scan", bw / 2, bh / 2 + 24);
-      break;
-
-    case STATE_ERROR:
-      sp.setTextColor(TFT_RED, TFT_BLACK);
-      sp.drawString("No card found", bw / 2, bh / 2 - 10);
-      sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-      sp.drawString("[Press] Retry", bw / 2, bh / 2 + 8);
-      break;
-
-    case STATE_CLONED:
-      sp.setTextColor(TFT_GREEN, TFT_BLACK);
-      sp.drawString("Cloned!", bw / 2, bh / 2 - 20);
-      sp.setTextColor(TFT_WHITE, TFT_BLACK);
-      sp.drawString("Card loaded to slot.", bw / 2, bh / 2 - 4);
-      sp.drawString("Emulating now.", bw / 2, bh / 2 + 12);
-      sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-      sp.drawString("[Press] Rescan", bw / 2, bh - 10);
-      break;
-
-    default: break;
-  }
+  sp.setTextColor(TFT_CYAN, TFT_BLACK);
+  sp.drawString("LF Card Reader", bw / 2, bh / 2 - 28);
+  sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
+  sp.drawString("Place EM410X card near", bw / 2, bh / 2 - 10);
+  sp.drawString("Chameleon reader", bw / 2, bh / 2 + 6);
+  sp.setTextColor(TFT_WHITE, TFT_BLACK);
+  sp.drawString("[Press] Scan", bw / 2, bh / 2 + 24);
 
   sp.pushSprite(bx, by);
   sp.deleteSprite();
@@ -123,7 +101,12 @@ void ChameleonLFScreen::_doScan() {
     if (n == 5)  Achievement.unlock("chameleon_lf_read_5");
     if (n == 10) Achievement.unlock("chameleon_lf_read_10");
   } else {
-    _state = STATE_ERROR;
+    _state = STATE_IDLE;
+    _needsDraw = true;
+    render();
+    ShowStatusAction::show("No card found", 1200);
+    render();
+    return;
   }
 
   _needsDraw = true;
@@ -141,14 +124,17 @@ void ChameleonLFScreen::_doT5577() {
   auto& c = ChameleonClient::get();
   bool ok = c.writeEM410XToT5577(_uid, nullptr, nullptr, 0);
 
+  _state = STATE_RESULT;
+  _needsDraw = true;
+  render();
+
   if (ok) {
     int n = Achievement.inc("chameleon_t5577_write");
     if (n == 1) Achievement.unlock("chameleon_t5577_write");
-    _state = STATE_CLONED;
+    ShowStatusAction::show("T5577 write OK", 1200);
   } else {
-    _state = STATE_ERROR;
+    ShowStatusAction::show("T5577 write failed", 1200);
   }
-  _needsDraw = true;
   render();
 }
 
@@ -163,17 +149,20 @@ void ChameleonLFScreen::_doClone() {
   auto& c = ChameleonClient::get();
   bool ok = c.setEM410XSlot(_uid);
 
+  _state = STATE_RESULT;
+  _needsDraw = true;
+  render();
+
   if (ok) {
     c.setMode(0); // emulator mode
     int n = Achievement.inc("chameleon_clone");
     if (n == 1)  Achievement.unlock("chameleon_clone");
     if (n == 3)  Achievement.unlock("chameleon_clone_3");
     if (n == 10) Achievement.unlock("chameleon_clone_10");
-    _state = STATE_CLONED;
+    ShowStatusAction::show("Clone OK", 1200);
   } else {
-    _state = STATE_ERROR;
+    ShowStatusAction::show("Clone failed", 1200);
   }
-  _needsDraw = true;
   render();
 }
 

--- a/firmware/src/screens/ble/chameleon/ChameleonScanScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonScanScreen.cpp
@@ -5,6 +5,7 @@
 #include "core/ScreenManager.h"
 #include "core/AchievementManager.h"
 #include "ui/components/StatusBar.h"
+#include "ui/actions/ShowStatusAction.h"
 #include "screens/ble/BLEMenuScreen.h"
 #include <NimBLEDevice.h>
 #include <string.h>
@@ -160,16 +161,13 @@ void ChameleonScanScreen::onItemSelected(uint8_t index) {
     if (n == 5) Achievement.unlock("chameleon_connect_5");
     Screen.push(new ChameleonMenuScreen());
   } else {
-    lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
-    lcd.setTextDatum(MC_DATUM);
-    lcd.setTextColor(TFT_RED, TFT_BLACK);
-    lcd.drawString("Connect failed, retrying...", bodyX() + bodyW() / 2, bodyY() + bodyH() / 2);
-    delay(1200);
     _devCount   = 0;
     _devChanged = false;
     _state      = STATE_EMPTY;
-    render();
     _startScan();
+    render();
+    ShowStatusAction::show("Connection failed", 1200);
+    render();
   }
 }
 

--- a/firmware/src/screens/ble/chameleon/ChameleonSlotEditScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonSlotEditScreen.cpp
@@ -8,6 +8,7 @@
 #include "ui/actions/InputSelectAction.h"
 #include "ui/actions/InputTextAction.h"
 #include "ui/actions/ShowStatusAction.h"
+#include "ui/views/ProgressView.h"
 
 void ChameleonSlotEditScreen::_load() {
   auto& c = ChameleonClient::get();
@@ -130,13 +131,16 @@ void ChameleonSlotEditScreen::_editType(bool lf) {
   if (!r) { render(); return; }
   uint16_t v = (uint16_t)strtoul(r, nullptr, 10);
 
-  if (ChameleonClient::get().setSlotTagType(_slot, v)) {
+  bool ok = ChameleonClient::get().setSlotTagType(_slot, v);
+  if (ok) {
     if (lf) _lfType = v; else _hfType = v;
-  } else {
-    ShowStatusAction::show("Set type failed", 1200);
   }
   _rebuildLabels();
   render();
+  if (!ok) {
+    ShowStatusAction::show("Set type failed", 1200);
+    render();
+  }
 }
 
 void ChameleonSlotEditScreen::_toggleEnable(bool lf) {
@@ -154,16 +158,19 @@ void ChameleonSlotEditScreen::_editNick(bool lf) {
   String r = InputTextAction::popup(lf ? "LF nick" : "HF nick", cur);
   if (r.length() == 0) { render(); return; }
   uint8_t freq = lf ? 1 : 2;
-  if (ChameleonClient::get().setSlotNick(_slot, freq, r.c_str())) {
+  bool ok = ChameleonClient::get().setSlotNick(_slot, freq, r.c_str());
+  if (ok) {
     strncpy(lf ? _lfNick : _hfNick, r.c_str(),
             (lf ? sizeof(_lfNick) : sizeof(_hfNick)) - 1);
     int n = Achievement.inc("chameleon_nick_set");
     if (n == 1) Achievement.unlock("chameleon_nick_set");
-  } else {
-    ShowStatusAction::show("Set nick failed", 1200);
   }
   _rebuildLabels();
   render();
+  if (!ok) {
+    ShowStatusAction::show("Set nick failed", 1200);
+    render();
+  }
 }
 
 void ChameleonSlotEditScreen::_loadDefault() {
@@ -175,8 +182,14 @@ void ChameleonSlotEditScreen::_loadDefault() {
   if (!r) { render(); return; }
   bool lf = (strcmp(r, "lf") == 0);
   uint16_t t = lf ? _lfType : _hfType;
-  if (t == 0) { ShowStatusAction::show("Set type first", 1200); render(); return; }
+  if (t == 0) {
+    render();
+    ShowStatusAction::show("Set type first", 1200);
+    render();
+    return;
+  }
   bool ok = ChameleonClient::get().setSlotDataDefault(_slot, t);
+  render();
   ShowStatusAction::show(ok ? "Default loaded" : "Load failed", 1200);
   render();
 }
@@ -191,17 +204,19 @@ void ChameleonSlotEditScreen::_deleteSlot(bool) {
   bool lf = (strcmp(r, "lf") == 0);
   uint8_t freq = lf ? 1 : 2;
   bool ok = ChameleonClient::get().deleteSlot(_slot, freq);
-  ShowStatusAction::show(ok ? "Deleted" : "Delete failed", 1200);
   if (ok) {
     if (lf) { _lfType = 0; _lfEnabled = false; _lfNick[0] = 0; }
     else    { _hfType = 0; _hfEnabled = false; _hfNick[0] = 0; }
   }
   _rebuildLabels();
   render();
+  ShowStatusAction::show(ok ? "Deleted" : "Delete failed", 1200);
+  render();
 }
 
 void ChameleonSlotEditScreen::_saveNicks() {
   bool ok = ChameleonClient::get().saveSlotNicks();
+  render();
   ShowStatusAction::show(ok ? "Nicks saved" : "Save failed", 1200);
   render();
 }
@@ -228,17 +243,14 @@ bool ChameleonSlotEditScreen::_writeHfFromBin(const char* path) {
   auto& c = ChameleonClient::get();
   if (!c.setSlotTagType(_slot, tagType)) {
     f.close();
-    ShowStatusAction::show("HF fail: type");
     return false;
   }
   if (!c.setSlotDataDefault(_slot, tagType)) {
     f.close();
-    ShowStatusAction::show("HF fail: init");
     return false;
   }
   if (!c.setActiveSlot(_slot)) {
     f.close();
-    ShowStatusAction::show("HF fail: active");
     return false;
   }
 
@@ -258,24 +270,48 @@ bool ChameleonSlotEditScreen::_writeHfFromBin(const char* path) {
                      acoPayload, 5 + uidLen, nullptr, nullptr, &st) ||
       (st != 0 && st != 0x68)) {
     f.close();
-    ShowStatusAction::show("HF fail: anticoll");
     return false;
   }
 
   // Stream blocks to the slot 8 blocks (128 B) at a time.
+  // Match the PN532 write UI: centered status text + real progress bar.
   f.seek(0);
   uint8_t buf[128];
   uint8_t startBlock = 0;
+  uint32_t loaded = 0;
+
+  const uint16_t totalBlocks = (uint16_t)(size / 16);
+
+  ProgressView::init();
+
   while (f.available()) {
     int n = f.read(buf, sizeof(buf));
     if (n <= 0) break;
-    if (!c.mf1LoadBlockData(_slot, startBlock, buf, (uint16_t)n)) { f.close(); return false; }
+
+    uint16_t loadedBlocks = (uint16_t)(loaded / 16);
+    char msg[40];
+    snprintf(msg, sizeof(msg), "Loading HF slot %u: block %u/%u",
+             _slot + 1,
+             (unsigned)loadedBlocks,
+             (unsigned)totalBlocks);
+
+    int pct = (size > 0) ? (int)((loaded * 100UL) / size) : 0;
+    ProgressView::progress(msg, pct);
+
+    if (!c.mf1LoadBlockData(_slot, startBlock, buf, (uint16_t)n)) {
+      f.close();
+      ProgressView::finish();
+      return false;
+    }
+
+    loaded += (uint32_t)n;
     startBlock += n / 16;
   }
   f.close();
 
+  ProgressView::finish();
+
   if (!c.setSlotEnable(_slot, 2, true)) {
-    ShowStatusAction::show("HF fail: enable");
     return false;
   } // HF = freq 2
   _hfType = tagType;
@@ -335,6 +371,7 @@ void ChameleonSlotEditScreen::_writeContent() {
     static constexpr uint8_t kMax = 10;
     uint8_t n = _browser.load(this, "/unigeek/nfc/dumps", ".bin");
     if (n == 0) {
+      render();
       ShowStatusAction::show("No .bin in nfc/dumps", 1500);
       render();
       return;
@@ -351,14 +388,19 @@ void ChameleonSlotEditScreen::_writeContent() {
     uint8_t idx = (uint8_t)atoi(r);
     if (idx >= count) { render(); return; }
     String path = _browser.entry(idx).path;
-    Uni.Lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
-    Uni.Lcd.setTextColor(TFT_WHITE, TFT_BLACK);
-    Uni.Lcd.setTextDatum(MC_DATUM);
-    Uni.Lcd.drawString("Loading HF dump...",
-                       bodyX() + bodyW() / 2,
-                       bodyY() + bodyH() / 2);
+
+    // The file picker is an overlay and leaves its cleared region behind.
+    // Restore the Slot Edit screen before the blocking BLE load begins.
+    render();
+
     bool ok = _writeHfFromBin(path.c_str());
-    ShowStatusAction::show(ok ? "HF loaded to slot" : "HF load failed", 1500);
+
+    _rebuildLabels();
+    render();
+
+    ShowStatusAction::show(ok ? "HF load OK" : "HF load failed", 1500);
+    render();
+
     if (ok) {
       int n = Achievement.inc("chameleon_slot_loaded");
       if (n == 1) Achievement.unlock("chameleon_slot_loaded");
@@ -366,21 +408,23 @@ void ChameleonSlotEditScreen::_writeContent() {
   } else {
     String hex = InputTextAction::popup("EM410X UID (10 hex)");
     if (hex.length() == 0) { render(); return; }
-    Uni.Lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
-    Uni.Lcd.setTextColor(TFT_WHITE, TFT_BLACK);
-    Uni.Lcd.setTextDatum(MC_DATUM);
-    Uni.Lcd.drawString("Loading LF dump...",
-                       bodyX() + bodyW() / 2,
-                       bodyY() + bodyH() / 2);
+
+    // Restore the Slot Edit screen before the blocking BLE write begins.
+    render();
+
     bool ok = _writeLfFromHex(hex.c_str());
-    ShowStatusAction::show(ok ? "LF loaded to slot" : "LF load failed", 1500);
+
+    _rebuildLabels();
+    render();
+
+    ShowStatusAction::show(ok ? "LF load OK" : "LF load failed", 1500);
+    render();
+
     if (ok) {
       int n = Achievement.inc("chameleon_slot_loaded");
       if (n == 1) Achievement.unlock("chameleon_slot_loaded");
     }
   }
-  _rebuildLabels();
-  render();
 }
 
 void ChameleonSlotEditScreen::onItemSelected(uint8_t index) {

--- a/firmware/src/screens/ble/chameleon/ChameleonSlotEditScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonSlotEditScreen.cpp
@@ -226,7 +226,21 @@ bool ChameleonSlotEditScreen::_writeHfFromBin(const char* path) {
   if (tagType == 0) { f.close(); return false; }
 
   auto& c = ChameleonClient::get();
-  if (!c.setSlotTagType(_slot, tagType)) { f.close(); return false; }
+  if (!c.setSlotTagType(_slot, tagType)) {
+    f.close();
+    ShowStatusAction::show("HF fail: type");
+    return false;
+  }
+  if (!c.setSlotDataDefault(_slot, tagType)) {
+    f.close();
+    ShowStatusAction::show("HF fail: init");
+    return false;
+  }
+  if (!c.setActiveSlot(_slot)) {
+    f.close();
+    ShowStatusAction::show("HF fail: active");
+    return false;
+  }
 
   // Block 0 holds UID / BCC / SAK / ATQA for anti-collision.
   uint8_t block0[16] = {};
@@ -235,12 +249,18 @@ bool ChameleonSlotEditScreen::_writeHfFromBin(const char* path) {
   uint8_t acoPayload[11] = {};
   acoPayload[0] = uidLen;
   memcpy(acoPayload + 1, block0, uidLen);
-  acoPayload[1 + uidLen] = block0[7];  // ATQA reversed for anti-coll payload
-  acoPayload[2 + uidLen] = block0[6];
+  acoPayload[1 + uidLen] = block0[6];  // ATQA in dump order
+  acoPayload[2 + uidLen] = block0[7];
   acoPayload[3 + uidLen] = block0[5];  // SAK
+  acoPayload[4 + uidLen] = 0;          // ATS length (MIFARE Classic: no ATS)
   uint16_t st = 0;
-  c.sendCommand(ChameleonClient::CMD_MF1_SET_ANTI_COLL,
-                acoPayload, 4 + uidLen, nullptr, nullptr, &st);
+  if (!c.sendCommand(ChameleonClient::CMD_MF1_SET_ANTI_COLL,
+                     acoPayload, 5 + uidLen, nullptr, nullptr, &st) ||
+      (st != 0 && st != 0x68)) {
+    f.close();
+    ShowStatusAction::show("HF fail: anticoll");
+    return false;
+  }
 
   // Stream blocks to the slot 8 blocks (128 B) at a time.
   f.seek(0);
@@ -254,7 +274,10 @@ bool ChameleonSlotEditScreen::_writeHfFromBin(const char* path) {
   }
   f.close();
 
-  c.setSlotEnable(_slot, 2, true);    // HF = freq 2
+  if (!c.setSlotEnable(_slot, 2, true)) {
+    ShowStatusAction::show("HF fail: enable");
+    return false;
+  } // HF = freq 2
   _hfType = tagType;
   _hfEnabled = true;
   return true;
@@ -280,8 +303,9 @@ bool ChameleonSlotEditScreen::_writeLfFromHex(const char* hex) {
 
   auto& c = ChameleonClient::get();
   if (!c.setSlotTagType(_slot, 100)) return false;   // EM4100
+  if (!c.setActiveSlot(_slot))       return false;
   if (!c.setEM410XSlot(uid))         return false;
-  c.setSlotEnable(_slot, 1, true);                   // LF = freq 1
+  if (!c.setSlotEnable(_slot, 1, true)) return false; // LF = freq 1
   _lfType    = 100;
   _lfEnabled = true;
   return true;

--- a/firmware/src/screens/ble/chameleon/ChameleonSlotEditScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonSlotEditScreen.cpp
@@ -351,7 +351,12 @@ void ChameleonSlotEditScreen::_writeContent() {
     uint8_t idx = (uint8_t)atoi(r);
     if (idx >= count) { render(); return; }
     String path = _browser.entry(idx).path;
-    ShowStatusAction::show("Loading HF dump...");
+    Uni.Lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
+    Uni.Lcd.setTextColor(TFT_WHITE, TFT_BLACK);
+    Uni.Lcd.setTextDatum(MC_DATUM);
+    Uni.Lcd.drawString("Loading HF dump...",
+                       bodyX() + bodyW() / 2,
+                       bodyY() + bodyH() / 2);
     bool ok = _writeHfFromBin(path.c_str());
     ShowStatusAction::show(ok ? "HF loaded to slot" : "HF load failed", 1500);
     if (ok) {
@@ -361,7 +366,12 @@ void ChameleonSlotEditScreen::_writeContent() {
   } else {
     String hex = InputTextAction::popup("EM410X UID (10 hex)");
     if (hex.length() == 0) { render(); return; }
-    ShowStatusAction::show("Loading LF dump...");
+    Uni.Lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
+    Uni.Lcd.setTextColor(TFT_WHITE, TFT_BLACK);
+    Uni.Lcd.setTextDatum(MC_DATUM);
+    Uni.Lcd.drawString("Loading LF dump...",
+                       bodyX() + bodyW() / 2,
+                       bodyY() + bodyH() / 2);
     bool ok = _writeLfFromHex(hex.c_str());
     ShowStatusAction::show(ok ? "LF loaded to slot" : "LF load failed", 1500);
     if (ok) {

--- a/firmware/src/screens/ble/chameleon/ChameleonSlotEditScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonSlotEditScreen.cpp
@@ -351,6 +351,7 @@ void ChameleonSlotEditScreen::_writeContent() {
     uint8_t idx = (uint8_t)atoi(r);
     if (idx >= count) { render(); return; }
     String path = _browser.entry(idx).path;
+    ShowStatusAction::show("Loading HF dump...");
     bool ok = _writeHfFromBin(path.c_str());
     ShowStatusAction::show(ok ? "HF loaded to slot" : "HF load failed", 1500);
     if (ok) {
@@ -360,6 +361,7 @@ void ChameleonSlotEditScreen::_writeContent() {
   } else {
     String hex = InputTextAction::popup("EM410X UID (10 hex)");
     if (hex.length() == 0) { render(); return; }
+    ShowStatusAction::show("Loading LF dump...");
     bool ok = _writeLfFromHex(hex.c_str());
     ShowStatusAction::show(ok ? "LF loaded to slot" : "LF load failed", 1500);
     if (ok) {

--- a/firmware/src/screens/ble/chameleon/ChameleonSlotsScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonSlotsScreen.cpp
@@ -38,6 +38,13 @@ void ChameleonSlotsScreen::onInit() {
   if (n == 1) Achievement.unlock("chameleon_slots_viewed");
 }
 
+void ChameleonSlotsScreen::onRestore() {
+  // The screen instance is restored from the navigation stack, so onInit()
+  // is not called again. Refresh slot state in-place before ScreenManager
+  // renders the restored screen, preserving the current selection/scroll.
+  _load();
+}
+
 void ChameleonSlotsScreen::onItemSelected(uint8_t index) {
   Screen.push(new ChameleonSlotEditScreen(index));
 }

--- a/firmware/src/screens/ble/chameleon/ChameleonSlotsScreen.h
+++ b/firmware/src/screens/ble/chameleon/ChameleonSlotsScreen.h
@@ -6,6 +6,7 @@ public:
   const char* title() override { return "Slot Manager"; }
 
   void onInit()                      override;
+  void onRestore()                   override;
   void onItemSelected(uint8_t index) override;
   void onBack()                      override;
 

--- a/firmware/src/screens/ble/chameleon/ChameleonVikingScreen.cpp
+++ b/firmware/src/screens/ble/chameleon/ChameleonVikingScreen.cpp
@@ -6,6 +6,7 @@
 #include "core/AchievementManager.h"
 #include "core/ConfigManager.h"
 #include "ui/actions/InputSelectAction.h"
+#include "ui/actions/ShowStatusAction.h"
 
 void ChameleonVikingScreen::_draw() {
   _needsDraw = false;
@@ -17,14 +18,14 @@ void ChameleonVikingScreen::_draw() {
   sp.fillSprite(TFT_BLACK);
   sp.setTextDatum(MC_DATUM);
 
-  if (_state == STATE_IDLE) {
+  if (_state == STATE_IDLE || _state == STATE_ERROR) {
     sp.setTextColor(TFT_CYAN, TFT_BLACK);
     sp.drawString("Viking Scanner", bw / 2, bh / 2 - 20);
     sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
     sp.drawString("Place Viking card", bw / 2, bh / 2);
     sp.setTextColor(TFT_WHITE, TFT_BLACK);
     sp.drawString("[OK] Scan  [Hold] Back", bw / 2, bh / 2 + 20);
-  } else if (_state == STATE_RESULT) {
+  } else if (_state == STATE_RESULT || _state == STATE_CLONED) {
     sp.setTextColor(TFT_GREEN, TFT_BLACK);
     sp.drawString("Viking detected", bw / 2, bh / 2 - 30);
     char hex[24] = {};
@@ -35,16 +36,6 @@ void ChameleonVikingScreen::_draw() {
     sp.drawString(hex, bw / 2, bh / 2 - 10);
     sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
     sp.drawString("[OK] Action  [Hold] Back", bw / 2, bh / 2 + 20);
-  } else if (_state == STATE_CLONED) {
-    sp.setTextColor(TFT_GREEN, TFT_BLACK);
-    sp.drawString("Success!", bw / 2, bh / 2 - 10);
-    sp.setTextColor(TFT_WHITE, TFT_BLACK);
-    sp.drawString("[Back] Menu", bw / 2, bh / 2 + 14);
-  } else {
-    sp.setTextColor(TFT_RED, TFT_BLACK);
-    sp.drawString("No card / failed", bw / 2, bh / 2 - 4);
-    sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-    sp.drawString("[OK] Retry", bw / 2, bh / 2 + 14);
   }
   sp.pushSprite(bx, by);
   sp.deleteSprite();
@@ -66,13 +57,17 @@ void ChameleonVikingScreen::_doScan() {
   c.setMode(1);
   bool ok = c.scanViking(_uid, &_uidLen);
   _scanning = false;
-  _state = ok ? STATE_RESULT : STATE_ERROR;
+  _state = ok ? STATE_RESULT : STATE_IDLE;
   if (ok) {
     int n = Achievement.inc("chameleon_viking_scan");
     if (n == 1) Achievement.unlock("chameleon_viking_scan");
   }
   _needsDraw = true;
   render();
+  if (!ok) {
+    ShowStatusAction::show("No card found", 1200);
+    render();
+  }
 }
 
 void ChameleonVikingScreen::_doCloneSlot() {
@@ -85,8 +80,10 @@ void ChameleonVikingScreen::_doCloneSlot() {
     if (n == 3) Achievement.unlock("chameleon_clone_3");
     if (n == 10) Achievement.unlock("chameleon_clone_10");
   }
-  _state = ok ? STATE_CLONED : STATE_ERROR;
+  _state = STATE_RESULT;
   _needsDraw = true;
+  render();
+  ShowStatusAction::show(ok ? "Clone OK" : "Clone failed", 1200);
   render();
 }
 
@@ -104,8 +101,10 @@ void ChameleonVikingScreen::_doT5577() {
     int n = Achievement.inc("chameleon_t5577_write");
     if (n == 1) Achievement.unlock("chameleon_t5577_write");
   }
-  _state = ok ? STATE_CLONED : STATE_ERROR;
+  _state = STATE_RESULT;
   _needsDraw = true;
+  render();
+  ShowStatusAction::show(ok ? "T5577 write OK" : "T5577 write failed", 1200);
   render();
 }
 

--- a/firmware/src/utils/ble/ChameleonClient.cpp
+++ b/firmware/src/utils/ble/ChameleonClient.cpp
@@ -547,17 +547,19 @@ bool ChameleonClient::mf1CheckKeysOfBlock(uint8_t block, uint8_t keyType,
 
 bool ChameleonClient::mf1LoadBlockData(uint8_t slot, uint8_t startBlock,
                                         const uint8_t* data, uint16_t dataLen) {
+  // CMD_MF1_LOAD_BLOCK operates on the active emulator slot. Its payload is
+  // [startBlock][block data...]; the slot number is not part of the command.
+  if (!setActiveSlot(slot)) return false;
+
   uint16_t st = 0;
-  // Buffer on heap to keep stack small.
-  uint8_t* buf = (uint8_t*)malloc(2 + dataLen);
+  uint8_t* buf = (uint8_t*)malloc(1 + dataLen);
   if (!buf) return false;
-  buf[0] = slot;
-  buf[1] = startBlock;
-  memcpy(buf + 2, data, dataLen);
-  bool ok = sendCommand(CMD_MF1_LOAD_BLOCK, buf, 2 + dataLen,
+  buf[0] = startBlock;
+  memcpy(buf + 1, data, dataLen);
+  bool ok = sendCommand(CMD_MF1_LOAD_BLOCK, buf, 1 + dataLen,
                         nullptr, nullptr, &st, 3000);
   free(buf);
-  return ok && st == 0;
+  return ok && (st == 0 || st == 0x68);
 }
 
 bool ChameleonClient::mf1GetBlockData(uint8_t startBlock, uint8_t count, uint8_t* out,

--- a/firmware/src/utils/ble/ChameleonClient.cpp
+++ b/firmware/src/utils/ble/ChameleonClient.cpp
@@ -328,23 +328,35 @@ uint16_t ChameleonClient::inferHFTagType(uint8_t sak, const uint8_t atqa[2]) {
 bool ChameleonClient::cloneHF(uint8_t slot, uint16_t tagType,
                                const uint8_t* uid, uint8_t uidLen,
                                const uint8_t atqa[2], uint8_t sak) {
-  uint16_t st = 0;
+  // Match the slot-loader sequence that is known to work:
+  // configure type -> initialise slot memory -> select slot ->
+  // configure anti-collision -> enable HF -> emulator mode.
+  if (!setSlotTagType(slot, tagType)) return false;
+  if (!setSlotDataDefault(slot, tagType)) return false;
+  if (!setActiveSlot(slot)) return false;
 
-  uint8_t typePayload[3] = { slot, (uint8_t)(tagType >> 8), (uint8_t)(tagType & 0xFF) };
-  if (!sendCommand(CMD_SET_SLOT_TAG_TYPE, typePayload, 3, nullptr, nullptr, &st)) return false;
-
-  // ATQA bytes are reversed in the anti-collision payload
-  uint8_t acoPayload[11] = {};
+  // Anti-collision payload:
+  //   uidLen | UID | ATQA[0] | ATQA[1] | SAK | ATS length
+  //
+  // scan14A() already returns ATQA in the order expected by the firmware.
+  // The old clone path reversed these bytes and omitted the ATS-length byte.
+  uint8_t acoPayload[12] = {};
   acoPayload[0] = uidLen;
   memcpy(acoPayload + 1, uid, uidLen);
-  acoPayload[1 + uidLen] = atqa[1];
-  acoPayload[2 + uidLen] = atqa[0];
+  acoPayload[1 + uidLen] = atqa[0];
+  acoPayload[2 + uidLen] = atqa[1];
   acoPayload[3 + uidLen] = sak;
-  if (!sendCommand(CMD_MF1_SET_ANTI_COLL, acoPayload, 4 + uidLen, nullptr, nullptr, &st)) return false;
+  acoPayload[4 + uidLen] = 0; // no ATS for MIFARE Classic
 
-  uint8_t enPayload[3] = { slot, 2, 1 }; // freq=HF(2), enabled
-  if (!sendCommand(CMD_SET_SLOT_ENABLE, enPayload, 3, nullptr, nullptr, &st)) return false;
+  uint16_t st = 0;
+  if (!sendCommand(CMD_MF1_SET_ANTI_COLL,
+                   acoPayload, 5 + uidLen,
+                   nullptr, nullptr, &st) ||
+      (st != 0 && st != 0x68)) {
+    return false;
+  }
 
+  if (!setSlotEnable(slot, 2, true)) return false; // HF
   return setMode(0); // emulator mode
 }
 
@@ -547,19 +559,17 @@ bool ChameleonClient::mf1CheckKeysOfBlock(uint8_t block, uint8_t keyType,
 
 bool ChameleonClient::mf1LoadBlockData(uint8_t slot, uint8_t startBlock,
                                         const uint8_t* data, uint16_t dataLen) {
-  // CMD_MF1_LOAD_BLOCK operates on the active emulator slot. Its payload is
-  // [startBlock][block data...]; the slot number is not part of the command.
-  if (!setActiveSlot(slot)) return false;
-
   uint16_t st = 0;
-  uint8_t* buf = (uint8_t*)malloc(1 + dataLen);
+  // Buffer on heap to keep stack small.
+  uint8_t* buf = (uint8_t*)malloc(2 + dataLen);
   if (!buf) return false;
-  buf[0] = startBlock;
-  memcpy(buf + 1, data, dataLen);
-  bool ok = sendCommand(CMD_MF1_LOAD_BLOCK, buf, 1 + dataLen,
+  buf[0] = slot;
+  buf[1] = startBlock;
+  memcpy(buf + 2, data, dataLen);
+  bool ok = sendCommand(CMD_MF1_LOAD_BLOCK, buf, 2 + dataLen,
                         nullptr, nullptr, &st, 3000);
   free(buf);
-  return ok && (st == 0 || st == 0x68);
+  return ok && st == 0;
 }
 
 bool ChameleonClient::mf1GetBlockData(uint8_t startBlock, uint8_t count, uint8_t* out,

--- a/firmware/src/utils/ble/ChameleonClient.cpp
+++ b/firmware/src/utils/ble/ChameleonClient.cpp
@@ -559,17 +559,19 @@ bool ChameleonClient::mf1CheckKeysOfBlock(uint8_t block, uint8_t keyType,
 
 bool ChameleonClient::mf1LoadBlockData(uint8_t slot, uint8_t startBlock,
                                         const uint8_t* data, uint16_t dataLen) {
+  // CMD_MF1_LOAD_BLOCK operates on the active emulator slot. Its payload is
+  // [startBlock][block data...]; the slot number is not part of the command.
+  if (!setActiveSlot(slot)) return false;
+
   uint16_t st = 0;
-  // Buffer on heap to keep stack small.
-  uint8_t* buf = (uint8_t*)malloc(2 + dataLen);
+  uint8_t* buf = (uint8_t*)malloc(1 + dataLen);
   if (!buf) return false;
-  buf[0] = slot;
-  buf[1] = startBlock;
-  memcpy(buf + 2, data, dataLen);
-  bool ok = sendCommand(CMD_MF1_LOAD_BLOCK, buf, 2 + dataLen,
+  buf[0] = startBlock;
+  memcpy(buf + 1, data, dataLen);
+  bool ok = sendCommand(CMD_MF1_LOAD_BLOCK, buf, 1 + dataLen,
                         nullptr, nullptr, &st, 3000);
   free(buf);
-  return ok && st == 0;
+  return ok && (st == 0 || st == 0x68);
 }
 
 bool ChameleonClient::mf1GetBlockData(uint8_t startBlock, uint8_t count, uint8_t* out,


### PR DESCRIPTION
## Summary

This PR improves Chameleon Ultra slot management and fixes loading tag content into emulator slots (#76).

### Changes

- Refresh Slot Manager state when returning from a slot screen.
- Fix MIFARE Classic dump loading into HF slots.
- Properly initialize HF slot data before loading a dump.
- Fix MF1 emulator block-load command handling.
- Handle the Chameleon HF success status correctly.
- Fix MIFARE Classic anti-collision configuration (UID, ATQA, SAK and ATS length).
- Fix ATQA byte order when restoring MIFARE Classic dumps.
- Ensure the target slot is selected when writing HF/LF content.
- Improve LF slot content loading.

## Tested

- MIFARE Classic 1K dump created from a physical tag.
- Dump successfully loaded into a Chameleon Ultra slot.
- Loaded dump verified through the slot content viewer.
- HF emulation successfully read by an external NFC reader.
- Slot Manager correctly refreshes after changing the active slot.