### PR TITLE
Add TCP, Telnet, SSH, FTP, and SFTP clients

### DIFF
--- a/firmware/boards/m5_cardputer/core/Keyboard.h
+++ b/firmware/boards/m5_cardputer/core/Keyboard.h
@@ -97,7 +97,7 @@ public:
         uint8_t x = x1 ? _KB_X1[j] : _KB_X2[j];
         char n = _KB_MAP[yf][x].n;
         if (n == '\0') continue; // modifier key
-        char c = _shift ? _KB_MAP[yf][x].s : n;
+        char c = (_fn && n == '`') ? '\x1b' : (_shift ? _KB_MAP[yf][x].s : n);
         _key       = c;
         _available = true;
         _setOutput(0); // restore

--- a/firmware/boards/m5_cardputer/core/Keyboard.h
+++ b/firmware/boards/m5_cardputer/core/Keyboard.h
@@ -97,7 +97,7 @@ public:
         uint8_t x = x1 ? _KB_X1[j] : _KB_X2[j];
         char n = _KB_MAP[yf][x].n;
         if (n == '\0') continue; // modifier key
-        char c = (_fn && n == '`') ? '\x1b' : (_shift ? _KB_MAP[yf][x].s : n);
+        char c = _shift ? _KB_MAP[yf][x].s : n;
         _key       = c;
         _available = true;
         _setOutput(0); // restore

--- a/firmware/boards/m5_cardputer_adv/core/Keyboard.h
+++ b/firmware/boards/m5_cardputer_adv/core/Keyboard.h
@@ -89,7 +89,7 @@ public:
     if (_available) return;
     if (n == '\0') return;
 
-    _key       = _shift ? _ADV_KB_MAP[row][col].s : n;
+    _key       = (_fn && n == '`') ? '\x1b' : (_shift ? _ADV_KB_MAP[row][col].s : n);
     _available = true;
     _keyHeld   = true;
   }

--- a/firmware/boards/m5_cardputer_adv/core/Keyboard.h
+++ b/firmware/boards/m5_cardputer_adv/core/Keyboard.h
@@ -89,7 +89,7 @@ public:
     if (_available) return;
     if (n == '\0') return;
 
-    _key       = (_fn && n == '`') ? '\x1b' : (_shift ? _ADV_KB_MAP[row][col].s : n);
+    _key       = _shift ? _ADV_KB_MAP[row][col].s : n;
     _available = true;
     _keyHeld   = true;
   }

--- a/firmware/lib/LibSSH-SFTP/README.md
+++ b/firmware/lib/LibSSH-SFTP/README.md
@@ -1,0 +1,11 @@
+# LibSSH-SFTP
+
+Minimal local SFTP extension for the UniGeek firmware.
+
+Upstream: libssh 0.11.5
+
+Local adaptations:
+- config.h -> libssh_esp32_config.h
+- sibling libssh header includes -> <libssh/...>
+- WITH_SFTP enabled only in local SFTP translation units
+- asynchronous SFTP sources omitted

--- a/firmware/lib/LibSSH-SFTP/library.json
+++ b/firmware/lib/LibSSH-SFTP/library.json
@@ -1,0 +1,14 @@
+{
+  "name": "LibSSH-SFTP",
+  "version": "0.11.5-ug2",
+  "description": "Minimal synchronous SFTP client support for LibSSH-ESP32 0.11.5",
+  "build": {
+    "srcFilter": [
+      "+<sftp.c>",
+      "+<sftp_common.c>"
+    ]
+  },
+  "dependencies": {
+    "LibSSH-ESP32": "*"
+  }
+}

--- a/firmware/lib/LibSSH-SFTP/src/libssh/sftp.h
+++ b/firmware/lib/LibSSH-SFTP/src/libssh/sftp.h
@@ -1,0 +1,1392 @@
+/*
+ * This file is part of the SSH Library
+ *
+ * Copyright (c) 2003-2008 by Aris Adamantiadis
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+/**
+ * @defgroup libssh_sftp The libssh SFTP API
+ *
+ * @brief SFTP handling functions
+ *
+ * SFTP commands are channeled by the ssh sftp subsystem. Every packet is
+ * sent/read using a sftp_packet type structure. Related to these packets,
+ * most of the server answers are messages having an ID and a message
+ * specific part. It is described by sftp_message when reading a message,
+ * the sftp system puts it into the queue, so the process having asked for
+ * it can fetch it, while continuing to read for other messages (it is
+ * unspecified in which order messages may be sent back to the client
+ *
+ * @{
+ */
+
+#ifndef SFTP_H
+#define SFTP_H
+
+#include <sys/types.h>
+
+#include <libssh/libssh.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef _WIN32
+#ifndef uid_t
+  typedef uint32_t uid_t;
+#endif /* uid_t */
+#ifndef gid_t
+  typedef uint32_t gid_t;
+#endif /* gid_t */
+#ifdef _MSC_VER
+
+# ifndef _SSIZE_T_DEFINED
+#  undef ssize_t
+#  include <BaseTsd.h>
+   typedef _W64 SSIZE_T ssize_t;
+#  define _SSIZE_T_DEFINED
+# endif /* _SSIZE_T_DEFINED */
+
+#endif /* _MSC_VER */
+#endif /* _WIN32 */
+
+#define LIBSFTP_VERSION 3
+
+typedef struct sftp_attributes_struct* sftp_attributes;
+typedef struct sftp_client_message_struct* sftp_client_message;
+typedef struct sftp_dir_struct* sftp_dir;
+typedef struct sftp_ext_struct *sftp_ext;
+typedef struct sftp_file_struct* sftp_file;
+typedef struct sftp_message_struct* sftp_message;
+typedef struct sftp_packet_struct* sftp_packet;
+typedef struct sftp_request_queue_struct* sftp_request_queue;
+typedef struct sftp_session_struct* sftp_session;
+typedef struct sftp_status_message_struct* sftp_status_message;
+typedef struct sftp_statvfs_struct* sftp_statvfs_t;
+typedef struct sftp_limits_struct* sftp_limits_t;
+typedef struct sftp_aio_struct* sftp_aio;
+
+struct sftp_session_struct {
+    ssh_session session;
+    ssh_channel channel;
+    int server_version;
+    int client_version;
+    int version;
+    sftp_request_queue queue;
+    uint32_t id_counter;
+    int errnum;
+    void **handles;
+    sftp_ext ext;
+    sftp_packet read_packet;
+    sftp_limits_t limits;
+    struct ssh_list *outstanding_ids;
+};
+
+struct sftp_packet_struct {
+    sftp_session sftp;
+    uint8_t type;
+    ssh_buffer payload;
+};
+
+/* file handler */
+struct sftp_file_struct {
+    sftp_session sftp;
+    char *name;
+    uint64_t offset;
+    ssh_string handle;
+    int eof;
+    int nonblocking;
+};
+
+struct sftp_dir_struct {
+    sftp_session sftp;
+    char *name;
+    ssh_string handle; /* handle to directory */
+    ssh_buffer buffer; /* contains raw attributes from server which haven't been parsed */
+    uint32_t count; /* counts the number of following attributes structures into buffer */
+    int eof; /* end of directory listing */
+};
+
+struct sftp_message_struct {
+    sftp_session sftp;
+    uint8_t packet_type;
+    ssh_buffer payload;
+    uint32_t id;
+};
+
+/* this is a bunch of all data that could be into a message */
+struct sftp_client_message_struct {
+    sftp_session sftp;
+    uint8_t type;
+    uint32_t id;
+    char *filename; /* can be "path" */
+    uint32_t flags;
+    sftp_attributes attr;
+    ssh_string handle;
+    uint64_t offset;
+    uint32_t len;
+    int attr_num;
+    ssh_buffer attrbuf; /* used by sftp_reply_attrs */
+    ssh_string data; /* can be newpath of rename() */
+    ssh_buffer complete_message; /* complete message in case of retransmission*/
+    char *str_data; /* cstring version of data */
+    char *submessage; /* for extended messages */
+};
+
+struct sftp_request_queue_struct {
+    sftp_request_queue next;
+    sftp_message message;
+};
+
+/* SSH_FXP_MESSAGE described into .7 page 26 */
+struct sftp_status_message_struct {
+    uint32_t id;
+	uint32_t status;
+    ssh_string error_unused; /* not used anymore */
+    ssh_string lang_unused;  /* not used anymore */
+    char *errormsg;
+    char *langmsg;
+};
+
+struct sftp_attributes_struct {
+    char *name;
+    char *longname; /* ls -l output on openssh, not reliable else */
+    uint32_t flags;
+    uint8_t type;
+    uint64_t size;
+    uint32_t uid;
+    uint32_t gid;
+    char *owner; /* set if openssh and version 4 */
+    char *group; /* set if openssh and version 4 */
+    uint32_t permissions;
+    uint64_t atime64;
+    uint32_t atime;
+    uint32_t atime_nseconds;
+    uint64_t createtime;
+    uint32_t createtime_nseconds;
+    uint64_t mtime64;
+    uint32_t mtime;
+    uint32_t mtime_nseconds;
+    ssh_string acl;
+    uint32_t extended_count;
+    ssh_string extended_type;
+    ssh_string extended_data;
+};
+
+/**
+ * @brief SFTP statvfs structure.
+ */
+struct sftp_statvfs_struct {
+  uint64_t f_bsize;   /** file system block size */
+  uint64_t f_frsize;  /** fundamental fs block size */
+  uint64_t f_blocks;  /** number of blocks (unit f_frsize) */
+  uint64_t f_bfree;   /** free blocks in file system */
+  uint64_t f_bavail;  /** free blocks for non-root */
+  uint64_t f_files;   /** total file inodes */
+  uint64_t f_ffree;   /** free file inodes */
+  uint64_t f_favail;  /** free file inodes for to non-root */
+  uint64_t f_fsid;    /** file system id */
+  uint64_t f_flag;    /** bit mask of f_flag values */
+  uint64_t f_namemax; /** maximum filename length */
+};
+
+/**
+ * @brief SFTP limits structure.
+ */
+struct sftp_limits_struct {
+    uint64_t max_packet_length;   /** maximum number of bytes in a single sftp packet */
+    uint64_t max_read_length;     /** maximum length in a SSH_FXP_READ packet */
+    uint64_t max_write_length;    /** maximum length in a SSH_FXP_WRITE packet */
+    uint64_t max_open_handles;    /** maximum number of active handles allowed by server */
+};
+
+/**
+ * @brief Creates a new sftp session.
+ *
+ * This function creates a new sftp session and allocates a new sftp channel
+ * with the server inside of the provided ssh session. This function call is
+ * usually followed by the sftp_init(), which initializes SFTP protocol itself.
+ *
+ * @param session       The ssh session to use.
+ *
+ * @return              A new sftp session or NULL on error.
+ *
+ * @see sftp_free()
+ * @see sftp_init()
+ */
+LIBSSH_API sftp_session sftp_new(ssh_session session);
+
+/**
+ * @brief Start a new sftp session with an existing channel.
+ *
+ * @param session       The ssh session to use.
+ * @param channel		An open session channel with subsystem already allocated
+ *
+ * @return              A new sftp session or NULL on error.
+ *
+ * @see sftp_free()
+ */
+LIBSSH_API sftp_session sftp_new_channel(ssh_session session, ssh_channel channel);
+
+
+/**
+ * @brief Close and deallocate a sftp session.
+ *
+ * @param sftp          The sftp session handle to free.
+ */
+LIBSSH_API void sftp_free(sftp_session sftp);
+
+/**
+ * @brief Initialize the sftp protocol with the server.
+ *
+ * This function involves the SFTP protocol initialization (as described
+ * in the SFTP specification), including the version and extensions negotiation.
+ *
+ * @param sftp          The sftp session to initialize.
+ *
+ * @return              0 on success, < 0 on error with ssh error set.
+ *
+ * @see sftp_new()
+ */
+LIBSSH_API int sftp_init(sftp_session sftp);
+
+/**
+ * @brief Get the last sftp error.
+ *
+ * Use this function to get the latest error set by a posix like sftp function.
+ *
+ * @param sftp          The sftp session where the error is saved.
+ *
+ * @return              The saved error (see server responses), < 0 if an error
+ *                      in the function occurred.
+ *
+ * @see Server responses
+ */
+LIBSSH_API int sftp_get_error(sftp_session sftp);
+
+/**
+ * @brief Get the count of extensions provided by the server.
+ *
+ * @param  sftp         The sftp session to use.
+ *
+ * @return The count of extensions provided by the server, 0 on error or
+ *         not available.
+ */
+LIBSSH_API unsigned int sftp_extensions_get_count(sftp_session sftp);
+
+/**
+ * @brief Get the name of the extension provided by the server.
+ *
+ * @param  sftp         The sftp session to use.
+ *
+ * @param  indexn        The index number of the extension name you want.
+ *
+ * @return              The name of the extension.
+ */
+LIBSSH_API const char *sftp_extensions_get_name(sftp_session sftp, unsigned int indexn);
+
+/**
+ * @brief Get the data of the extension provided by the server.
+ *
+ * This is normally the version number of the extension.
+ *
+ * @param  sftp         The sftp session to use.
+ *
+ * @param  indexn        The index number of the extension data you want.
+ *
+ * @return              The data of the extension.
+ */
+LIBSSH_API const char *sftp_extensions_get_data(sftp_session sftp, unsigned int indexn);
+
+/**
+ * @brief Check if the given extension is supported.
+ *
+ * @param  sftp         The sftp session to use.
+ *
+ * @param  name         The name of the extension.
+ *
+ * @param  data         The data of the extension.
+ *
+ * @return 1 if supported, 0 if not.
+ *
+ * Example:
+ *
+ * @code
+ * sftp_extension_supported(sftp, "statvfs@openssh.com", "2");
+ * @endcode
+ */
+LIBSSH_API int sftp_extension_supported(sftp_session sftp, const char *name,
+    const char *data);
+
+/**
+ * @brief Open a directory used to obtain directory entries.
+ *
+ * @param session       The sftp session handle to open the directory.
+ * @param path          The path of the directory to open.
+ *
+ * @return              A sftp directory handle or NULL on error with ssh and
+ *                      sftp error set.
+ *
+ * @see                 sftp_readdir
+ * @see                 sftp_closedir
+ */
+LIBSSH_API sftp_dir sftp_opendir(sftp_session session, const char *path);
+
+/**
+ * @brief Get a single file attributes structure of a directory.
+ *
+ * @param session      The sftp session handle to read the directory entry.
+ * @param dir          The opened sftp directory handle to read from.
+ *
+ * @return             A file attribute structure or NULL at the end of the
+ *                     directory.
+ *
+ * @see                sftp_opendir()
+ * @see                sftp_attribute_free()
+ * @see                sftp_closedir()
+ */
+LIBSSH_API sftp_attributes sftp_readdir(sftp_session session, sftp_dir dir);
+
+/**
+ * @brief Tell if the directory has reached EOF (End Of File).
+ *
+ * @param dir           The sftp directory handle.
+ *
+ * @return              1 if the directory is EOF, 0 if not.
+ *
+ * @see                 sftp_readdir()
+ */
+LIBSSH_API int sftp_dir_eof(sftp_dir dir);
+
+/**
+ * @brief Get information about a file or directory.
+ *
+ * @param session       The sftp session handle.
+ * @param path          The path to the file or directory to obtain the
+ *                      information.
+ *
+ * @return              The sftp attributes structure of the file or directory,
+ *                      NULL on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API sftp_attributes sftp_stat(sftp_session session, const char *path);
+
+/**
+ * @brief Get information about a file or directory.
+ *
+ * Identical to sftp_stat, but if the file or directory is a symbolic link,
+ * then the link itself is stated, not the file that it refers to.
+ *
+ * @param session       The sftp session handle.
+ * @param path          The path to the file or directory to obtain the
+ *                      information.
+ *
+ * @return              The sftp attributes structure of the file or directory,
+ *                      NULL on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API sftp_attributes sftp_lstat(sftp_session session, const char *path);
+
+/**
+ * @brief Get information about a file or directory from a file handle.
+ *
+ * @param file          The sftp file handle to get the stat information.
+ *
+ * @return              The sftp attributes structure of the file or directory,
+ *                      NULL on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API sftp_attributes sftp_fstat(sftp_file file);
+
+/**
+ * @brief Free a sftp attribute structure.
+ *
+ * @param file          The sftp attribute structure to free.
+ */
+LIBSSH_API void sftp_attributes_free(sftp_attributes file);
+
+/**
+ * @brief Close a directory handle opened by sftp_opendir().
+ *
+ * @param dir           The sftp directory handle to close.
+ *
+ * @return              Returns SSH_NO_ERROR or SSH_ERROR if an error occurred.
+ */
+LIBSSH_API int sftp_closedir(sftp_dir dir);
+
+/**
+ * @brief Close an open file handle.
+ *
+ * @param file          The open sftp file handle to close.
+ *
+ * @return              Returns SSH_NO_ERROR or SSH_ERROR if an error occurred.
+ *
+ * @see                 sftp_open()
+ */
+LIBSSH_API int sftp_close(sftp_file file);
+
+/**
+ * @brief Open a file on the server.
+ *
+ * @param session       The sftp session handle.
+ *
+ * @param file          The file to be opened.
+ *
+ * @param accesstype    Is one of O_RDONLY, O_WRONLY or O_RDWR which request
+ *                      opening  the  file  read-only,write-only or read/write.
+ *                      Acesss may also be bitwise-or'd with one or  more of
+ *                      the following:
+ *                      O_CREAT - If the file does not exist it will be
+ *                      created.
+ *                      O_EXCL - When  used with O_CREAT, if the file already
+ *                      exists it is an error and the open will fail.
+ *                      O_TRUNC - If the file already exists it will be
+ *                      truncated.
+ *
+ * @param mode          Mode specifies the permissions to use if a new file is
+ *                      created.  It  is  modified  by  the process's umask in
+ *                      the usual way: The permissions of the created file are
+ *                      (mode & ~umask)
+ *
+ * @return              A sftp file handle, NULL on error with ssh and sftp
+ *                      error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API sftp_file sftp_open(sftp_session session, const char *file, int accesstype,
+    mode_t mode);
+
+/**
+ * @brief Make the sftp communication for this file handle non blocking.
+ *
+ * @param[in]  handle   The file handle to set non blocking.
+ */
+LIBSSH_API void sftp_file_set_nonblocking(sftp_file handle);
+
+/**
+ * @brief Make the sftp communication for this file handle blocking.
+ *
+ * @param[in]  handle   The file handle to set blocking.
+ */
+LIBSSH_API void sftp_file_set_blocking(sftp_file handle);
+
+/**
+ * @brief Read from a file using an opened sftp file handle.
+ *
+ * This function caps the length a user is allowed to read from an sftp file.
+ *
+ * The value used for the cap is same as the value of the max_read_length
+ * field of the sftp_limits_t returned by sftp_limits().
+ *
+ * @param file          The opened sftp file handle to be read from.
+ *
+ * @param buf           Pointer to buffer to receive read data.
+ *
+ * @param count         Size of the buffer in bytes.
+ *
+ * @return              Number of bytes read, < 0 on error with ssh and sftp
+ *                      error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API ssize_t sftp_read(sftp_file file, void *buf, size_t count);
+
+/**
+ * @brief Start an asynchronous read from a file using an opened sftp file handle.
+ *
+ * Its goal is to avoid the slowdowns related to the request/response pattern
+ * of a synchronous read. To do so, you must call 2 functions:
+ *
+ * sftp_async_read_begin() and sftp_async_read().
+ *
+ * The first step is to call sftp_async_read_begin(). This function returns a
+ * request identifier. The second step is to call sftp_async_read() using the
+ * returned identifier.
+ *
+ * @param file          The opened sftp file handle to be read from.
+ *
+ * @param len           Size to read in bytes.
+ *
+ * @return              An identifier corresponding to the sent request, < 0 on
+ *                      error.
+ *
+ * @warning             When calling this function, the internal offset is
+ *                      updated corresponding to the len parameter.
+ *
+ * @warning             A call to sftp_async_read_begin() sends a request to
+ *                      the server. When the server answers, libssh allocates
+ *                      memory to store it until sftp_async_read() is called.
+ *                      Not calling sftp_async_read() will lead to memory
+ *                      leaks.
+ *
+ * @see                 sftp_async_read()
+ * @see                 sftp_open()
+ */
+SSH_DEPRECATED LIBSSH_API int sftp_async_read_begin(sftp_file file,
+                                                    uint32_t len);
+
+/**
+ * @brief Wait for an asynchronous read to complete and save the data.
+ *
+ * @param file          The opened sftp file handle to be read from.
+ *
+ * @param data          Pointer to buffer to receive read data.
+ *
+ * @param len           Size of the buffer in bytes. It should be bigger or
+ *                      equal to the length parameter of the
+ *                      sftp_async_read_begin() call.
+ *
+ * @param id            The identifier returned by the sftp_async_read_begin()
+ *                      function.
+ *
+ * @return              Number of bytes read, 0 on EOF, SSH_ERROR if an error
+ *                      occurred, SSH_AGAIN if the file is opened in nonblocking
+ *                      mode and the request hasn't been executed yet.
+ *
+ * @warning             A call to this function with an invalid identifier
+ *                      will never return.
+ *
+ * @see sftp_async_read_begin()
+ */
+SSH_DEPRECATED LIBSSH_API int sftp_async_read(sftp_file file,
+                                              void *data,
+                                              uint32_t len,
+                                              uint32_t id);
+
+/**
+ * @brief Write to a file using an opened sftp file handle.
+ *
+ * This function caps the length a user is allowed to write to an sftp file.
+ *
+ * The value used for the cap is same as the value of the max_write_length
+ * field of the sftp_limits_t returned by sftp_limits().
+ *
+ * @param file          Open sftp file handle to write to.
+ *
+ * @param buf           Pointer to buffer to write data.
+ *
+ * @param count         Size of buffer in bytes.
+ *
+ * @return              Number of bytes written, < 0 on error with ssh and sftp
+ *                      error set.
+ *
+ * @see                 sftp_open()
+ * @see                 sftp_read()
+ * @see                 sftp_close()
+ */
+LIBSSH_API ssize_t sftp_write(sftp_file file, const void *buf, size_t count);
+
+/**
+ * @brief Deallocate memory corresponding to a sftp aio handle.
+ *
+ * This function deallocates memory corresponding to the aio handle returned
+ * by the sftp_aio_begin_*() functions. Users can use this function to free
+ * memory corresponding to an aio handle for an outstanding async i/o request
+ * on encountering some error.
+ *
+ * @param aio           sftp aio handle corresponding to which memory has
+ *                      to be deallocated.
+ *
+ * @see sftp_aio_begin_read()
+ * @see sftp_aio_wait_read()
+ * @see sftp_aio_begin_write()
+ * @see sftp_aio_wait_write()
+ */
+LIBSSH_API void sftp_aio_free(sftp_aio aio);
+#define SFTP_AIO_FREE(x) \
+    do { if(x != NULL) {sftp_aio_free(x); x = NULL;} } while(0)
+
+/**
+ * @brief Start an asynchronous read from a file using an opened sftp
+ * file handle.
+ *
+ * Its goal is to avoid the slowdowns related to the request/response pattern
+ * of a synchronous read. To do so, you must call 2 functions :
+ *
+ * sftp_aio_begin_read() and sftp_aio_wait_read().
+ *
+ * - The first step is to call sftp_aio_begin_read(). This function sends a
+ *   read request to the sftp server, dynamically allocates memory to store
+ *   information about the sent request and provides the caller an sftp aio
+ *   handle to that memory.
+ *
+ * - The second step is to call sftp_aio_wait_read() and pass it the address
+ *   of a location storing the sftp aio handle provided by
+ *   sftp_aio_begin_read().
+ *
+ * These two functions do not close the open sftp file handle passed to
+ * sftp_aio_begin_read() irrespective of whether they fail or not.
+ *
+ * It is the responsibility of the caller to ensure that the open sftp file
+ * handle passed to sftp_aio_begin_read() must not be closed before the
+ * corresponding call to sftp_aio_wait_read(). After sftp_aio_wait_read()
+ * returns, it is caller's decision whether to immediately close the file by
+ * calling sftp_close() or to keep it open and perform some more operations
+ * on it.
+ *
+ * This function caps the length a user is allowed to read from an sftp file,
+ * the value of len parameter after capping is returned on success.
+ *
+ * The value used for the cap is same as the value of the max_read_length
+ * field of the sftp_limits_t returned by sftp_limits().
+ *
+ * @param file          The opened sftp file handle to be read from.
+ *
+ * @param len           Number of bytes to read.
+ *
+ * @param aio           Pointer to a location where the sftp aio handle
+ *                      (corresponding to the sent request) should be stored.
+ *
+ * @returns             On success, the number of bytes the server is
+ *                      requested to read (value of len parameter after
+ *                      capping). On error, SSH_ERROR with sftp and ssh
+ *                      errors set.
+ *
+ * @warning             When calling this function, the internal file offset is
+ *                      updated corresponding to the number of bytes requested
+ *                      to read.
+ *
+ * @warning             A call to sftp_aio_begin_read() sends a request to
+ *                      the server. When the server answers, libssh allocates
+ *                      memory to store it until sftp_aio_wait_read() is called.
+ *                      Not calling sftp_aio_wait_read() will lead to memory
+ *                      leaks.
+ *
+ * @see                 sftp_aio_wait_read()
+ * @see                 sftp_aio_free()
+ * @see                 sftp_open()
+ * @see                 sftp_close()
+ * @see                 sftp_get_error()
+ * @see                 ssh_get_error()
+ */
+LIBSSH_API ssize_t sftp_aio_begin_read(sftp_file file,
+                                       size_t len,
+                                       sftp_aio *aio);
+
+/**
+ * @brief Wait for an asynchronous read to complete and store the read data
+ * in the supplied buffer.
+ *
+ * A pointer to an sftp aio handle should be passed while calling
+ * this function. Except when the return value is SSH_AGAIN,
+ * this function releases the memory corresponding to the supplied
+ * aio handle and assigns NULL to that aio handle using the passed
+ * pointer to that handle.
+ *
+ * If the file is opened in non-blocking mode and the request hasn't been
+ * executed yet, this function returns SSH_AGAIN and must be called again
+ * using the same sftp aio handle.
+ *
+ * @param aio           Pointer to the sftp aio handle returned by
+ *                      sftp_aio_begin_read().
+ *
+ * @param buf           Pointer to the buffer in which read data will be stored.
+ *
+ * @param buf_size      Size of the buffer in bytes. It should be bigger or
+ *                      equal to the length parameter of the
+ *                      sftp_aio_begin_read() call.
+ *
+ * @return              Number of bytes read, 0 on EOF, SSH_ERROR if an error
+ *                      occurred, SSH_AGAIN if the file is opened in nonblocking
+ *                      mode and the request hasn't been executed yet.
+ *
+ * @warning             A call to this function with an invalid sftp aio handle
+ *                      may never return.
+ *
+ * @see sftp_aio_begin_read()
+ * @see sftp_aio_free()
+ */
+LIBSSH_API ssize_t sftp_aio_wait_read(sftp_aio *aio,
+                                      void *buf,
+                                      size_t buf_size);
+
+/**
+ * @brief Start an asynchronous write to a file using an opened sftp
+ * file handle.
+ *
+ * Its goal is to avoid the slowdowns related to the request/response pattern
+ * of a synchronous write. To do so, you must call 2 functions :
+ *
+ * sftp_aio_begin_write() and sftp_aio_wait_write().
+ *
+ * - The first step is to call sftp_aio_begin_write(). This function sends a
+ *   write request to the sftp server, dynamically allocates memory to store
+ *   information about the sent request and provides the caller an sftp aio
+ *   handle to that memory.
+ *
+ * - The second step is to call sftp_aio_wait_write() and pass it the address
+ *   of a location storing the sftp aio handle provided by
+ *   sftp_aio_begin_write().
+ *
+ * These two functions do not close the open sftp file handle passed to
+ * sftp_aio_begin_write() irrespective of whether they fail or not.
+ *
+ * It is the responsibility of the caller to ensure that the open sftp file
+ * handle passed to sftp_aio_begin_write() must not be closed before the
+ * corresponding call to sftp_aio_wait_write(). After sftp_aio_wait_write()
+ * returns, it is caller's decision whether to immediately close the file by
+ * calling sftp_close() or to keep it open and perform some more operations
+ * on it.
+ *
+ * This function caps the length a user is allowed to write to an sftp file,
+ * the value of len parameter after capping is returned on success.
+ *
+ * The value used for the cap is same as the value of the max_write_length
+ * field of the sftp_limits_t returned by sftp_limits().
+ *
+ * @param file          The opened sftp file handle to write to.
+ *
+ * @param buf           Pointer to the buffer containing data to write.
+ *
+ * @param len           Number of bytes to write.
+ *
+ * @param aio           Pointer to a location where the sftp aio handle
+ *                      (corresponding to the sent request) should be stored.
+ *
+ * @returns             On success, the number of bytes the server is
+ *                      requested to write (value of len parameter after
+ *                      capping). On error, SSH_ERROR with sftp and ssh errors
+ *                      set.
+ *
+ * @warning             When calling this function, the internal file offset is
+ *                      updated corresponding to the number of bytes requested
+ *                      to write.
+ *
+ * @warning             A call to sftp_aio_begin_write() sends a request to
+ *                      the server. When the server answers, libssh allocates
+ *                      memory to store it until sftp_aio_wait_write() is
+ *                      called. Not calling sftp_aio_wait_write() will lead to
+ *                      memory leaks.
+ *
+ * @see                 sftp_aio_wait_write()
+ * @see                 sftp_aio_free()
+ * @see                 sftp_open()
+ * @see                 sftp_close()
+ * @see                 sftp_get_error()
+ * @see                 ssh_get_error()
+ */
+LIBSSH_API ssize_t sftp_aio_begin_write(sftp_file file,
+                                        const void *buf,
+                                        size_t len,
+                                        sftp_aio *aio);
+
+/**
+ * @brief Wait for an asynchronous write to complete.
+ *
+ * A pointer to an sftp aio handle should be passed while calling
+ * this function. Except when the return value is SSH_AGAIN,
+ * this function releases the memory corresponding to the supplied
+ * aio handle and assigns NULL to that aio handle using the passed
+ * pointer to that handle.
+ *
+ * If the file is opened in non-blocking mode and the request hasn't
+ * been executed yet, this function returns SSH_AGAIN and must be called
+ * again using the same sftp aio handle.
+ *
+ * @param aio           Pointer to the sftp aio handle returned by
+ *                      sftp_aio_begin_write().
+ *
+ * @return              Number of bytes written on success, SSH_ERROR
+ *                      if an error occurred, SSH_AGAIN if the file is
+ *                      opened in nonblocking mode and the request hasn't
+ *                      been executed yet.
+ *
+ * @warning             A call to this function with an invalid sftp aio handle
+ *                      may never return.
+ *
+ * @see sftp_aio_begin_write()
+ * @see sftp_aio_free()
+ */
+LIBSSH_API ssize_t sftp_aio_wait_write(sftp_aio *aio);
+
+/**
+ * @brief Seek to a specific location in a file.
+ *
+ * @param file         Open sftp file handle to seek in.
+ *
+ * @param new_offset   Offset in bytes to seek.
+ *
+ * @return             0 on success, < 0 on error.
+ */
+LIBSSH_API int sftp_seek(sftp_file file, uint32_t new_offset);
+
+/**
+ * @brief Seek to a specific location in a file. This is the
+ * 64bit version.
+ *
+ * @param file         Open sftp file handle to seek in.
+ *
+ * @param new_offset   Offset in bytes to seek.
+ *
+ * @return             0 on success, < 0 on error.
+ */
+LIBSSH_API int sftp_seek64(sftp_file file, uint64_t new_offset);
+
+/**
+ * @brief Report current byte position in file.
+ *
+ * @param file          Open sftp file handle.
+ *
+ * @return              The offset of the current byte relative to the beginning
+ *                      of the file associated with the file descriptor. < 0 on
+ *                      error.
+ */
+LIBSSH_API unsigned long sftp_tell(sftp_file file);
+
+/**
+ * @brief Report current byte position in file.
+ *
+ * @param file          Open sftp file handle.
+ *
+ * @return              The offset of the current byte relative to the beginning
+ *                      of the file associated with the file descriptor.
+ */
+LIBSSH_API uint64_t sftp_tell64(sftp_file file);
+
+/**
+ * @brief Rewinds the position of the file pointer to the beginning of the
+ * file.
+ *
+ * @param file          Open sftp file handle.
+ */
+LIBSSH_API void sftp_rewind(sftp_file file);
+
+/**
+ * @brief Unlink (delete) a file.
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @param file          The file to unlink/delete.
+ *
+ * @return              0 on success, < 0 on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API int sftp_unlink(sftp_session sftp, const char *file);
+
+/**
+ * @brief Remove a directory.
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @param directory     The directory to remove.
+ *
+ * @return              0 on success, < 0 on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API int sftp_rmdir(sftp_session sftp, const char *directory);
+
+/**
+ * @brief Create a directory.
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @param directory     The directory to create.
+ *
+ * @param mode          Specifies the permissions to use. It is modified by the
+ *                      process's umask in the usual way:
+ *                      The permissions of the created file are (mode & ~umask)
+ *
+ * @return              0 on success, < 0 on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API int sftp_mkdir(sftp_session sftp, const char *directory, mode_t mode);
+
+/**
+ * @brief Rename or move a file or directory.
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @param original      The original url (source url) of file or directory to
+ *                      be moved.
+ *
+ * @param newname       The new url (destination url) of the file or directory
+ *                      after the move.
+ *
+ * @return              0 on success, < 0 on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API int sftp_rename(sftp_session sftp, const char *original, const  char *newname);
+
+/**
+ * @brief Set file attributes on a file, directory or symbolic link.
+ *
+ * Note, that this function can only set time values using 32 bit values due to
+ * the restrictions in the SFTP protocol version 3 implemented by libssh.
+ * The support for 64 bit time values was introduced in SFTP version 5, which is
+ * not implemented by libssh nor any major SFTP servers.
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @param file          The file which attributes should be changed.
+ *
+ * @param attr          The file attributes structure with the attributes set
+ *                      which should be changed.
+ *
+ * @return              0 on success, < 0 on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API int sftp_setstat(sftp_session sftp, const char *file, sftp_attributes attr);
+
+/**
+ * @brief This request is like setstat (excluding mode and size) but sets file
+ * attributes on symlinks themselves.
+ *
+ * Note, that this function can only set time values using 32 bit values due to
+ * the restrictions in the SFTP protocol version 3 implemented by libssh.
+ * The support for 64 bit time values was introduced in SFTP version 5, which is
+ * not implemented by libssh nor any major SFTP servers.
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @param file          The symbolic link which attributes should be changed.
+ *
+ * @param attr          The file attributes structure with the attributes set
+ *                      which should be changed.
+ *
+ * @return              0 on success, < 0 on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API int
+sftp_lsetstat(sftp_session sftp, const char *file, sftp_attributes attr);
+
+/**
+ * @brief Change the file owner and group
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @param file          The file which owner and group should be changed.
+ *
+ * @param owner         The new owner which should be set.
+ *
+ * @param group         The new group which should be set.
+ *
+ * @return              0 on success, < 0 on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API int sftp_chown(sftp_session sftp, const char *file, uid_t owner, gid_t group);
+
+/**
+ * @brief Change permissions of a file
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @param file          The file which owner and group should be changed.
+ *
+ * @param mode          Specifies the permissions to use. It is modified by the
+ *                      process's umask in the usual way:
+ *                      The permissions of the created file are (mode & ~umask)
+ *
+ * @return              0 on success, < 0 on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API int sftp_chmod(sftp_session sftp, const char *file, mode_t mode);
+
+/**
+ * @brief Change the last modification and access time of a file.
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @param file          The file which owner and group should be changed.
+ *
+ * @param times         A timeval structure which contains the desired access
+ *                      and modification time.
+ *
+ * @return              0 on success, < 0 on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API int sftp_utimes(sftp_session sftp, const char *file, const struct timeval *times);
+
+/**
+ * @brief Create a symbolic link.
+ *
+ * @param  sftp         The sftp session handle.
+ *
+ * @param  target       Specifies the target of the symlink.
+ *
+ * @param  dest         Specifies the path name of the symlink to be created.
+ *
+ * @return              0 on success, < 0 on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API int sftp_symlink(sftp_session sftp, const char *target, const char *dest);
+
+/**
+ * @brief Read the value of a symbolic link.
+ *
+ * @param  sftp         The sftp session handle.
+ *
+ * @param  path         Specifies the path name of the symlink to be read.
+ *
+ * @return              The target of the link, NULL on error.
+ *                      The caller needs to free the memory
+ *                      using ssh_string_free_char().
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API char *sftp_readlink(sftp_session sftp, const char *path);
+
+/**
+ * @brief Create a hard link.
+ *
+ * @param  sftp         The sftp session handle.
+ *
+ * @param  oldpath      Specifies the pathname of the file for
+ *                      which the new hardlink is to be created.
+ *
+ * @param  newpath      Specifies the pathname of the hardlink to be created.
+ *
+ * @return              0 on success, -1 on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API int sftp_hardlink(sftp_session sftp, const char *oldpath, const char *newpath);
+
+/**
+ * @brief Get information about a mounted file system.
+ *
+ * @param  sftp         The sftp session handle.
+ *
+ * @param  path         The pathname of any file within the mounted file system.
+ *
+ * @return A statvfs structure or NULL on error.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API sftp_statvfs_t sftp_statvfs(sftp_session sftp, const char *path);
+
+/**
+ * @brief Get information about a mounted file system.
+ *
+ * @param  file         An opened file.
+ *
+ * @return A statvfs structure or NULL on error.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API sftp_statvfs_t sftp_fstatvfs(sftp_file file);
+
+/**
+ * @brief Free the memory of an allocated statvfs.
+ *
+ * @param  statvfs_o      The statvfs to free.
+ */
+LIBSSH_API void sftp_statvfs_free(sftp_statvfs_t statvfs_o);
+
+/**
+ * @brief Synchronize a file's in-core state with storage device
+ *
+ * This calls the "fsync@openssh.com" extension. You should check if the
+ * extensions is supported using:
+ *
+ * @code
+ * int supported = sftp_extension_supported(sftp, "fsync@openssh.com", "1");
+ * @endcode
+ *
+ * @param file          The opened sftp file handle to sync
+ *
+ * @return              0 on success, < 0 on error with ssh and sftp error set.
+ */
+LIBSSH_API int sftp_fsync(sftp_file file);
+
+/**
+ * @brief Get information about the various limits the server might impose.
+ *
+ * @param  sftp         The sftp session handle.
+ *
+ * @return A limits structure or NULL on error.
+ *
+ * @see sftp_get_error()
+ */
+LIBSSH_API sftp_limits_t sftp_limits(sftp_session sftp);
+
+/**
+ * @brief Free the memory of an allocated limits.
+ *
+ * @param  limits      The limits to free.
+ */
+LIBSSH_API void sftp_limits_free(sftp_limits_t limits);
+
+/**
+ * @brief Canonicalize a sftp path.
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @param path          The path to be canonicalized.
+ *
+ * @return              A pointer to the newly allocated canonicalized path,
+ *                      NULL on error. The caller needs to free the memory
+ *                      using ssh_string_free_char().
+ */
+LIBSSH_API char *sftp_canonicalize_path(sftp_session sftp, const char *path);
+
+/**
+ * @brief Get the version of the SFTP protocol supported by the server
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @return              The server version.
+ */
+LIBSSH_API int sftp_server_version(sftp_session sftp);
+
+/**
+ * @brief Canonicalize path using expand-path@openssh.com extension
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @param path          The path to be canonicalized.
+ *
+ * @return              A pointer to the newly allocated canonicalized path,
+ *                      NULL on error. The caller needs to free the memory
+ *                      using ssh_string_free_char().
+ */
+LIBSSH_API char *sftp_expand_path(sftp_session sftp, const char *path);
+
+/**
+ * @brief Get the specified user's home directory
+ *
+ * This calls the "home-directory" extension. You should check if the extension
+ * is supported using:
+ *
+ * @code
+ * int supported  = sftp_extension_supported(sftp, "home-directory", "1");
+ * @endcode
+ *
+ * @param sftp          The sftp session handle.
+ *
+ * @param username      username of the user whose home directory is requested.
+ *
+ * @return              On success, a newly allocated string containing the
+ *                      absolute real-path of the home directory of the user.
+ *                      NULL on error. The caller needs to free the memory
+ *                      using ssh_string_free_char().
+ */
+LIBSSH_API char *sftp_home_directory(sftp_session sftp, const char *username);
+
+#ifdef WITH_SERVER
+/**
+ * @brief Create a new sftp server session.
+ *
+ * @param session       The ssh session to use.
+ *
+ * @param chan          The ssh channel to use.
+ *
+ * @return              A new sftp server session.
+ */
+LIBSSH_API sftp_session sftp_server_new(ssh_session session, ssh_channel chan);
+
+/**
+ * @brief Initialize the sftp server.
+ *
+ * @param sftp         The sftp session to init.
+ *
+ * @return             0 on success, < 0 on error.
+ */
+SSH_DEPRECATED LIBSSH_API int sftp_server_init(sftp_session sftp);
+
+/**
+ * @brief Close and deallocate a sftp server session.
+ *
+ * @param sftp          The sftp session handle to free.
+ */
+LIBSSH_API void sftp_server_free(sftp_session sftp);
+#endif  /* WITH_SERVER */
+
+/* sftpserver.c */
+
+LIBSSH_API sftp_client_message sftp_get_client_message(sftp_session sftp);
+LIBSSH_API void sftp_client_message_free(sftp_client_message msg);
+LIBSSH_API uint8_t sftp_client_message_get_type(sftp_client_message msg);
+LIBSSH_API const char *sftp_client_message_get_filename(sftp_client_message msg);
+LIBSSH_API void sftp_client_message_set_filename(sftp_client_message msg, const char *newname);
+LIBSSH_API const char *sftp_client_message_get_data(sftp_client_message msg);
+LIBSSH_API uint32_t sftp_client_message_get_flags(sftp_client_message msg);
+LIBSSH_API const char *sftp_client_message_get_submessage(sftp_client_message msg);
+LIBSSH_API int sftp_send_client_message(sftp_session sftp, sftp_client_message msg);
+LIBSSH_API int sftp_reply_name(sftp_client_message msg, const char *name,
+    sftp_attributes attr);
+LIBSSH_API int sftp_reply_handle(sftp_client_message msg, ssh_string handle);
+LIBSSH_API ssh_string sftp_handle_alloc(sftp_session sftp, void *info);
+LIBSSH_API int sftp_reply_attr(sftp_client_message msg, sftp_attributes attr);
+LIBSSH_API void *sftp_handle(sftp_session sftp, ssh_string handle);
+LIBSSH_API int sftp_reply_status(sftp_client_message msg, uint32_t status, const char *message);
+LIBSSH_API int sftp_reply_names_add(sftp_client_message msg, const char *file,
+    const char *longname, sftp_attributes attr);
+LIBSSH_API int sftp_reply_names(sftp_client_message msg);
+LIBSSH_API int sftp_reply_data(sftp_client_message msg, const void *data, int len);
+LIBSSH_API void sftp_handle_remove(sftp_session sftp, void *handle);
+
+/* SFTP commands and constants */
+#define SSH_FXP_INIT 1
+#define SSH_FXP_VERSION 2
+#define SSH_FXP_OPEN 3
+#define SSH_FXP_CLOSE 4
+#define SSH_FXP_READ 5
+#define SSH_FXP_WRITE 6
+#define SSH_FXP_LSTAT 7
+#define SSH_FXP_FSTAT 8
+#define SSH_FXP_SETSTAT 9
+#define SSH_FXP_FSETSTAT 10
+#define SSH_FXP_OPENDIR 11
+#define SSH_FXP_READDIR 12
+#define SSH_FXP_REMOVE 13
+#define SSH_FXP_MKDIR 14
+#define SSH_FXP_RMDIR 15
+#define SSH_FXP_REALPATH 16
+#define SSH_FXP_STAT 17
+#define SSH_FXP_RENAME 18
+#define SSH_FXP_READLINK 19
+#define SSH_FXP_SYMLINK 20
+
+#define SSH_FXP_STATUS 101
+#define SSH_FXP_HANDLE 102
+#define SSH_FXP_DATA 103
+#define SSH_FXP_NAME 104
+#define SSH_FXP_ATTRS 105
+
+#define SSH_FXP_EXTENDED 200
+#define SSH_FXP_EXTENDED_REPLY 201
+
+/* attributes */
+/* sftp draft is completely braindead : version 3 and 4 have different flags for same constants */
+/* and even worst, version 4 has same flag for 2 different constants */
+/* follow up : i won't develop any sftp4 compliant library before having a clarification */
+
+#define SSH_FILEXFER_ATTR_SIZE 0x00000001
+#define SSH_FILEXFER_ATTR_PERMISSIONS 0x00000004
+#define SSH_FILEXFER_ATTR_ACCESSTIME 0x00000008
+#define SSH_FILEXFER_ATTR_ACMODTIME  0x00000008
+#define SSH_FILEXFER_ATTR_CREATETIME 0x00000010
+#define SSH_FILEXFER_ATTR_MODIFYTIME 0x00000020
+#define SSH_FILEXFER_ATTR_ACL 0x00000040
+#define SSH_FILEXFER_ATTR_OWNERGROUP 0x00000080
+#define SSH_FILEXFER_ATTR_SUBSECOND_TIMES 0x00000100
+#define SSH_FILEXFER_ATTR_EXTENDED 0x80000000
+#define SSH_FILEXFER_ATTR_UIDGID 0x00000002
+
+/* types */
+#define SSH_FILEXFER_TYPE_REGULAR 1
+#define SSH_FILEXFER_TYPE_DIRECTORY 2
+#define SSH_FILEXFER_TYPE_SYMLINK 3
+#define SSH_FILEXFER_TYPE_SPECIAL 4
+#define SSH_FILEXFER_TYPE_UNKNOWN 5
+
+/**
+ * @name Server responses
+ *
+ * @brief Responses returned by the sftp server.
+ * @{
+ */
+
+/** No error */
+#define SSH_FX_OK 0
+/** End-of-file encountered */
+#define SSH_FX_EOF 1
+/** File doesn't exist */
+#define SSH_FX_NO_SUCH_FILE 2
+/** Permission denied */
+#define SSH_FX_PERMISSION_DENIED 3
+/** Generic failure */
+#define SSH_FX_FAILURE 4
+/** Garbage received from server */
+#define SSH_FX_BAD_MESSAGE 5
+/** No connection has been set up */
+#define SSH_FX_NO_CONNECTION 6
+/** There was a connection, but we lost it */
+#define SSH_FX_CONNECTION_LOST 7
+/** Operation not supported by the server */
+#define SSH_FX_OP_UNSUPPORTED 8
+/** Invalid file handle */
+#define SSH_FX_INVALID_HANDLE 9
+/** No such file or directory path exists */
+#define SSH_FX_NO_SUCH_PATH 10
+/** An attempt to create an already existing file or directory has been made */
+#define SSH_FX_FILE_ALREADY_EXISTS 11
+/** We are trying to write on a write-protected filesystem */
+#define SSH_FX_WRITE_PROTECT 12
+/** No media in remote drive */
+#define SSH_FX_NO_MEDIA 13
+
+/** @} */
+
+/* file flags */
+#define SSH_FXF_READ 0x01
+#define SSH_FXF_WRITE 0x02
+#define SSH_FXF_APPEND 0x04
+#define SSH_FXF_CREAT 0x08
+#define SSH_FXF_TRUNC 0x10
+#define SSH_FXF_EXCL 0x20
+#define SSH_FXF_TEXT 0x40
+
+/* file type flags */
+#define SSH_S_IFMT   00170000
+#define SSH_S_IFSOCK 0140000
+#define SSH_S_IFLNK  0120000
+#define SSH_S_IFREG  0100000
+#define SSH_S_IFBLK  0060000
+#define SSH_S_IFDIR  0040000
+#define SSH_S_IFCHR  0020000
+#define SSH_S_IFIFO  0010000
+
+/* rename flags */
+#define SSH_FXF_RENAME_OVERWRITE  0x00000001
+#define SSH_FXF_RENAME_ATOMIC     0x00000002
+#define SSH_FXF_RENAME_NATIVE     0x00000004
+
+#define SFTP_OPEN SSH_FXP_OPEN
+#define SFTP_CLOSE SSH_FXP_CLOSE
+#define SFTP_READ SSH_FXP_READ
+#define SFTP_WRITE SSH_FXP_WRITE
+#define SFTP_LSTAT SSH_FXP_LSTAT
+#define SFTP_FSTAT SSH_FXP_FSTAT
+#define SFTP_SETSTAT SSH_FXP_SETSTAT
+#define SFTP_FSETSTAT SSH_FXP_FSETSTAT
+#define SFTP_OPENDIR SSH_FXP_OPENDIR
+#define SFTP_READDIR SSH_FXP_READDIR
+#define SFTP_REMOVE SSH_FXP_REMOVE
+#define SFTP_MKDIR SSH_FXP_MKDIR
+#define SFTP_RMDIR SSH_FXP_RMDIR
+#define SFTP_REALPATH SSH_FXP_REALPATH
+#define SFTP_STAT SSH_FXP_STAT
+#define SFTP_RENAME SSH_FXP_RENAME
+#define SFTP_READLINK SSH_FXP_READLINK
+#define SFTP_SYMLINK SSH_FXP_SYMLINK
+#define SFTP_EXTENDED SSH_FXP_EXTENDED
+
+/* openssh flags */
+#define SSH_FXE_STATVFS_ST_RDONLY 0x1 /* read-only */
+#define SSH_FXE_STATVFS_ST_NOSUID 0x2 /* no setuid */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SFTP_H */
+
+/** @} */

--- a/firmware/lib/LibSSH-SFTP/src/libssh/sftp_priv.h
+++ b/firmware/lib/LibSSH-SFTP/src/libssh/sftp_priv.h
@@ -1,0 +1,87 @@
+/*
+ * This file is part of the SSH Library
+ *
+ * Copyright (c) 2003-2008 by Aris Adamantiadis
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef SFTP_PRIV_H
+#define SFTP_PRIV_H
+
+#include "libssh/sftp.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+sftp_packet sftp_packet_read(sftp_session sftp);
+int sftp_packet_write(sftp_session sftp, uint8_t type, ssh_buffer payload);
+void sftp_packet_free(sftp_packet packet);
+int buffer_add_attributes(ssh_buffer buffer, sftp_attributes attr);
+sftp_attributes sftp_parse_attr(sftp_session session,
+                                ssh_buffer buf,
+                                int expectname);
+/**
+ * @brief Reply to the SSH_FXP_INIT message with the SSH_FXP_VERSION message
+ *
+ * @param  client_msg         The pointer to client message.
+ *
+ * @return                    0 on success, < 0 on error with ssh and sftp error set.
+ *
+ * @see sftp_get_error()
+ */
+int sftp_reply_version(sftp_client_message client_msg);
+/**
+ * @brief Decode the data from channel buffer into sftp read_packet.
+ *
+ * @param  sftp         The sftp session handle.
+ *
+ * @param  data         The pointer to the data buffer of channel.
+ * @param  len          The data buffer length
+ *
+ * @return              Length of data decoded.
+ */
+int sftp_decode_channel_data_to_packet(sftp_session sftp, void *data, uint32_t len);
+
+void sftp_set_error(sftp_session sftp, int errnum);
+
+void sftp_message_free(sftp_message msg);
+
+int sftp_read_and_dispatch(sftp_session sftp);
+
+sftp_message sftp_dequeue(sftp_session sftp, uint32_t id);
+
+/**
+ * @brief Assigns a new SFTP ID for new requests and assures there is no
+ *        collision between them.
+ *
+ * @param sftp           The sftp session handle.
+ * @param id_out         Pointer to store the new ID.
+ *
+ * @returns SSH_OK on success with the new ID stored in *id
+ * @returns SSH_ERROR on failure with the sftp and ssh errors set
+ */
+int sftp_get_new_id(sftp_session sftp, uint32_t *id_out);
+
+sftp_status_message parse_status_msg(sftp_message msg);
+
+void status_msg_free(sftp_status_message status);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SFTP_PRIV_H */

--- a/firmware/lib/LibSSH-SFTP/src/sftp.c
+++ b/firmware/lib/LibSSH-SFTP/src/sftp.c
@@ -1,0 +1,3433 @@
+/*
+ * sftp.c - Secure FTP functions
+ *
+ * This file is part of the SSH Library
+ *
+ * Copyright (c) 2005-2008 by Aris Adamantiadis
+ * Copyright (c) 2008-2018 by Andreas Schneider <asn@cryptomilk.org>
+ *
+ * The SSH Library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * The SSH Library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the SSH Library; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
+ * MA 02111-1307, USA.
+ */
+
+/* This file contains code written by Nick Zitzmann */
+
+#include "libssh_esp32_config.h"
+#ifndef WITH_SFTP
+#define WITH_SFTP 1
+#endif
+
+#include <stdbool.h>
+#include <errno.h>
+#include <ctype.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdint.h>
+#ifdef HAVE_SYS_TIME_H
+#include <sys/time.h>
+#endif /* HAVE_SYS_TIME_H */
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <limits.h>
+
+#ifndef _WIN32
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#endif
+
+#include "libssh/priv.h"
+#include "libssh/ssh2.h"
+#include "libssh/sftp.h"
+#include "libssh/sftp_priv.h"
+#include "libssh/buffer.h"
+#include "libssh/channels.h"
+#include "libssh/session.h"
+#include "libssh/misc.h"
+#include "libssh/bytearray.h"
+
+#ifdef WITH_SFTP
+
+struct sftp_ext_struct {
+  uint32_t count;
+  char **name;
+  char **data;
+};
+
+static sftp_ext sftp_ext_new(void) {
+  sftp_ext ext;
+
+  ext = calloc(1, sizeof(struct sftp_ext_struct));
+  if (ext == NULL) {
+    return NULL;
+  }
+
+  return ext;
+}
+
+static void sftp_ext_free(sftp_ext ext)
+{
+    size_t i;
+
+    if (ext == NULL) {
+        return;
+    }
+
+    if (ext->count > 0) {
+        if (ext->name != NULL) {
+            for (i = 0; i < ext->count; i++) {
+                SAFE_FREE(ext->name[i]);
+            }
+            SAFE_FREE(ext->name);
+        }
+
+        if (ext->data != NULL) {
+            for (i = 0; i < ext->count; i++) {
+                SAFE_FREE(ext->data[i]);
+            }
+            SAFE_FREE(ext->data);
+        }
+    }
+
+    SAFE_FREE(ext);
+}
+
+sftp_session sftp_new(ssh_session session)
+{
+    sftp_session sftp;
+
+    if (session == NULL) {
+        return NULL;
+    }
+
+    sftp = calloc(1, sizeof(struct sftp_session_struct));
+    if (sftp == NULL) {
+        ssh_set_error_oom(session);
+
+        return NULL;
+    }
+
+    sftp->ext = sftp_ext_new();
+    if (sftp->ext == NULL) {
+        ssh_set_error_oom(session);
+        goto error;
+    }
+
+    sftp->read_packet = calloc(1, sizeof(struct sftp_packet_struct));
+    if (sftp->read_packet == NULL) {
+        ssh_set_error_oom(session);
+        goto error;
+    }
+
+    sftp->read_packet->payload = ssh_buffer_new();
+    if (sftp->read_packet->payload == NULL) {
+        ssh_set_error_oom(session);
+        goto error;
+    }
+
+    sftp->session = session;
+    sftp->channel = ssh_channel_new(session);
+    if (sftp->channel == NULL) {
+        ssh_set_error_oom(session);
+        goto error;
+    }
+
+    sftp->outstanding_ids = ssh_list_new();
+    if (sftp->outstanding_ids == NULL) {
+        ssh_set_error_oom(session);
+        goto error;
+    }
+
+    if (ssh_channel_open_session(sftp->channel)) {
+        goto error;
+    }
+
+    if (ssh_channel_request_sftp(sftp->channel)) {
+        goto error;
+    }
+
+    return sftp;
+error:
+    if (sftp->ext != NULL) {
+        sftp_ext_free(sftp->ext);
+    }
+    if (sftp->channel != NULL) {
+        ssh_channel_free(sftp->channel);
+    }
+    ssh_list_free(sftp->outstanding_ids);
+    if (sftp->read_packet != NULL) {
+        if (sftp->read_packet->payload != NULL) {
+            SSH_BUFFER_FREE(sftp->read_packet->payload);
+        }
+        SAFE_FREE(sftp->read_packet);
+    }
+    SAFE_FREE(sftp);
+    return NULL;
+}
+
+sftp_session
+sftp_new_channel(ssh_session session, ssh_channel channel)
+{
+    sftp_session sftp = NULL;
+
+    if (session == NULL) {
+        return NULL;
+    }
+
+    sftp = calloc(1, sizeof(struct sftp_session_struct));
+    if (sftp == NULL) {
+        ssh_set_error_oom(session);
+        return NULL;
+    }
+
+    sftp->ext = sftp_ext_new();
+    if (sftp->ext == NULL) {
+        ssh_set_error_oom(session);
+        goto error;
+    }
+
+    sftp->outstanding_ids = ssh_list_new();
+    if (sftp->outstanding_ids == NULL) {
+        ssh_set_error_oom(session);
+        goto error;
+    }
+
+    sftp->read_packet = calloc(1, sizeof(struct sftp_packet_struct));
+    if (sftp->read_packet == NULL) {
+        ssh_set_error_oom(session);
+        goto error;
+    }
+
+    sftp->read_packet->payload = ssh_buffer_new();
+    if (sftp->read_packet->payload == NULL) {
+        ssh_set_error_oom(session);
+        goto error;
+    }
+
+    sftp->session = session;
+    sftp->channel = channel;
+
+    return sftp;
+
+error:
+    if (sftp->ext != NULL) {
+        sftp_ext_free(sftp->ext);
+    }
+    ssh_list_free(sftp->outstanding_ids);
+    if (sftp->read_packet != NULL) {
+        if (sftp->read_packet->payload != NULL) {
+            SSH_BUFFER_FREE(sftp->read_packet->payload);
+        }
+        SAFE_FREE(sftp->read_packet);
+    }
+    SAFE_FREE(sftp);
+    return NULL;
+}
+
+#ifdef WITH_SERVER
+sftp_session
+sftp_server_new(ssh_session session, ssh_channel chan)
+{
+    sftp_session sftp = NULL;
+
+    sftp = calloc(1, sizeof(struct sftp_session_struct));
+    if (sftp == NULL) {
+        ssh_set_error_oom(session);
+        return NULL;
+    }
+
+    sftp->read_packet = calloc(1, sizeof(struct sftp_packet_struct));
+    if (sftp->read_packet == NULL) {
+        goto error;
+    }
+
+    sftp->read_packet->payload = ssh_buffer_new();
+    if (sftp->read_packet->payload == NULL) {
+        goto error;
+    }
+
+    sftp->session = session;
+    sftp->channel = chan;
+
+    return sftp;
+
+error:
+    ssh_set_error_oom(session);
+    if (sftp->read_packet != NULL) {
+        if (sftp->read_packet->payload != NULL) {
+            SSH_BUFFER_FREE(sftp->read_packet->payload);
+        }
+        SAFE_FREE(sftp->read_packet);
+    }
+    SAFE_FREE(sftp);
+    return NULL;
+}
+
+/* @deprecated in favor of sftp_server_new() and callbacks based sftp server */
+int sftp_server_init(sftp_session sftp)
+{
+    ssh_session session = sftp->session;
+    sftp_client_message msg = NULL;
+    int rc;
+
+    /* handles setting the sftp->client_version */
+    msg = sftp_get_client_message(sftp);
+    if (msg == NULL) {
+        return -1;
+    }
+
+    if (msg->type != SSH_FXP_INIT) {
+        ssh_set_error(session,
+                      SSH_FATAL,
+                      "Packet read of type %d instead of SSH_FXP_INIT",
+                      msg->type);
+        return -1;
+    }
+
+    SSH_LOG(SSH_LOG_PACKET, "Received SSH_FXP_INIT");
+
+    rc = sftp_reply_version(msg);
+    if (rc != SSH_OK) {
+        ssh_set_error(session,
+                      SSH_FATAL,
+                      "Failed to process the SSH_FXP_INIT message");
+        return -1;
+    }
+
+    return 0;
+}
+
+void sftp_server_free(sftp_session sftp)
+{
+    sftp_request_queue ptr;
+
+    if (sftp == NULL) {
+        return;
+    }
+
+    ptr = sftp->queue;
+    while(ptr) {
+        sftp_request_queue old;
+        sftp_message_free(ptr->message);
+        old = ptr->next;
+        SAFE_FREE(ptr);
+        ptr = old;
+    }
+
+    SAFE_FREE(sftp->handles);
+    SSH_BUFFER_FREE(sftp->read_packet->payload);
+    SAFE_FREE(sftp->read_packet);
+
+    sftp_ext_free(sftp->ext);
+
+    SAFE_FREE(sftp);
+}
+
+#endif /* WITH_SERVER */
+
+void sftp_free(sftp_session sftp)
+{
+    sftp_request_queue ptr = NULL;
+    struct ssh_iterator *id_it = NULL;
+
+    if (sftp == NULL) {
+        return;
+    }
+
+    if (sftp->channel != NULL) {
+        ssh_channel_send_eof(sftp->channel);
+        ptr = sftp->queue;
+        while(ptr) {
+            sftp_request_queue old;
+            sftp_message_free(ptr->message);
+            old = ptr->next;
+            SAFE_FREE(ptr);
+            ptr = old;
+        }
+
+        ssh_channel_free(sftp->channel);
+        sftp->channel = NULL;
+    }
+
+    SAFE_FREE(sftp->handles);
+    SSH_BUFFER_FREE(sftp->read_packet->payload);
+    SAFE_FREE(sftp->read_packet);
+
+    sftp_ext_free(sftp->ext);
+    sftp_limits_free(sftp->limits);
+
+    id_it = ssh_list_get_iterator(sftp->outstanding_ids);
+    for (; id_it != NULL; id_it = id_it->next) {
+        free((uint32_t *)id_it->data);
+    }
+    ssh_list_free(sftp->outstanding_ids);
+
+    SAFE_FREE(sftp);
+}
+
+/* @internal
+ * Process the incoming data and copy them from the SSH packet buffer to the
+ * SFTP packet buffer.
+ * @returns number of decoded bytes.
+ */
+int
+sftp_decode_channel_data_to_packet(sftp_session sftp, void *data, uint32_t len)
+{
+    sftp_packet packet = sftp->read_packet;
+    size_t nread;
+    size_t payload_len;
+    size_t data_offset;
+    size_t to_read, rc;
+
+    if (packet->sftp == NULL) {
+        packet->sftp = sftp;
+    }
+
+    data_offset = sizeof(uint32_t) + sizeof(uint8_t);
+    /* not enough bytes to read */
+    if (len < data_offset) {
+        return SSH_ERROR;
+    }
+
+    payload_len = PULL_BE_U32(data, 0);
+    packet->type = PULL_BE_U8(data, 4);
+
+    /* We should check the legality of payload length */
+    if (payload_len > len - sizeof(uint32_t) || payload_len < sizeof(uint8_t)) {
+        return SSH_ERROR;
+    }
+
+    to_read = payload_len - sizeof(uint8_t);
+    rc = ssh_buffer_add_data(packet->payload,
+                             (void*)((uint8_t *)data + data_offset),
+                             to_read);
+    if (rc != 0) {
+        return SSH_ERROR;
+    }
+    nread = ssh_buffer_get_len(packet->payload);
+
+    /* We should check if we copied the whole data */
+    if (nread != to_read) {
+        return SSH_ERROR;
+    }
+
+    /*
+     * We should return how many bytes we decoded, including packet length
+     * header and the payload length.
+     * This can't overflow as we pulled this from unit32_t and checked this fits
+     * into the buffer's max size of 0x10000000 (256MB).
+     */
+    return (int)(payload_len + sizeof(uint32_t));
+}
+
+/* Get the last sftp error */
+int sftp_get_error(sftp_session sftp) {
+  if (sftp == NULL) {
+    return -1;
+  }
+
+  return sftp->errnum;
+}
+
+static sftp_limits_t sftp_limits_use_extension(sftp_session sftp);
+static sftp_limits_t sftp_limits_use_default(sftp_session sftp);
+
+/* Initialize the sftp session with the server. */
+int sftp_init(sftp_session sftp)
+{
+    sftp_packet packet = NULL;
+    ssh_buffer buffer = NULL;
+    char *ext_name = NULL;
+    char *ext_data = NULL;
+    uint32_t version;
+    int rc;
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = ssh_buffer_pack(buffer, "d", LIBSFTP_VERSION);
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_INIT, buffer);
+    if (rc == SSH_ERROR) {
+        SSH_BUFFER_FREE(buffer);
+        return -1;
+    }
+
+    SSH_BUFFER_FREE(buffer);
+
+    packet = sftp_packet_read(sftp);
+    if (packet == NULL) {
+        return -1;
+    }
+
+    if (packet->type != SSH_FXP_VERSION) {
+        ssh_set_error(sftp->session, SSH_FATAL,
+                      "Received a %d messages instead of SSH_FXP_VERSION",
+                      packet->type);
+        return -1;
+    }
+
+    /* TODO: are we sure there are 4 bytes ready? */
+    rc = ssh_buffer_unpack(packet->payload, "d", &version);
+    if (rc != SSH_OK) {
+        ssh_set_error(sftp->session,
+                      SSH_FATAL,
+                      "Unable to unpack SSH_FXP_VERSION packet");
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    SSH_LOG(SSH_LOG_DEBUG,
+            "SFTP server version %" PRIu32,
+            version);
+    rc = ssh_buffer_unpack(packet->payload, "s", &ext_name);
+    while (rc == SSH_OK) {
+        uint32_t count = sftp->ext->count;
+        char **tmp;
+
+        rc = ssh_buffer_unpack(packet->payload, "s", &ext_data);
+        if (rc == SSH_ERROR) {
+            break;
+        }
+
+        SSH_LOG(SSH_LOG_DEBUG,
+                "SFTP server extension: %s, version: %s",
+                ext_name, ext_data);
+
+        count++;
+        tmp = realloc(sftp->ext->name, count * sizeof(char *));
+        if (tmp == NULL) {
+            ssh_set_error_oom(sftp->session);
+            SAFE_FREE(ext_name);
+            SAFE_FREE(ext_data);
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return -1;
+        }
+
+        tmp[count - 1] = ext_name;
+        sftp->ext->name = tmp;
+
+        tmp = realloc(sftp->ext->data, count * sizeof(char *));
+        if (tmp == NULL) {
+            ssh_set_error_oom(sftp->session);
+            SAFE_FREE(ext_name);
+            SAFE_FREE(ext_data);
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return -1;
+        }
+
+        tmp[count - 1] = ext_data;
+        sftp->ext->data = tmp;
+
+        sftp->ext->count = count;
+
+        rc = ssh_buffer_unpack(packet->payload, "s", &ext_name);
+    }
+
+    sftp->version = sftp->server_version = (int)version;
+
+    /* Set the limits */
+    rc = sftp_extension_supported(sftp, "limits@openssh.com", "1");
+    if (rc == 1) {
+        /* Get the ssh and sftp errors */
+        const char *static_ssh_err_msg = ssh_get_error(sftp->session);
+        int ssh_err_code = ssh_get_error_code(sftp->session);
+        int sftp_err_code = sftp_get_error(sftp);
+        char *ssh_err_msg = strdup(static_ssh_err_msg);
+        if (ssh_err_msg == NULL) {
+            ssh_set_error_oom(sftp->session);
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return -1;
+        }
+
+        sftp->limits = sftp_limits_use_extension(sftp);
+        if (sftp->limits == NULL) {
+            /* fallback and use the default limits on failure */
+            SSH_LOG(SSH_LOG_TRACE,
+                    "Failed to get the limits from a server claiming to "
+                    "support the limits@openssh.com extension, falling back "
+                    "and using the default limits");
+
+            /* Restore the sftp and ssh errors to their previous state */
+            ssh_set_error(sftp->session, ssh_err_code, "%s", ssh_err_msg);
+            sftp_set_error(sftp, sftp_err_code);
+            SAFE_FREE(ssh_err_msg);
+
+            sftp->limits = sftp_limits_use_default(sftp);
+            if (sftp->limits == NULL) {
+                return -1;
+            }
+        } else {
+            SAFE_FREE(ssh_err_msg);
+        }
+    } else {
+        sftp->limits = sftp_limits_use_default(sftp);
+        if (sftp->limits == NULL) {
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+unsigned int sftp_extensions_get_count(sftp_session sftp)
+{
+    if (sftp == NULL || sftp->ext == NULL) {
+        return 0;
+    }
+
+    return sftp->ext->count;
+}
+
+const char *sftp_extensions_get_name(sftp_session sftp, unsigned int idx)
+{
+    if (sftp == NULL) {
+        return NULL;
+    }
+
+    if (sftp->ext == NULL || sftp->ext->name == NULL) {
+        ssh_set_error_invalid(sftp->session);
+        return NULL;
+    }
+
+    if (idx >= sftp->ext->count) {
+        ssh_set_error_invalid(sftp->session);
+        return NULL;
+    }
+
+    return sftp->ext->name[idx];
+}
+
+const char *sftp_extensions_get_data(sftp_session sftp, unsigned int idx)
+{
+    if (sftp == NULL) {
+        return NULL;
+    }
+
+    if (sftp->ext == NULL || sftp->ext->name == NULL) {
+        ssh_set_error_invalid(sftp->session);
+        return NULL;
+    }
+
+    if (idx >= sftp->ext->count) {
+        ssh_set_error_invalid(sftp->session);
+        return NULL;
+    }
+
+    return sftp->ext->data[idx];
+}
+
+int sftp_extension_supported(sftp_session sftp, const char *name,
+    const char *data) {
+  size_t i, n;
+
+  if (sftp == NULL || name == NULL || data == NULL) {
+    return 0;
+  }
+
+  n = sftp_extensions_get_count(sftp);
+  for (i = 0; i < n; i++) {
+    const char *ext_name = sftp_extensions_get_name(sftp, i);
+    const char *ext_data = sftp_extensions_get_data(sftp, i);
+
+    if (ext_name != NULL && ext_data != NULL &&
+        strcmp(ext_name, name) == 0 &&
+        strcmp(ext_data, data) == 0) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+static sftp_file parse_handle_msg(sftp_message msg){
+  sftp_file file;
+
+  if(msg->packet_type != SSH_FXP_HANDLE) {
+    ssh_set_error(msg->sftp->session, SSH_FATAL,
+        "Not a ssh_fxp_handle message passed in!");
+    return NULL;
+  }
+
+  file = calloc(1, sizeof(struct sftp_file_struct));
+  if (file == NULL) {
+    ssh_set_error_oom(msg->sftp->session);
+    sftp_set_error(msg->sftp, SSH_FX_FAILURE);
+    return NULL;
+  }
+
+  file->handle = ssh_buffer_get_ssh_string(msg->payload);
+  if (file->handle == NULL) {
+    ssh_set_error(msg->sftp->session, SSH_FATAL,
+        "Invalid SSH_FXP_HANDLE message");
+    SAFE_FREE(file);
+    sftp_set_error(msg->sftp, SSH_FX_FAILURE);
+    return NULL;
+  }
+
+  file->sftp = msg->sftp;
+  file->offset = 0;
+  file->eof = 0;
+
+  return file;
+}
+
+/* Open a directory */
+sftp_dir sftp_opendir(sftp_session sftp, const char *path)
+{
+    sftp_message msg = NULL;
+    sftp_file file = NULL;
+    sftp_dir dir = NULL;
+    sftp_status_message status;
+    ssh_buffer payload = NULL;
+    uint32_t id;
+    int rc;
+
+    if (sftp == NULL) {
+        return NULL;
+    }
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return NULL;
+    }
+
+    payload = ssh_buffer_new();
+    if (payload == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = ssh_buffer_pack(payload,
+                         "ds",
+                         id,
+                         path);
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(payload);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_OPENDIR, payload);
+    SSH_BUFFER_FREE(payload);
+    if (rc < 0) {
+        return NULL;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            /* something nasty has happened */
+            return NULL;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    switch (msg->packet_type) {
+        case SSH_FXP_STATUS:
+            status = parse_status_msg(msg);
+            sftp_message_free(msg);
+            if (status == NULL) {
+                return NULL;
+            }
+            sftp_set_error(sftp, status->status);
+            ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                          "SFTP server: %s", status->errormsg);
+            status_msg_free(status);
+            return NULL;
+        case SSH_FXP_HANDLE:
+            file = parse_handle_msg(msg);
+            sftp_message_free(msg);
+            if (file != NULL) {
+                dir = calloc(1, sizeof(struct sftp_dir_struct));
+                if (dir == NULL) {
+                    ssh_set_error_oom(sftp->session);
+                    free(file);
+                    return NULL;
+                }
+
+                dir->sftp = sftp;
+                dir->name = strdup(path);
+                if (dir->name == NULL) {
+                    SAFE_FREE(dir);
+                    SAFE_FREE(file);
+                    return NULL;
+                }
+                dir->handle = file->handle;
+                SAFE_FREE(file);
+            }
+            return dir;
+        default:
+            ssh_set_error(sftp->session, SSH_FATAL,
+                          "Received message %d during opendir!",
+                          msg->packet_type);
+            sftp_message_free(msg);
+    }
+
+    return NULL;
+}
+
+/* Get the version of the SFTP protocol supported by the server */
+int sftp_server_version(sftp_session sftp) {
+  return sftp->server_version;
+}
+
+/* Get a single file attributes structure of a directory. */
+sftp_attributes sftp_readdir(sftp_session sftp, sftp_dir dir)
+{
+    sftp_message msg = NULL;
+    sftp_status_message status;
+    sftp_attributes attr;
+    ssh_buffer payload;
+    uint32_t id;
+    int rc;
+
+    if (dir->buffer == NULL) {
+        rc = sftp_get_new_id(sftp, &id);
+        if (rc != SSH_OK) {
+            return NULL;
+        }
+
+        payload = ssh_buffer_new();
+        if (payload == NULL) {
+            ssh_set_error_oom(sftp->session);
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return NULL;
+        }
+
+        rc = ssh_buffer_pack(payload,
+                             "dS",
+                             id,
+                             dir->handle);
+        if (rc != 0) {
+            ssh_set_error_oom(sftp->session);
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            SSH_BUFFER_FREE(payload);
+            return NULL;
+        }
+
+        rc = sftp_packet_write(sftp, SSH_FXP_READDIR, payload);
+        SSH_BUFFER_FREE(payload);
+        if (rc < 0) {
+            return NULL;
+        }
+
+        SSH_LOG(SSH_LOG_PACKET,
+                "Sent a ssh_fxp_readdir with id %" PRIu32, id);
+
+        while (msg == NULL) {
+            if (sftp_read_and_dispatch(sftp) < 0) {
+                /* something nasty has happened */
+                return NULL;
+            }
+            msg = sftp_dequeue(sftp, id);
+        }
+
+        switch (msg->packet_type){
+            case SSH_FXP_STATUS:
+                status = parse_status_msg(msg);
+                sftp_message_free(msg);
+                if (status == NULL) {
+                    return NULL;
+                }
+                sftp_set_error(sftp, status->status);
+                switch (status->status) {
+                    case SSH_FX_EOF:
+                        dir->eof = 1;
+                        status_msg_free(status);
+                        return NULL;
+                    default:
+                        break;
+                }
+
+                ssh_set_error(sftp->session, SSH_FATAL,
+                        "Unknown error status: %" PRIu32, status->status);
+                status_msg_free(status);
+
+                return NULL;
+            case SSH_FXP_NAME:
+                ssh_buffer_get_u32(msg->payload, &dir->count);
+                dir->count = ntohl(dir->count);
+                dir->buffer = msg->payload;
+                msg->payload = NULL;
+                sftp_message_free(msg);
+                break;
+            default:
+                ssh_set_error(sftp->session, SSH_FATAL,
+                        "Unsupported message back %d", msg->packet_type);
+                sftp_message_free(msg);
+                sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+
+                return NULL;
+        }
+    }
+
+    /* now dir->buffer contains a buffer and dir->count != 0 */
+    if (dir->count == 0) {
+        ssh_set_error(sftp->session, SSH_FATAL,
+                "Count of files sent by the server is zero, which is invalid, or "
+                "libsftp bug");
+        return NULL;
+    }
+
+    SSH_LOG(SSH_LOG_DEBUG, "Count is %" PRIu32, dir->count);
+
+    attr = sftp_parse_attr(sftp, dir->buffer, 1);
+    if (attr == NULL) {
+        ssh_set_error(sftp->session, SSH_FATAL,
+                "Couldn't parse the SFTP attributes");
+        return NULL;
+    }
+
+    dir->count--;
+    if (dir->count == 0) {
+        SSH_BUFFER_FREE(dir->buffer);
+        dir->buffer = NULL;
+    }
+
+    return attr;
+}
+
+/* Tell if the directory has reached EOF (End Of File). */
+int sftp_dir_eof(sftp_dir dir) {
+  return dir->eof;
+}
+
+/* Free a SFTP_ATTRIBUTE handle */
+void sftp_attributes_free(sftp_attributes file){
+  if (file == NULL) {
+    return;
+  }
+
+  SSH_STRING_FREE(file->acl);
+  SSH_STRING_FREE(file->extended_data);
+  SSH_STRING_FREE(file->extended_type);
+
+  SAFE_FREE(file->name);
+  SAFE_FREE(file->longname);
+  SAFE_FREE(file->group);
+  SAFE_FREE(file->owner);
+
+  SAFE_FREE(file);
+}
+
+static int sftp_handle_close(sftp_session sftp, ssh_string handle)
+{
+    sftp_status_message status;
+    sftp_message msg = NULL;
+    ssh_buffer buffer = NULL;
+    uint32_t id;
+    int rc;
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return -1;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "dS",
+                         id,
+                         handle);
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_CLOSE, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return -1;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            /* something nasty has happened */
+            return -1;
+        }
+        msg = sftp_dequeue(sftp,id);
+    }
+
+    switch (msg->packet_type) {
+        case SSH_FXP_STATUS:
+            status = parse_status_msg(msg);
+            sftp_message_free(msg);
+            if(status == NULL) {
+                return -1;
+            }
+            sftp_set_error(sftp, status->status);
+            switch (status->status) {
+                case SSH_FX_OK:
+                    status_msg_free(status);
+                    return 0;
+                    break;
+                default:
+                    break;
+            }
+            ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                    "SFTP server: %s", status->errormsg);
+            status_msg_free(status);
+            return -1;
+        default:
+            ssh_set_error(sftp->session, SSH_FATAL,
+                    "Received message %d during sftp_handle_close!", msg->packet_type);
+            sftp_message_free(msg);
+            sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return -1;
+}
+
+/* Close an open file handle. */
+int sftp_close(sftp_file file){
+  int err = SSH_NO_ERROR;
+
+  if (file == NULL) {
+      return err;
+  }
+
+  SAFE_FREE(file->name);
+  if (file->handle){
+    err = sftp_handle_close(file->sftp,file->handle);
+    SSH_STRING_FREE(file->handle);
+  }
+  /* FIXME: check server response and implement errno */
+  SAFE_FREE(file);
+
+  return err;
+}
+
+/* Close an open directory. */
+int sftp_closedir(sftp_dir dir){
+  int err = SSH_NO_ERROR;
+
+  SAFE_FREE(dir->name);
+  if (dir->handle) {
+    err = sftp_handle_close(dir->sftp, dir->handle);
+    SSH_STRING_FREE(dir->handle);
+  }
+  /* FIXME: check server response and implement errno */
+  SSH_BUFFER_FREE(dir->buffer);
+  SAFE_FREE(dir);
+
+  return err;
+}
+
+/* Open a file on the server. */
+sftp_file sftp_open(sftp_session sftp,
+                    const char *file,
+                    int flags,
+                    mode_t mode)
+{
+    sftp_message msg = NULL;
+    sftp_status_message status;
+    struct sftp_attributes_struct attr;
+    sftp_file handle;
+    ssh_buffer buffer = NULL;
+    sftp_attributes stat_data;
+    uint32_t sftp_flags = 0;
+    uint32_t id;
+    int rc;
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return NULL;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        return NULL;
+    }
+
+    ZERO_STRUCT(attr);
+    attr.permissions = mode;
+    attr.flags = SSH_FILEXFER_ATTR_PERMISSIONS;
+
+    if ((flags & O_RDWR) == O_RDWR) {
+        sftp_flags |= (SSH_FXF_WRITE | SSH_FXF_READ);
+    } else if ((flags & O_WRONLY) == O_WRONLY) {
+        sftp_flags |= SSH_FXF_WRITE;
+    } else {
+        sftp_flags |= SSH_FXF_READ;
+    }
+    if ((flags & O_CREAT) == O_CREAT)
+        sftp_flags |= SSH_FXF_CREAT;
+    if ((flags & O_TRUNC) == O_TRUNC)
+        sftp_flags |= SSH_FXF_TRUNC;
+    if ((flags & O_EXCL) == O_EXCL)
+        sftp_flags |= SSH_FXF_EXCL;
+    if ((flags & O_APPEND) == O_APPEND) {
+        sftp_flags |= SSH_FXF_APPEND;
+    }
+    SSH_LOG(SSH_LOG_PACKET, "Opening file %s with sftp flags %" PRIx32,
+            file, sftp_flags);
+
+    rc = ssh_buffer_pack(buffer,
+                         "dsd",
+                         id,
+                         file,
+                         sftp_flags);
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = buffer_add_attributes(buffer, &attr);
+    if (rc < 0) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_OPEN, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return NULL;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            /* something nasty has happened */
+            return NULL;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    switch (msg->packet_type) {
+    case SSH_FXP_STATUS:
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return NULL;
+        }
+        sftp_set_error(sftp, status->status);
+        ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                      "SFTP server: %s", status->errormsg);
+        status_msg_free(status);
+
+        return NULL;
+    case SSH_FXP_HANDLE:
+        handle = parse_handle_msg(msg);
+        if (handle == NULL) {
+            return NULL;
+        }
+        sftp_message_free(msg);
+        if ((flags & O_APPEND) == O_APPEND) {
+            stat_data = sftp_stat(sftp, file);
+            if (stat_data == NULL) {
+                sftp_close(handle);
+                return NULL;
+            }
+            if ((stat_data->flags & SSH_FILEXFER_ATTR_SIZE) != SSH_FILEXFER_ATTR_SIZE) {
+                ssh_set_error(sftp->session,
+                              SSH_FATAL,
+                              "Cannot open in append mode. Unknown file size.");
+                sftp_attributes_free(stat_data);
+                sftp_close(handle);
+                sftp_set_error(sftp, SSH_FX_FAILURE);
+                return NULL;
+            }
+
+            handle->offset = stat_data->size;
+            sftp_attributes_free(stat_data);
+        }
+        return handle;
+    default:
+        ssh_set_error(sftp->session, SSH_FATAL,
+                      "Received message %d during open!", msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return NULL;
+}
+
+void sftp_file_set_nonblocking(sftp_file handle)
+{
+    handle->nonblocking = 1;
+}
+void sftp_file_set_blocking(sftp_file handle)
+{
+    handle->nonblocking = 0;
+}
+
+/* Read from a file using an opened sftp file handle. */
+ssize_t sftp_read(sftp_file handle, void *buf, size_t count) {
+  sftp_session sftp;
+  sftp_message msg = NULL;
+  sftp_status_message status;
+  ssh_string datastring;
+  size_t datalen;
+  ssh_buffer buffer;
+  uint32_t id;
+  int rc;
+
+  if (handle == NULL) {
+      return -1;
+  }
+  sftp = handle->sftp;
+
+  if (handle->eof) {
+    return 0;
+  }
+
+  /*
+   * limit the reads to the maximum specified in Section 3 of
+   * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02
+   * or to the values provided by the limits@openssh.com extension.
+   *
+   * TODO: We should iterate over the blocks rather than writing less than
+   * requested to provide less surprises to the calling applications.
+   */
+  if (count > sftp->limits->max_read_length) {
+      count = sftp->limits->max_read_length;
+  }
+
+  buffer = ssh_buffer_new();
+  if (buffer == NULL) {
+    ssh_set_error_oom(sftp->session);
+    return -1;
+  }
+
+  rc = sftp_get_new_id(handle->sftp, &id);
+  if (rc != SSH_OK) {
+    return -1;
+  }
+
+  rc = ssh_buffer_pack(buffer,
+                       "dSqd",
+                       id,
+                       handle->handle,
+                       handle->offset,
+                       count);
+  if (rc != SSH_OK){
+    ssh_set_error_oom(sftp->session);
+    SSH_BUFFER_FREE(buffer);
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return -1;
+  }
+  if (sftp_packet_write(handle->sftp, SSH_FXP_READ, buffer) < 0) {
+    SSH_BUFFER_FREE(buffer);
+    return -1;
+  }
+  SSH_BUFFER_FREE(buffer);
+
+  while (msg == NULL) {
+    if (handle->nonblocking) {
+      if (ssh_channel_poll(handle->sftp->channel, 0) == 0) {
+        /* we cannot block */
+        return 0;
+      }
+    }
+    if (sftp_read_and_dispatch(handle->sftp) < 0) {
+      /* something nasty has happened */
+      return -1;
+    }
+    msg = sftp_dequeue(handle->sftp, id);
+  }
+
+  switch (msg->packet_type) {
+    case SSH_FXP_STATUS:
+      status = parse_status_msg(msg);
+      sftp_message_free(msg);
+      if (status == NULL) {
+        return -1;
+      }
+      sftp_set_error(sftp, status->status);
+      switch (status->status) {
+        case SSH_FX_EOF:
+          handle->eof = 1;
+          status_msg_free(status);
+          return 0;
+        default:
+          break;
+      }
+      ssh_set_error(sftp->session,SSH_REQUEST_DENIED,
+          "SFTP server: %s", status->errormsg);
+      status_msg_free(status);
+      return -1;
+    case SSH_FXP_DATA:
+      datastring = ssh_buffer_get_ssh_string(msg->payload);
+      sftp_message_free(msg);
+      if (datastring == NULL) {
+        ssh_set_error(sftp->session, SSH_FATAL,
+            "Received invalid DATA packet from sftp server");
+        return -1;
+      }
+
+      datalen = ssh_string_len(datastring);
+      if (datalen > count) {
+        ssh_set_error(sftp->session, SSH_FATAL,
+            "Received a too big DATA packet from sftp server: "
+            "%zu and asked for %zu",
+            datalen, count);
+        SSH_STRING_FREE(datastring);
+        return -1;
+      }
+      handle->offset += (uint64_t)datalen;
+      memcpy(buf, ssh_string_data(datastring), datalen);
+      SSH_STRING_FREE(datastring);
+      return datalen;
+    default:
+      ssh_set_error(sftp->session, SSH_FATAL,
+          "Received message %d during read!", msg->packet_type);
+      sftp_message_free(msg);
+      sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+      return -1;
+  }
+
+  return -1; /* not reached */
+}
+
+/* Start an asynchronous read from a file using an opened sftp file handle. */
+int sftp_async_read_begin(sftp_file file, uint32_t len){
+  sftp_session sftp = file->sftp;
+  ssh_buffer buffer;
+  uint32_t id;
+  int rc;
+
+  buffer = ssh_buffer_new();
+  if (buffer == NULL) {
+    ssh_set_error_oom(sftp->session);
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return -1;
+  }
+
+  rc = sftp_get_new_id(sftp, &id);
+  if (rc != SSH_OK) {
+      return -1;
+  }
+
+  rc = ssh_buffer_pack(buffer,
+                       "dSqd",
+                       id,
+                       file->handle,
+                       file->offset,
+                       len);
+  if (rc != SSH_OK) {
+    ssh_set_error_oom(sftp->session);
+    SSH_BUFFER_FREE(buffer);
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return -1;
+  }
+  if (sftp_packet_write(sftp, SSH_FXP_READ, buffer) < 0) {
+    SSH_BUFFER_FREE(buffer);
+    return -1;
+  }
+  SSH_BUFFER_FREE(buffer);
+
+  file->offset += len; /* assume we'll read len bytes */
+
+  return id;
+}
+
+/* Wait for an asynchronous read to complete and save the data. */
+int sftp_async_read(sftp_file file, void *data, uint32_t size, uint32_t id){
+  sftp_session sftp;
+  sftp_message msg = NULL;
+  sftp_status_message status;
+  ssh_string datastring;
+  int err = SSH_OK;
+  uint32_t len;
+
+  if (file == NULL) {
+    return SSH_ERROR;
+  }
+  sftp = file->sftp;
+
+  if (file->eof) {
+    return 0;
+  }
+
+  /* handle an existing request */
+  while (msg == NULL) {
+    if (file->nonblocking){
+      if (ssh_channel_poll(sftp->channel, 0) == 0) {
+        /* we cannot block */
+        return SSH_AGAIN;
+      }
+    }
+
+    if (sftp_read_and_dispatch(sftp) < 0) {
+      /* something nasty has happened */
+      return SSH_ERROR;
+    }
+
+    msg = sftp_dequeue(sftp,id);
+  }
+
+  switch (msg->packet_type) {
+    case SSH_FXP_STATUS:
+      status = parse_status_msg(msg);
+      sftp_message_free(msg);
+      if (status == NULL) {
+        return -1;
+      }
+      sftp_set_error(sftp, status->status);
+      if (status->status != SSH_FX_EOF) {
+        ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+            "SFTP server : %s", status->errormsg);
+        err = SSH_ERROR;
+      } else {
+        file->eof = 1;
+      }
+      status_msg_free(status);
+      return err;
+    case SSH_FXP_DATA:
+      datastring = ssh_buffer_get_ssh_string(msg->payload);
+      sftp_message_free(msg);
+      if (datastring == NULL) {
+        ssh_set_error(sftp->session, SSH_FATAL,
+            "Received invalid DATA packet from sftp server");
+        return SSH_ERROR;
+      }
+      if (ssh_string_len(datastring) > size) {
+        ssh_set_error(sftp->session, SSH_FATAL,
+            "Received a too big DATA packet from sftp server: "
+            "%zu and asked for %" PRIu32,
+            ssh_string_len(datastring), size);
+        SSH_STRING_FREE(datastring);
+        return SSH_ERROR;
+      }
+      len = ssh_string_len(datastring);
+      /* Update the offset with the correct value */
+      file->offset = file->offset - (size - len);
+      memcpy(data, ssh_string_data(datastring), len);
+      SSH_STRING_FREE(datastring);
+      return len;
+    default:
+      ssh_set_error(sftp->session,SSH_FATAL,"Received message %d during read!",msg->packet_type);
+      sftp_message_free(msg);
+      sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+      return SSH_ERROR;
+  }
+
+  return SSH_ERROR;
+}
+
+ssize_t sftp_write(sftp_file file, const void *buf, size_t count) {
+  sftp_session sftp;
+  sftp_message msg = NULL;
+  sftp_status_message status;
+  ssh_buffer buffer;
+  uint32_t id;
+  ssize_t len;
+  size_t packetlen;
+  int rc;
+
+  if (file == NULL) {
+      return -1;
+  }
+  sftp = file->sftp;
+
+  buffer = ssh_buffer_new();
+  if (buffer == NULL) {
+    ssh_set_error_oom(sftp->session);
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return -1;
+  }
+
+  rc = sftp_get_new_id(file->sftp, &id);
+  if (rc != SSH_OK) {
+    return -1;
+  }
+
+  /*
+   * limit the writes to the maximum specified in Section 3 of
+   * https://datatracker.ietf.org/doc/html/draft-ietf-secsh-filexfer-02
+   * or to the values provided by the limits@openssh.com extension.
+   *
+   * TODO: We should iterate over the blocks rather than writing less than
+   * requested to provide less surprises to the calling applications.
+   */
+  if (count > sftp->limits->max_write_length) {
+      count = sftp->limits->max_write_length;
+  }
+
+  rc = ssh_buffer_pack(buffer,
+                       "dSqdP",
+                       id,
+                       file->handle,
+                       file->offset,
+                       count, /* len of datastring */
+                       (size_t)count, buf);
+  if (rc != SSH_OK){
+    ssh_set_error_oom(sftp->session);
+    SSH_BUFFER_FREE(buffer);
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return -1;
+  }
+  len = sftp_packet_write(file->sftp, SSH_FXP_WRITE, buffer);
+  packetlen=ssh_buffer_get_len(buffer);
+  SSH_BUFFER_FREE(buffer);
+  if (len < 0) {
+    return -1;
+  } else  if ((size_t)len != packetlen) {
+    SSH_LOG(SSH_LOG_PACKET,
+        "Could not write as much data as expected");
+  }
+
+  while (msg == NULL) {
+    if (sftp_read_and_dispatch(file->sftp) < 0) {
+      /* something nasty has happened */
+      return -1;
+    }
+    msg = sftp_dequeue(file->sftp, id);
+  }
+
+  switch (msg->packet_type) {
+    case SSH_FXP_STATUS:
+      status = parse_status_msg(msg);
+      sftp_message_free(msg);
+      if (status == NULL) {
+        return -1;
+      }
+      sftp_set_error(sftp, status->status);
+      switch (status->status) {
+        case SSH_FX_OK:
+          file->offset += count;
+          status_msg_free(status);
+          return count;
+        default:
+          break;
+      }
+      ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+          "SFTP server: %s", status->errormsg);
+      file->offset += count;
+      status_msg_free(status);
+      return -1;
+    default:
+      ssh_set_error(sftp->session, SSH_FATAL,
+          "Received message %d during write!", msg->packet_type);
+      sftp_message_free(msg);
+      sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+      return -1;
+  }
+
+  return -1; /* not reached */
+}
+
+/* Seek to a specific location in a file. */
+int sftp_seek(sftp_file file, uint32_t new_offset) {
+  if (file == NULL) {
+    return -1;
+  }
+
+  file->offset = new_offset;
+  file->eof = 0;
+
+  return 0;
+}
+
+int sftp_seek64(sftp_file file, uint64_t new_offset) {
+  if (file == NULL) {
+    return -1;
+  }
+
+  file->offset = new_offset;
+  file->eof = 0;
+
+  return 0;
+}
+
+/* Report current byte position in file. */
+unsigned long sftp_tell(sftp_file file) {
+  return (unsigned long)file->offset;
+}
+/* Report current byte position in file. */
+uint64_t sftp_tell64(sftp_file file) {
+  return (uint64_t) file->offset;
+}
+
+/* Rewinds the position of the file pointer to the beginning of the file.*/
+void sftp_rewind(sftp_file file) {
+  file->offset = 0;
+  file->eof = 0;
+}
+
+/* code written by Nick */
+int sftp_unlink(sftp_session sftp, const char *file) {
+  sftp_status_message status = NULL;
+  sftp_message msg = NULL;
+  ssh_buffer buffer;
+  uint32_t id;
+  int rc;
+
+  rc = sftp_get_new_id(sftp, &id);
+  if (rc != SSH_OK) {
+    return -1;
+  }
+
+  buffer = ssh_buffer_new();
+  if (buffer == NULL) {
+    ssh_set_error_oom(sftp->session);
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return -1;
+  }
+
+  rc = ssh_buffer_pack(buffer,
+                       "ds",
+                       id,
+                       file);
+  if (rc != SSH_OK) {
+    ssh_set_error_oom(sftp->session);
+    SSH_BUFFER_FREE(buffer);
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return -1;
+  }
+
+  if (sftp_packet_write(sftp, SSH_FXP_REMOVE, buffer) < 0) {
+    SSH_BUFFER_FREE(buffer);
+    return -1;
+  }
+  SSH_BUFFER_FREE(buffer);
+
+  while (msg == NULL) {
+    if (sftp_read_and_dispatch(sftp)) {
+      return -1;
+    }
+    msg = sftp_dequeue(sftp, id);
+  }
+
+  if (msg->packet_type == SSH_FXP_STATUS) {
+    /* by specification, this command's only supposed to return SSH_FXP_STATUS */
+    status = parse_status_msg(msg);
+    sftp_message_free(msg);
+    if (status == NULL) {
+      return -1;
+    }
+    sftp_set_error(sftp, status->status);
+    switch (status->status) {
+      case SSH_FX_OK:
+        status_msg_free(status);
+        return 0;
+      default:
+        break;
+    }
+
+    /*
+     * The status should be SSH_FX_OK if the command was successful, if it
+     * didn't, then there was an error
+     */
+    ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+        "SFTP server: %s", status->errormsg);
+    status_msg_free(status);
+    return -1;
+  } else {
+    ssh_set_error(sftp->session,SSH_FATAL,
+        "Received message %d when attempting to remove file", msg->packet_type);
+    sftp_message_free(msg);
+    sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+  }
+
+  return -1;
+}
+
+/* code written by Nick */
+int sftp_rmdir(sftp_session sftp, const char *directory) {
+  sftp_status_message status = NULL;
+  sftp_message msg = NULL;
+  ssh_buffer buffer;
+  uint32_t id;
+  int rc;
+
+  rc = sftp_get_new_id(sftp, &id);
+  if (rc != SSH_OK) {
+    return -1;
+  }
+
+  buffer = ssh_buffer_new();
+  if (buffer == NULL) {
+    ssh_set_error_oom(sftp->session);
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return -1;
+  }
+
+  rc = ssh_buffer_pack(buffer,
+                       "ds",
+                       id,
+                       directory);
+  if (rc != SSH_OK) {
+    ssh_set_error_oom(sftp->session);
+    SSH_BUFFER_FREE(buffer);
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return -1;
+  }
+  if (sftp_packet_write(sftp, SSH_FXP_RMDIR, buffer) < 0) {
+    SSH_BUFFER_FREE(buffer);
+    return -1;
+  }
+  SSH_BUFFER_FREE(buffer);
+
+  while (msg == NULL) {
+    if (sftp_read_and_dispatch(sftp) < 0) {
+      return -1;
+    }
+    msg = sftp_dequeue(sftp, id);
+  }
+
+  /* By specification, this command returns SSH_FXP_STATUS */
+  if (msg->packet_type == SSH_FXP_STATUS) {
+    status = parse_status_msg(msg);
+    sftp_message_free(msg);
+    if (status == NULL) {
+      return -1;
+    }
+    sftp_set_error(sftp, status->status);
+    switch (status->status) {
+      case SSH_FX_OK:
+        status_msg_free(status);
+        return 0;
+      default:
+        break;
+    }
+    ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+        "SFTP server: %s", status->errormsg);
+    status_msg_free(status);
+    return -1;
+  } else {
+    ssh_set_error(sftp->session, SSH_FATAL,
+        "Received message %d when attempting to remove directory",
+        msg->packet_type);
+    sftp_message_free(msg);
+    sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+  }
+
+  return -1;
+}
+
+/* Code written by Nick */
+int sftp_mkdir(sftp_session sftp, const char *directory, mode_t mode)
+{
+    sftp_status_message status = NULL;
+    sftp_message msg = NULL;
+    sftp_attributes errno_attr = NULL;
+    struct sftp_attributes_struct attr;
+    ssh_buffer buffer;
+    uint32_t id;
+    int rc;
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return -1;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    ZERO_STRUCT(attr);
+    attr.permissions = mode;
+    attr.flags = SSH_FILEXFER_ATTR_PERMISSIONS;
+
+    rc = ssh_buffer_pack(buffer,
+                         "ds",
+                         id,
+                         directory);
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = buffer_add_attributes(buffer, &attr);
+    if (rc < 0) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_MKDIR, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return -1;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            return -1;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    /* By specification, this command only returns SSH_FXP_STATUS */
+    if (msg->packet_type == SSH_FXP_STATUS) {
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return -1;
+        }
+        sftp_set_error(sftp, status->status);
+        switch (status->status) {
+            case SSH_FX_FAILURE:
+                /*
+                 * mkdir always returns a failure, even if the path already exists.
+                 * To be POSIX conform and to be able to map it to EEXIST a stat
+                 * call is needed here.
+                 */
+                errno_attr = sftp_lstat(sftp, directory);
+                if (errno_attr != NULL) {
+                    SAFE_FREE(errno_attr);
+                    sftp_set_error(sftp, SSH_FX_FILE_ALREADY_EXISTS);
+                }
+                break;
+            case SSH_FX_OK:
+                status_msg_free(status);
+                return 0;
+            default:
+                break;
+        }
+        /*
+         * The status should be SSH_FX_OK if the command was successful, if it
+         * didn't, then there was an error
+         */
+        ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                "SFTP server: %s", status->errormsg);
+        status_msg_free(status);
+        return -1;
+    } else {
+        ssh_set_error(sftp->session, SSH_FATAL,
+                "Received message %d when attempting to make directory",
+                msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return -1;
+}
+
+/* code written by nick */
+int sftp_rename(sftp_session sftp, const char *original, const char *newname)
+{
+    sftp_status_message status = NULL;
+    sftp_message msg = NULL;
+    ssh_buffer buffer = NULL;
+    uint32_t id;
+    const char *extension_name = "posix-rename@openssh.com";
+    int request_type;
+    int rc;
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return -1;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    /*
+     * posix-rename@openssh.com extension will be used
+     * if it is supported by sftp
+     */
+    if (sftp_extension_supported(sftp,
+                                 extension_name,
+                                 "1")) {
+        rc = ssh_buffer_pack(buffer,
+                             "dsss",
+                             id,
+                             extension_name,
+                             original,
+                             newname);
+        if (rc != SSH_OK) {
+            ssh_set_error_oom(sftp->session);
+            SSH_BUFFER_FREE(buffer);
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return -1;
+        }
+
+        request_type = SSH_FXP_EXTENDED;
+    } else {
+        rc = ssh_buffer_pack(buffer,
+                             "dss",
+                             id,
+                             original,
+                             newname);
+        if (rc != SSH_OK) {
+            ssh_set_error_oom(sftp->session);
+            SSH_BUFFER_FREE(buffer);
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return -1;
+        }
+
+        if (sftp->version >= 4) {
+            /*
+             * POSIX rename atomically replaces newpath,
+             * we should do the same only available on >=v4
+             */
+            ssh_buffer_add_u32(buffer, SSH_FXF_RENAME_OVERWRITE);
+        }
+
+        request_type = SSH_FXP_RENAME;
+    }
+
+    rc = sftp_packet_write(sftp, request_type, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return -1;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            return -1;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    /* By specification, this command only returns SSH_FXP_STATUS */
+    if (msg->packet_type == SSH_FXP_STATUS) {
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return -1;
+        }
+        sftp_set_error(sftp, status->status);
+        switch (status->status) {
+            case SSH_FX_OK:
+                status_msg_free(status);
+                return 0;
+            default:
+                break;
+        }
+        /*
+         * Status should be SSH_FX_OK if the command was successful,
+         * if it didn't, then there was an error
+         */
+        ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                      "SFTP server: %s", status->errormsg);
+        status_msg_free(status);
+        return -1;
+    } else {
+        ssh_set_error(sftp->session, SSH_FATAL,
+                      "Received message %d when attempting to rename",
+                      msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return -1;
+}
+
+/* Code written by Nick */
+/* Set file attributes on a file, directory or symbolic link. */
+int sftp_setstat(sftp_session sftp, const char *file, sftp_attributes attr)
+{
+    uint32_t id;
+    ssh_buffer buffer;
+    sftp_message msg = NULL;
+    sftp_status_message status = NULL;
+    int rc;
+
+    if (sftp == NULL || file == NULL || attr == NULL) {
+        return -1;
+    }
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return -1;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "ds",
+                         id,
+                         file);
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = buffer_add_attributes(buffer, attr);
+    if (rc != 0) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_SETSTAT, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return -1;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            return -1;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    /* By specification, this command only returns SSH_FXP_STATUS */
+    if (msg->packet_type == SSH_FXP_STATUS) {
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return -1;
+        }
+        sftp_set_error(sftp, status->status);
+        switch (status->status) {
+            case SSH_FX_OK:
+                status_msg_free(status);
+                return 0;
+            default:
+                break;
+        }
+        /*
+         * The status should be SSH_FX_OK if the command was successful, if it
+         * didn't, then there was an error
+         */
+        ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                "SFTP server: %s", status->errormsg);
+        status_msg_free(status);
+        return -1;
+    } else {
+        ssh_set_error(sftp->session, SSH_FATAL,
+                "Received message %d when attempting to set stats", msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return -1;
+}
+
+int
+sftp_lsetstat(sftp_session sftp, const char *file, sftp_attributes attr)
+{
+    uint32_t id;
+    ssh_buffer buffer = NULL;
+    sftp_message msg = NULL;
+    sftp_status_message status = NULL;
+    const char *extension_name = "lsetstat@openssh.com";
+    int rc;
+
+    if (sftp == NULL || file == NULL || attr == NULL) {
+        return -1;
+    }
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return -1;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = ssh_buffer_pack(buffer, "dss", id, extension_name, file);
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = buffer_add_attributes(buffer, attr);
+    if (rc != 0) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_EXTENDED, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return -1;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            return -1;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    /* By specification, this command only returns SSH_FXP_STATUS */
+    if (msg->packet_type == SSH_FXP_STATUS) {
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return -1;
+        }
+        sftp_set_error(sftp, status->status);
+        switch (status->status) {
+        case SSH_FX_OK:
+            status_msg_free(status);
+            return 0;
+        default:
+            break;
+        }
+        /*
+         * The status should be SSH_FX_OK if the command was successful, if it
+         * didn't, then there was an error
+         */
+        ssh_set_error(sftp->session,
+                      SSH_REQUEST_DENIED,
+                      "SFTP server: %s",
+                      status->errormsg);
+        status_msg_free(status);
+        return -1;
+    } else {
+        ssh_set_error(sftp->session,
+                      SSH_FATAL,
+                      "Received message %d when attempting to lsetstat",
+                      msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return -1;
+}
+
+/* Change the file owner and group */
+int sftp_chown(sftp_session sftp, const char *file, uid_t owner, gid_t group) {
+	struct sftp_attributes_struct attr;
+  ZERO_STRUCT(attr);
+
+  attr.uid = owner;
+  attr.gid = group;
+
+  attr.flags = SSH_FILEXFER_ATTR_UIDGID;
+
+  return sftp_setstat(sftp, file, &attr);
+}
+
+/* Change permissions of a file */
+int sftp_chmod(sftp_session sftp, const char *file, mode_t mode) {
+	struct sftp_attributes_struct attr;
+  ZERO_STRUCT(attr);
+  attr.permissions = mode;
+  attr.flags = SSH_FILEXFER_ATTR_PERMISSIONS;
+
+  return sftp_setstat(sftp, file, &attr);
+}
+
+/* Change the last modification and access time of a file. */
+int sftp_utimes(sftp_session sftp, const char *file,
+    const struct timeval *times) {
+	struct sftp_attributes_struct attr;
+  ZERO_STRUCT(attr);
+
+  attr.atime = times[0].tv_sec;
+  attr.atime_nseconds = times[0].tv_usec;
+
+  attr.mtime = times[1].tv_sec;
+  attr.mtime_nseconds = times[1].tv_usec;
+
+  attr.flags |= SSH_FILEXFER_ATTR_ACCESSTIME | SSH_FILEXFER_ATTR_MODIFYTIME |
+    SSH_FILEXFER_ATTR_SUBSECOND_TIMES;
+
+  return sftp_setstat(sftp, file, &attr);
+}
+
+int sftp_symlink(sftp_session sftp, const char *target, const char *dest)
+{
+  sftp_status_message status = NULL;
+  sftp_message msg = NULL;
+  ssh_buffer buffer;
+  uint32_t id;
+  int rc;
+
+  if (sftp == NULL)
+    return -1;
+  if (target == NULL || dest == NULL) {
+    ssh_set_error_invalid(sftp->session);
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return -1;
+  }
+
+  rc = sftp_get_new_id(sftp, &id);
+  if (rc != SSH_OK) {
+    return -1;
+  }
+
+  buffer = ssh_buffer_new();
+  if (buffer == NULL) {
+    ssh_set_error_oom(sftp->session);
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return -1;
+  }
+
+  /* The OpenSSH sftp server has order of the arguments reversed, see the
+   * section "4.1 sftp: Reversal of arguments to SSH_FXP_SYMLINK' in
+   * https://github.com/openssh/openssh-portable/blob/master/PROTOCOL
+   * for more information */
+  if (ssh_get_openssh_version(sftp->session)) {
+      rc = ssh_buffer_pack(buffer,
+                           "dss",
+                           id,
+                           target,
+                           dest);
+  } else {
+      rc = ssh_buffer_pack(buffer,
+                           "dss",
+                           id,
+                           dest,
+                           target);
+  }
+  if (rc != SSH_OK){
+      ssh_set_error_oom(sftp->session);
+      SSH_BUFFER_FREE(buffer);
+      sftp_set_error(sftp, SSH_FX_FAILURE);
+      return -1;
+  }
+
+  if (sftp_packet_write(sftp, SSH_FXP_SYMLINK, buffer) < 0) {
+    SSH_BUFFER_FREE(buffer);
+    return -1;
+  }
+  SSH_BUFFER_FREE(buffer);
+
+  while (msg == NULL) {
+    if (sftp_read_and_dispatch(sftp) < 0) {
+      return -1;
+    }
+    msg = sftp_dequeue(sftp, id);
+  }
+
+  /* By specification, this command only returns SSH_FXP_STATUS */
+  if (msg->packet_type == SSH_FXP_STATUS) {
+    status = parse_status_msg(msg);
+    sftp_message_free(msg);
+    if (status == NULL) {
+      return -1;
+    }
+    sftp_set_error(sftp, status->status);
+    switch (status->status) {
+      case SSH_FX_OK:
+        status_msg_free(status);
+        return 0;
+      default:
+        break;
+    }
+    /*
+     * The status should be SSH_FX_OK if the command was successful, if it
+     * didn't, then there was an error
+     */
+    ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+        "SFTP server: %s", status->errormsg);
+    status_msg_free(status);
+    return -1;
+  } else {
+    ssh_set_error(sftp->session, SSH_FATAL,
+        "Received message %d when attempting to set stats", msg->packet_type);
+    sftp_message_free(msg);
+    sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+  }
+
+  return -1;
+}
+
+char *sftp_readlink(sftp_session sftp, const char *path)
+{
+    sftp_status_message status = NULL;
+    sftp_message msg = NULL;
+    ssh_buffer buffer;
+    uint32_t id;
+    int rc;
+
+    if (sftp == NULL) {
+        return NULL;
+    }
+
+    if (path == NULL) {
+        ssh_set_error_invalid(sftp);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+    if (sftp->version < 3){
+        ssh_set_error(sftp,SSH_REQUEST_DENIED,"sftp version %d does not support sftp_readlink",sftp->version);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return NULL;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "ds",
+                         id,
+                         path);
+    if (rc < 0) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_READLINK, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return NULL;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            return NULL;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    if (msg->packet_type == SSH_FXP_NAME) {
+        uint32_t ignored = 0;
+        char *lnk = NULL;
+
+        rc = ssh_buffer_unpack(msg->payload,
+                               "ds",
+                               &ignored,
+                               &lnk);
+        sftp_message_free(msg);
+        if (rc != SSH_OK) {
+            ssh_set_error(sftp->session,
+                          SSH_ERROR,
+                          "Failed to retrieve link");
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return NULL;
+        }
+
+        return lnk;
+    } else if (msg->packet_type == SSH_FXP_STATUS) { /* bad response (error) */
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return NULL;
+        }
+        sftp_set_error(sftp, status->status);
+        ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                "SFTP server: %s", status->errormsg);
+        status_msg_free(status);
+    } else { /* this shouldn't happen */
+        ssh_set_error(sftp->session, SSH_FATAL,
+                "Received message %d when attempting to set stats", msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return NULL;
+}
+
+int sftp_hardlink(sftp_session sftp, const char *oldpath, const char *newpath)
+{
+    ssh_buffer buffer = NULL;
+    uint32_t id;
+    const char *extension_name = "hardlink@openssh.com";
+    sftp_status_message status = NULL;
+    sftp_message msg = NULL;
+    int rc;
+
+    if (sftp == NULL) {
+        return -1;
+    }
+
+    if (oldpath == NULL || newpath == NULL) {
+        ssh_set_error_invalid(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return -1;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "dsss",
+                         id,
+                         extension_name,
+                         oldpath,
+                         newpath);
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_EXTENDED, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return -1;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            return -1;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    /* By specification, this command only returns SSH_FXP_STATUS */
+    if (msg->packet_type == SSH_FXP_STATUS) {
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return -1;
+        }
+        sftp_set_error(sftp, status->status);
+        switch (status->status) {
+            case SSH_FX_OK:
+                status_msg_free(status);
+                return 0;
+            default:
+                break;
+        }
+        /*
+         * Status should be SSH_FX_OK if the command was successful,
+         * if it didn't, then there was an error
+         */
+        ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                      "SFTP server: %s", status->errormsg);
+        status_msg_free(status);
+        return -1;
+    } else {
+        ssh_set_error(sftp->session, SSH_FATAL,
+                      "Received message %d when attempting to create hardlink",
+                      msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return -1;
+}
+
+static sftp_statvfs_t sftp_parse_statvfs(sftp_session sftp, ssh_buffer buf) {
+  sftp_statvfs_t  statvfs;
+  int rc;
+
+  statvfs = calloc(1, sizeof(struct sftp_statvfs_struct));
+  if (statvfs == NULL) {
+    ssh_set_error_oom(sftp->session);
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return NULL;
+  }
+
+  rc = ssh_buffer_unpack(buf, "qqqqqqqqqqq",
+          &statvfs->f_bsize,  /* file system block size */
+          &statvfs->f_frsize, /* fundamental fs block size */
+          &statvfs->f_blocks, /* number of blocks (unit f_frsize) */
+          &statvfs->f_bfree,  /* free blocks in file system */
+          &statvfs->f_bavail, /* free blocks for non-root */
+          &statvfs->f_files,  /* total file inodes */
+          &statvfs->f_ffree,  /* free file inodes */
+          &statvfs->f_favail, /* free file inodes for to non-root */
+          &statvfs->f_fsid,   /* file system id */
+          &statvfs->f_flag,   /* bit mask of f_flag values */
+          &statvfs->f_namemax/* maximum filename length */
+          );
+  if (rc != SSH_OK) {
+    SAFE_FREE(statvfs);
+    ssh_set_error(sftp->session, SSH_FATAL, "Invalid statvfs structure");
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+    return NULL;
+  }
+
+  return statvfs;
+}
+
+sftp_statvfs_t sftp_statvfs(sftp_session sftp, const char *path)
+{
+    sftp_status_message status = NULL;
+    sftp_message msg = NULL;
+    ssh_buffer buffer;
+    uint32_t id;
+    int rc;
+
+    if (sftp == NULL)
+        return NULL;
+    if (path == NULL) {
+        ssh_set_error_invalid(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+    if (sftp->version < 3){
+        ssh_set_error(sftp,SSH_REQUEST_DENIED,"sftp version %d does not support sftp_statvfs",sftp->version);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return NULL;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "dss",
+                         id,
+                         "statvfs@openssh.com",
+                         path);
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_EXTENDED, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return NULL;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            return NULL;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    if (msg->packet_type == SSH_FXP_EXTENDED_REPLY) {
+        sftp_statvfs_t  buf = sftp_parse_statvfs(sftp, msg->payload);
+        sftp_message_free(msg);
+        if (buf == NULL) {
+            return NULL;
+        }
+
+        return buf;
+    } else if (msg->packet_type == SSH_FXP_STATUS) { /* bad response (error) */
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return NULL;
+        }
+        sftp_set_error(sftp, status->status);
+        ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                "SFTP server: %s", status->errormsg);
+        status_msg_free(status);
+    } else { /* this shouldn't happen */
+        ssh_set_error(sftp->session, SSH_FATAL,
+                "Received message %d when attempting to get statvfs", msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return NULL;
+}
+
+int sftp_fsync(sftp_file file)
+{
+    sftp_session sftp;
+    sftp_message msg = NULL;
+    ssh_buffer buffer;
+    uint32_t id;
+    int rc;
+
+    if (file == NULL) {
+        return -1;
+    }
+    sftp = file->sftp;
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return -1;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "dsS",
+                         id,
+                         "fsync@openssh.com",
+                         file->handle);
+    if (rc < 0) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        goto done;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_EXTENDED, buffer);
+    if (rc < 0) {
+        ssh_set_error_oom(sftp->session);
+        goto done;
+    }
+
+    do {
+        rc = sftp_read_and_dispatch(sftp);
+        if (rc < 0) {
+            ssh_set_error_oom(sftp->session);
+            rc = -1;
+            goto done;
+        }
+        msg = sftp_dequeue(sftp, id);
+    } while (msg == NULL);
+
+    /* By specification, this command only returns SSH_FXP_STATUS */
+    if (msg->packet_type == SSH_FXP_STATUS) {
+        sftp_status_message status;
+
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            rc = -1;
+            goto done;
+        }
+
+        sftp_set_error(sftp, status->status);
+        switch (status->status) {
+            case SSH_FX_OK:
+                /* SUCCESS, LEAVE */
+                status_msg_free(status);
+                rc = 0;
+                goto done;
+            default:
+                break;
+        }
+
+        /*
+         * The status should be SSH_FX_OK if the command was successful, if it
+         * didn't, then there was an error
+         */
+        ssh_set_error(sftp->session,
+                      SSH_REQUEST_DENIED,
+                      "SFTP server: %s",
+                      status->errormsg);
+        status_msg_free(status);
+
+        rc = -1;
+        goto done;
+    } else {
+        ssh_set_error(sftp->session,
+                      SSH_FATAL,
+                      "Received message %d when attempting to set stats",
+                      msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    rc = -1;
+done:
+    SSH_BUFFER_FREE(buffer);
+
+    return rc;
+}
+
+sftp_statvfs_t sftp_fstatvfs(sftp_file file)
+{
+    sftp_status_message status = NULL;
+    sftp_message msg = NULL;
+    sftp_session sftp;
+    ssh_buffer buffer;
+    uint32_t id;
+    int rc;
+
+    if (file == NULL) {
+        return NULL;
+    }
+    sftp = file->sftp;
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return NULL;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "dsS",
+                         id,
+                         "fstatvfs@openssh.com",
+                         file->handle);
+    if (rc < 0) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_EXTENDED, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return NULL;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            return NULL;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    if (msg->packet_type == SSH_FXP_EXTENDED_REPLY) {
+        sftp_statvfs_t buf = sftp_parse_statvfs(sftp, msg->payload);
+        sftp_message_free(msg);
+        if (buf == NULL) {
+            return NULL;
+        }
+
+        return buf;
+    } else if (msg->packet_type == SSH_FXP_STATUS) { /* bad response (error) */
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return NULL;
+        }
+        sftp_set_error(sftp, status->status);
+        ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                "SFTP server: %s", status->errormsg);
+        status_msg_free(status);
+    } else { /* this shouldn't happen */
+        ssh_set_error(sftp->session, SSH_FATAL,
+                "Received message %d when attempting to set stats", msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return NULL;
+}
+
+void sftp_statvfs_free(sftp_statvfs_t statvfs) {
+    if (statvfs == NULL) {
+        return;
+    }
+
+    SAFE_FREE(statvfs);
+}
+
+static sftp_limits_t sftp_limits_new(void)
+{
+    return calloc(1, sizeof(struct sftp_limits_struct));
+}
+
+static sftp_limits_t sftp_parse_limits(sftp_session sftp, ssh_buffer buf)
+{
+    sftp_limits_t limits = NULL;
+    int rc;
+
+    limits = sftp_limits_new();
+    if (limits == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = ssh_buffer_unpack(buf, "qqqq",
+            &limits->max_packet_length,  /** maximum number of bytes in a single sftp packet */
+            &limits->max_read_length,    /** maximum length in a SSH_FXP_READ packet */
+            &limits->max_write_length,   /** maximum length in a SSH_FXP_WRITE packet */
+            &limits->max_open_handles    /** maximum number of active handles allowed by server */
+            );
+    if (rc != SSH_OK) {
+        SAFE_FREE(limits);
+        ssh_set_error(sftp->session, SSH_FATAL, "Invalid limits structure");
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    return limits;
+}
+
+static sftp_limits_t sftp_limits_use_extension(sftp_session sftp)
+{
+    sftp_status_message status = NULL;
+    sftp_message msg = NULL;
+    ssh_buffer buffer;
+    uint32_t id;
+    int rc;
+
+    if (sftp == NULL)
+        return NULL;
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return NULL;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "ds",
+                         id,
+                         "limits@openssh.com");
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_EXTENDED, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return NULL;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            return NULL;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    if (msg->packet_type == SSH_FXP_EXTENDED_REPLY) {
+        sftp_limits_t limits = sftp_parse_limits(sftp, msg->payload);
+        sftp_message_free(msg);
+        if (limits == NULL) {
+            return NULL;
+        }
+
+        return limits;
+    } else if (msg->packet_type == SSH_FXP_STATUS) { /* bad response (error) */
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return NULL;
+        }
+        sftp_set_error(sftp, status->status);
+        ssh_set_error(sftp->session,
+                      SSH_REQUEST_DENIED,
+                      "SFTP server: %s",
+                      status->errormsg);
+        status_msg_free(status);
+    } else { /* this shouldn't happen */
+        ssh_set_error(sftp->session,
+                      SSH_FATAL,
+                      "Received message %d when attempting to get limits",
+                      msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return NULL;
+}
+
+static sftp_limits_t sftp_limits_use_default(sftp_session sftp)
+{
+    sftp_limits_t limits = NULL;
+
+    if (sftp == NULL) {
+        return NULL;
+    }
+
+    limits = sftp_limits_new();
+    if (limits == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    limits->max_packet_length = 34000;
+    limits->max_read_length = 32768;
+    limits->max_write_length = 32768;
+
+    /*
+     * For max-open-handles field openssh says :
+     * If the server doesn't enforce a specific limit, then the field may
+     * be set to 0.  This implies the server relies on the OS to enforce
+     * limits (e.g. available memory or file handles), and such limits
+     * might be dynamic.  The client SHOULD take care to not try to exceed
+     * reasonable limits.
+     */
+    limits->max_open_handles = 0;
+
+    return limits;
+}
+
+sftp_limits_t sftp_limits(sftp_session sftp)
+{
+    sftp_limits_t limits = NULL;
+
+    if (sftp == NULL) {
+        return NULL;
+    }
+
+    if (sftp->limits == NULL) {
+        ssh_set_error(sftp, SSH_FATAL,
+                      "Uninitialized sftp session, "
+                      "sftp_init() was not called or failed");
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    limits = sftp_limits_new();
+    if (limits == NULL) {
+        ssh_set_error_oom(sftp);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    memcpy(limits, sftp->limits, sizeof(struct sftp_limits_struct));
+    return limits;
+}
+
+void sftp_limits_free(sftp_limits_t limits)
+{
+    if (limits == NULL) {
+        return;
+    }
+
+    SAFE_FREE(limits);
+}
+
+/* another code written by Nick */
+char *sftp_canonicalize_path(sftp_session sftp, const char *path)
+{
+    sftp_status_message status = NULL;
+    sftp_message msg = NULL;
+    ssh_buffer buffer;
+    uint32_t id;
+    int rc;
+
+    if (sftp == NULL)
+        return NULL;
+    if (path == NULL) {
+        ssh_set_error_invalid(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return NULL;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "ds",
+                         id,
+                         path);
+    if (rc < 0) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_REALPATH, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return NULL;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            return NULL;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    if (msg->packet_type == SSH_FXP_NAME) {
+        uint32_t ignored = 0;
+        char *cname = NULL;
+
+        rc = ssh_buffer_unpack(msg->payload,
+                               "ds",
+                               &ignored,
+                               &cname);
+        sftp_message_free(msg);
+        if (rc != SSH_OK) {
+            ssh_set_error(sftp->session,
+                          SSH_ERROR,
+                          "Failed to parse canonicalized path");
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return NULL;
+        }
+
+        return cname;
+    } else if (msg->packet_type == SSH_FXP_STATUS) { /* bad response (error) */
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return NULL;
+        }
+        sftp_set_error(sftp, status->status);
+        ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                "SFTP server: %s", status->errormsg);
+        status_msg_free(status);
+    } else { /* this shouldn't happen */
+        ssh_set_error(sftp->session, SSH_FATAL,
+                "Received message %d when attempting to set stats", msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return NULL;
+}
+
+static sftp_attributes sftp_xstat(sftp_session sftp,
+                                  const char *path,
+                                  int param)
+{
+    sftp_status_message status = NULL;
+    sftp_message msg = NULL;
+    ssh_buffer buffer;
+    uint32_t id;
+    int rc;
+
+    if (sftp == NULL) {
+        return NULL;
+    }
+
+    if (path == NULL) {
+        ssh_set_error_invalid(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return NULL;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "ds",
+                         id,
+                         path);
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_packet_write(sftp, param, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return NULL;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(sftp) < 0) {
+            return NULL;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    if (msg->packet_type == SSH_FXP_ATTRS) {
+        sftp_attributes attr = sftp_parse_attr(sftp, msg->payload, 0);
+        sftp_message_free(msg);
+
+        return attr;
+    } else if (msg->packet_type == SSH_FXP_STATUS) {
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return NULL;
+        }
+        sftp_set_error(sftp, status->status);
+        ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                "SFTP server: %s", status->errormsg);
+        status_msg_free(status);
+        return NULL;
+    }
+    ssh_set_error(sftp->session, SSH_FATAL,
+            "Received mesg %d during stat()", msg->packet_type);
+    sftp_message_free(msg);
+    sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+
+    return NULL;
+}
+
+sftp_attributes sftp_stat(sftp_session session, const char *path) {
+  return sftp_xstat(session, path, SSH_FXP_STAT);
+}
+
+sftp_attributes sftp_lstat(sftp_session session, const char *path) {
+  return sftp_xstat(session, path, SSH_FXP_LSTAT);
+}
+
+sftp_attributes sftp_fstat(sftp_file file)
+{
+    sftp_status_message status = NULL;
+    sftp_message msg = NULL;
+    ssh_buffer buffer;
+    uint32_t id;
+    int rc;
+
+    if (file == NULL) {
+        return NULL;
+    }
+
+    rc = sftp_get_new_id(file->sftp, &id);
+    if (rc != SSH_OK) {
+        return NULL;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(file->sftp->session);
+        sftp_set_error(file->sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "dS",
+                         id,
+                         file->handle);
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(file->sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(file->sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_packet_write(file->sftp, SSH_FXP_FSTAT, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return NULL;
+    }
+
+    while (msg == NULL) {
+        if (sftp_read_and_dispatch(file->sftp) < 0) {
+            return NULL;
+        }
+        msg = sftp_dequeue(file->sftp, id);
+    }
+
+    if (msg->packet_type == SSH_FXP_ATTRS){
+        sftp_attributes attr = sftp_parse_attr(file->sftp, msg->payload, 0);
+        sftp_message_free(msg);
+
+        return attr;
+    } else if (msg->packet_type == SSH_FXP_STATUS) {
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return NULL;
+        }
+        sftp_set_error(file->sftp, status->status);
+        ssh_set_error(file->sftp->session, SSH_REQUEST_DENIED,
+                "SFTP server: %s", status->errormsg);
+        status_msg_free(status);
+
+        return NULL;
+    }
+    ssh_set_error(file->sftp->session, SSH_FATAL,
+            "Received msg %d during fstat()", msg->packet_type);
+    sftp_message_free(msg);
+    sftp_set_error(file->sftp, SSH_FX_BAD_MESSAGE);
+
+    return NULL;
+}
+
+char *sftp_expand_path(sftp_session sftp, const char *path)
+{
+    sftp_status_message status = NULL;
+    sftp_message msg = NULL;
+    ssh_buffer buffer = NULL;
+    uint32_t id;
+    int rc;
+
+    if (sftp == NULL) {
+        return NULL;
+    }
+
+    if (path == NULL) {
+        ssh_set_error(sftp->session,
+                      SSH_FATAL,
+                      "NULL received as an argument instead of the path to expand");
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return NULL;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "dss",
+                         id,
+                         "expand-path@openssh.com",
+                         path);
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_EXTENDED, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return NULL;
+    }
+
+    while (msg == NULL) {
+        rc = sftp_read_and_dispatch(sftp);
+        if (rc < 0) {
+            return NULL;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    if (msg->packet_type == SSH_FXP_NAME) {
+        uint32_t ignored = 0;
+        char *cname = NULL;
+
+        rc = ssh_buffer_unpack(msg->payload,
+                               "ds",
+                               &ignored,
+                               &cname);
+        sftp_message_free(msg);
+        if (rc != SSH_OK) {
+            ssh_set_error(sftp->session,
+                          SSH_ERROR,
+                          "Failed to parse expanded path");
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return NULL;
+        }
+
+        return cname;
+    } else if (msg->packet_type == SSH_FXP_STATUS) {
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return NULL;
+        }
+        sftp_set_error(sftp, status->status);
+        ssh_set_error(sftp->session, SSH_REQUEST_DENIED,
+                      "SFTP server: %s", status->errormsg);
+        status_msg_free(status);
+    } else {
+        ssh_set_error(sftp->session, SSH_FATAL,
+                      "Received message %d when attempting to expand path",
+                      msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return NULL;
+}
+
+char *
+sftp_home_directory(sftp_session sftp, const char *username)
+{
+    sftp_status_message status = NULL;
+    sftp_message msg = NULL;
+    ssh_buffer buffer = NULL;
+    uint32_t id;
+    int rc;
+
+    if (sftp == NULL) {
+        return NULL;
+    }
+
+    rc = sftp_get_new_id(sftp, &id);
+    if (rc != SSH_OK) {
+        return NULL;
+    }
+
+    buffer = ssh_buffer_new();
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = ssh_buffer_pack(buffer,
+                         "dss",
+                         id,
+                         "home-directory",
+                         username ? username : "");
+    if (rc != SSH_OK) {
+        ssh_set_error_oom(sftp->session);
+        SSH_BUFFER_FREE(buffer);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = sftp_packet_write(sftp, SSH_FXP_EXTENDED, buffer);
+    SSH_BUFFER_FREE(buffer);
+    if (rc < 0) {
+        return NULL;
+    }
+
+    while (msg == NULL) {
+        rc = sftp_read_and_dispatch(sftp);
+        if (rc < 0) {
+            return NULL;
+        }
+        msg = sftp_dequeue(sftp, id);
+    }
+
+    if (msg->packet_type == SSH_FXP_NAME) {
+        uint32_t count = 0;
+        char *homepath = NULL;
+        char *longpath = NULL;
+        sftp_attributes attr = NULL;
+
+        rc = ssh_buffer_unpack(msg->payload, "ds", &count, &homepath);
+        if (rc != SSH_OK) {
+            ssh_set_error(sftp->session,
+                          SSH_ERROR,
+                          "Failed to query user home directory");
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return NULL;
+        }
+        /*
+          for SFTP version > 3, longname field in SSH_FXP_NAME is omitted.
+        */
+        if (sftp->version <= 3) {
+            rc = ssh_buffer_unpack(msg->payload, "s", &longpath);
+            if (rc != SSH_OK) {
+                ssh_set_error(sftp->session,
+                              SSH_ERROR,
+                              "Failed to extract longname from payload");
+                sftp_set_error(sftp, SSH_FX_FAILURE);
+                return NULL;
+            }
+        }
+        attr = sftp_parse_attr(sftp, msg->payload, 0);
+        if (attr == NULL) {
+            ssh_set_error(sftp->session,
+                          SSH_FATAL,
+                          "Couldn't parse the SFTP attributes");
+            return NULL;
+        }
+        sftp_message_free(msg);
+
+        if (count != 1) {
+            if (count > 1) {
+                ssh_set_error(sftp->session,
+                              SSH_ERROR,
+                              "Multiple results returned");
+            } else {
+                ssh_set_error(sftp->session, SSH_ERROR, "No result returned");
+            }
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return NULL;
+        }
+
+        if (longpath) {
+            free(longpath);
+        }
+        sftp_attributes_free(attr);
+        return homepath;
+    } else if (msg->packet_type == SSH_FXP_STATUS) {
+        status = parse_status_msg(msg);
+        sftp_message_free(msg);
+        if (status == NULL) {
+            return NULL;
+        }
+
+        sftp_set_error(sftp, status->status);
+        ssh_set_error(sftp->session,
+                      SSH_REQUEST_DENIED,
+                      "SFTP server: %s",
+                      status->errormsg);
+        status_msg_free(status);
+    } else {
+        ssh_set_error(
+            sftp->session,
+            SSH_FATAL,
+            "Received message %d when attempting to query user home directory",
+            msg->packet_type);
+        sftp_message_free(msg);
+        sftp_set_error(sftp, SSH_FX_BAD_MESSAGE);
+    }
+
+    return NULL;
+}
+
+#endif /* WITH_SFTP */

--- a/firmware/lib/LibSSH-SFTP/src/sftp_common.c
+++ b/firmware/lib/LibSSH-SFTP/src/sftp_common.c
@@ -1,0 +1,994 @@
+/*
+ * sftp_common.c - Secure FTP functions which are private and are used
+ *                 internally by other sftp api functions spread across
+ *                 various source files.
+ *
+ * This file is part of the SSH Library
+ *
+ * Copyright (c) 2005-2008 by Aris Adamantiadis
+ * Copyright (c) 2008-2018 by Andreas Schneider <asn@cryptomilk.org>
+ *
+ * The SSH Library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation; either version 2.1 of the License, or (at your
+ * option) any later version.
+ *
+ * The SSH Library is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ * License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with the SSH Library; see the file COPYING.  If not, write to
+ * the Free Software Foundation, Inc., 59 Temple Place - Suite 330, Boston,
+ * MA 02111-1307, USA.
+ */
+
+#include "libssh_esp32_config.h"
+#ifndef WITH_SFTP
+#define WITH_SFTP 1
+#endif
+
+#include <ctype.h>
+
+#include "libssh/sftp.h"
+#include "libssh/sftp_priv.h"
+#include "libssh/buffer.h"
+#include "libssh/session.h"
+#include "libssh/bytearray.h"
+
+#ifdef WITH_SFTP
+
+/* Buffer size maximum is 256M */
+#define SFTP_PACKET_SIZE_MAX 0x10000000
+
+sftp_packet sftp_packet_read(sftp_session sftp)
+{
+    uint8_t tmpbuf[4];
+    uint8_t *buffer = NULL;
+    sftp_packet packet = sftp->read_packet;
+    uint32_t size;
+    int nread;
+    bool is_eof;
+    int rc;
+
+    packet->sftp = sftp;
+
+    /*
+     * If the packet has a payload, then just reinit the buffer, otherwise
+     * allocate a new one.
+     */
+    if (packet->payload != NULL) {
+        rc = ssh_buffer_reinit(packet->payload);
+        if (rc != 0) {
+            ssh_set_error_oom(sftp->session);
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return NULL;
+        }
+    } else {
+        packet->payload = ssh_buffer_new();
+        if (packet->payload == NULL) {
+            ssh_set_error_oom(sftp->session);
+            sftp_set_error(sftp, SSH_FX_FAILURE);
+            return NULL;
+        }
+    }
+
+    nread = 0;
+    do {
+        int s;
+
+        /* read from channel until 4 bytes have been read or an error occurs */
+        s = ssh_channel_read(sftp->channel, tmpbuf + nread, 4 - nread, 0);
+        if (s < 0) {
+            goto error;
+        } else if (s == 0) {
+            is_eof = ssh_channel_is_eof(sftp->channel);
+            if (is_eof) {
+                ssh_set_error(sftp->session,
+                              SSH_FATAL,
+                              "Received EOF while reading sftp packet size");
+                sftp_set_error(sftp, SSH_FX_EOF);
+                goto error;
+            } else {
+                ssh_set_error(sftp->session,
+                              SSH_FATAL,
+                              "Timeout while reading sftp packet size");
+                sftp_set_error(sftp, SSH_FX_FAILURE);
+                goto error;
+            }
+        } else {
+            nread += s;
+        }
+    } while (nread < 4);
+
+    size = PULL_BE_U32(tmpbuf, 0);
+    if (size == 0 || size > SFTP_PACKET_SIZE_MAX) {
+        ssh_set_error(sftp->session, SSH_FATAL, "Invalid sftp packet size!");
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        goto error;
+    }
+
+    do {
+        nread = ssh_channel_read(sftp->channel, tmpbuf, 1, 0);
+        if (nread < 0) {
+            goto error;
+        } else if (nread == 0) {
+            is_eof = ssh_channel_is_eof(sftp->channel);
+            if (is_eof) {
+                ssh_set_error(sftp->session,
+                              SSH_FATAL,
+                              "Received EOF while reading sftp packet type");
+                sftp_set_error(sftp, SSH_FX_EOF);
+                goto error;
+            } else {
+                ssh_set_error(sftp->session,
+                              SSH_FATAL,
+                              "Timeout while reading sftp packet type");
+                sftp_set_error(sftp, SSH_FX_FAILURE);
+                goto error;
+            }
+        }
+    } while (nread < 1);
+
+    packet->type = tmpbuf[0];
+
+    /* Remove the packet type size */
+    size -= sizeof(uint8_t);
+
+    /* Allocate the receive buffer from payload */
+    buffer = ssh_buffer_allocate(packet->payload, size);
+    if (buffer == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        goto error;
+    }
+    while (size > 0 && size < SFTP_PACKET_SIZE_MAX) {
+        nread = ssh_channel_read(sftp->channel, buffer, size, 0);
+        if (nread < 0) {
+            /* TODO: check if there are cases where an error needs to be set here */
+            goto error;
+        }
+
+        if (nread > 0) {
+            buffer += nread;
+            size -= nread;
+        } else { /* nread == 0 */
+            /* Retry the reading unless the remote was closed */
+            is_eof = ssh_channel_is_eof(sftp->channel);
+            if (is_eof) {
+                ssh_set_error(sftp->session,
+                              SSH_REQUEST_DENIED,
+                              "Received EOF while reading sftp packet");
+                sftp_set_error(sftp, SSH_FX_EOF);
+                goto error;
+            } else {
+                ssh_set_error(sftp->session,
+                              SSH_FATAL,
+                              "Timeout while reading sftp packet");
+                sftp_set_error(sftp, SSH_FX_FAILURE);
+                goto error;
+            }
+        }
+    }
+
+    return packet;
+error:
+    ssh_buffer_reinit(packet->payload);
+    return NULL;
+}
+
+int sftp_packet_write(sftp_session sftp, uint8_t type, ssh_buffer payload)
+{
+    uint8_t header[5] = {0};
+    uint32_t payload_size;
+    int size;
+    int rc;
+
+    /* Add size of type */
+    payload_size = ssh_buffer_get_len(payload) + sizeof(uint8_t);
+    PUSH_BE_U32(header, 0, payload_size);
+    PUSH_BE_U8(header, 4, type);
+
+    rc = ssh_buffer_prepend_data(payload, header, sizeof(header));
+    if (rc < 0) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    size = ssh_channel_write(sftp->channel,
+                             ssh_buffer_get(payload),
+                             ssh_buffer_get_len(payload));
+    if (size < 0) {
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return -1;
+    }
+
+    if ((uint32_t)size != ssh_buffer_get_len(payload)) {
+        SSH_LOG(SSH_LOG_PACKET,
+                "Had to write %" PRIu32 " bytes, wrote only %d",
+                ssh_buffer_get_len(payload),
+                size);
+    }
+
+    return size;
+}
+
+void sftp_packet_free(sftp_packet packet)
+{
+    if (packet == NULL) {
+        return;
+    }
+
+    SSH_BUFFER_FREE(packet->payload);
+    free(packet);
+}
+
+int buffer_add_attributes(ssh_buffer buffer, sftp_attributes attr)
+{
+    uint32_t flags = (attr ? attr->flags : 0);
+    int rc;
+
+    flags &= (SSH_FILEXFER_ATTR_SIZE | SSH_FILEXFER_ATTR_UIDGID |
+              SSH_FILEXFER_ATTR_PERMISSIONS | SSH_FILEXFER_ATTR_ACMODTIME);
+
+    rc = ssh_buffer_pack(buffer, "d", flags);
+    if (rc != SSH_OK) {
+        return -1;
+    }
+
+    if (attr != NULL) {
+        if (flags & SSH_FILEXFER_ATTR_SIZE) {
+            rc = ssh_buffer_pack(buffer, "q", attr->size);
+            if (rc != SSH_OK) {
+                return -1;
+            }
+        }
+
+        if (flags & SSH_FILEXFER_ATTR_UIDGID) {
+            rc = ssh_buffer_pack(buffer, "dd", attr->uid, attr->gid);
+            if (rc != SSH_OK) {
+                return -1;
+            }
+        }
+
+        if (flags & SSH_FILEXFER_ATTR_PERMISSIONS) {
+            rc = ssh_buffer_pack(buffer, "d", attr->permissions);
+            if (rc != SSH_OK) {
+                return -1;
+            }
+        }
+
+        if (flags & SSH_FILEXFER_ATTR_ACMODTIME) {
+            rc = ssh_buffer_pack(buffer, "dd", attr->atime, attr->mtime);
+            if (rc != SSH_OK) {
+                return -1;
+            }
+        }
+    }
+
+    return 0;
+}
+
+/*
+ * Parse the attributes from a payload from some messages. It is coded on
+ * baselines from the protocol version 4.
+ * This code is more or less dead but maybe we will need it in the future.
+ */
+static sftp_attributes sftp_parse_attr_4(sftp_session sftp,
+                                         ssh_buffer buf,
+                                         int expectnames)
+{
+    sftp_attributes attr = NULL;
+    ssh_string owner = NULL;
+    ssh_string group = NULL;
+    uint32_t flags = 0;
+    int ok = 0;
+
+    /* unused member variable */
+    (void) expectnames;
+
+    attr = calloc(1, sizeof(struct sftp_attributes_struct));
+    if (attr == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    /* This isn't really a loop, but it is like a try..catch.. */
+    do {
+        if (ssh_buffer_get_u32(buf, &flags) != 4) {
+            break;
+        }
+
+        flags = ntohl(flags);
+        attr->flags = flags;
+
+        if (flags & SSH_FILEXFER_ATTR_SIZE) {
+            if (ssh_buffer_get_u64(buf, &attr->size) != 8) {
+                break;
+            }
+            attr->size = ntohll(attr->size);
+        }
+
+        if (flags & SSH_FILEXFER_ATTR_OWNERGROUP) {
+            owner = ssh_buffer_get_ssh_string(buf);
+            if (owner == NULL) {
+                break;
+            }
+            attr->owner = ssh_string_to_char(owner);
+            SSH_STRING_FREE(owner);
+            if (attr->owner == NULL) {
+                break;
+            }
+
+            group = ssh_buffer_get_ssh_string(buf);
+            if (group == NULL) {
+                break;
+            }
+            attr->group = ssh_string_to_char(group);
+            SSH_STRING_FREE(group);
+            if (attr->group == NULL) {
+                break;
+            }
+        }
+
+        if (flags & SSH_FILEXFER_ATTR_PERMISSIONS) {
+            if (ssh_buffer_get_u32(buf, &attr->permissions) != 4) {
+                break;
+            }
+            attr->permissions = ntohl(attr->permissions);
+
+            /* FIXME on windows! */
+            switch (attr->permissions & SSH_S_IFMT) {
+            case SSH_S_IFSOCK:
+            case SSH_S_IFBLK:
+            case SSH_S_IFCHR:
+            case SSH_S_IFIFO:
+                attr->type = SSH_FILEXFER_TYPE_SPECIAL;
+                break;
+            case SSH_S_IFLNK:
+                attr->type = SSH_FILEXFER_TYPE_SYMLINK;
+                break;
+            case SSH_S_IFREG:
+                attr->type = SSH_FILEXFER_TYPE_REGULAR;
+                break;
+            case SSH_S_IFDIR:
+                attr->type = SSH_FILEXFER_TYPE_DIRECTORY;
+                break;
+            default:
+                attr->type = SSH_FILEXFER_TYPE_UNKNOWN;
+                break;
+            }
+        }
+
+        if (flags & SSH_FILEXFER_ATTR_ACCESSTIME) {
+            if (ssh_buffer_get_u64(buf, &attr->atime64) != 8) {
+                break;
+            }
+            attr->atime64 = ntohll(attr->atime64);
+
+            if (flags & SSH_FILEXFER_ATTR_SUBSECOND_TIMES) {
+                if (ssh_buffer_get_u32(buf, &attr->atime_nseconds) != 4) {
+                    break;
+                }
+                attr->atime_nseconds = ntohl(attr->atime_nseconds);
+            }
+        }
+
+        if (flags & SSH_FILEXFER_ATTR_CREATETIME) {
+            if (ssh_buffer_get_u64(buf, &attr->createtime) != 8) {
+                break;
+            }
+            attr->createtime = ntohll(attr->createtime);
+
+            if (flags & SSH_FILEXFER_ATTR_SUBSECOND_TIMES) {
+                if (ssh_buffer_get_u32(buf, &attr->createtime_nseconds) != 4) {
+                    break;
+                }
+                attr->createtime_nseconds = ntohl(attr->createtime_nseconds);
+            }
+        }
+
+        if (flags & SSH_FILEXFER_ATTR_MODIFYTIME) {
+            if (ssh_buffer_get_u64(buf, &attr->mtime64) != 8) {
+                break;
+            }
+            attr->mtime64 = ntohll(attr->mtime64);
+
+            if (flags & SSH_FILEXFER_ATTR_SUBSECOND_TIMES) {
+                if (ssh_buffer_get_u32(buf, &attr->mtime_nseconds) != 4) {
+                    break;
+                }
+                attr->mtime_nseconds = ntohl(attr->mtime_nseconds);
+            }
+        }
+
+        if (flags & SSH_FILEXFER_ATTR_ACL) {
+            if ((attr->acl = ssh_buffer_get_ssh_string(buf)) == NULL) {
+                break;
+            }
+        }
+
+        if (flags & SSH_FILEXFER_ATTR_EXTENDED) {
+            if (ssh_buffer_get_u32(buf,&attr->extended_count) != 4) {
+                break;
+            }
+            attr->extended_count = ntohl(attr->extended_count);
+
+            while (attr->extended_count &&
+                   (attr->extended_type = ssh_buffer_get_ssh_string(buf)) &&
+                   (attr->extended_data = ssh_buffer_get_ssh_string(buf))) {
+                attr->extended_count--;
+            }
+
+            if (attr->extended_count) {
+                break;
+            }
+        }
+        ok = 1;
+    } while (0);
+
+    if (ok == 0) {
+        /* break issued somewhere */
+        SSH_STRING_FREE(attr->acl);
+        SSH_STRING_FREE(attr->extended_type);
+        SSH_STRING_FREE(attr->extended_data);
+        SAFE_FREE(attr->owner);
+        SAFE_FREE(attr->group);
+        SAFE_FREE(attr);
+
+        ssh_set_error(sftp->session, SSH_FATAL, "Invalid ATTR structure");
+
+        return NULL;
+    }
+
+    return attr;
+}
+
+enum sftp_longname_field_e {
+    SFTP_LONGNAME_PERM = 0,
+    SFTP_LONGNAME_FIXME,
+    SFTP_LONGNAME_OWNER,
+    SFTP_LONGNAME_GROUP,
+    SFTP_LONGNAME_SIZE,
+    SFTP_LONGNAME_DATE,
+    SFTP_LONGNAME_TIME,
+    SFTP_LONGNAME_NAME,
+};
+
+static char * sftp_parse_longname(const char *longname,
+                                  enum sftp_longname_field_e longname_field)
+{
+    const char *p = NULL, *q = NULL;
+    size_t len, field = 0;
+
+    if (longname == NULL || longname_field < SFTP_LONGNAME_PERM ||
+        longname_field > SFTP_LONGNAME_NAME) {
+        return NULL;
+    }
+
+    p = longname;
+    /*
+     * Find the beginning of the field which is specified
+     * by sftp_longname_field_e.
+     */
+    while (*p != '\0' && field != longname_field) {
+        if (isspace(*p)) {
+            field++;
+            p++;
+            while (*p != '\0' && isspace(*p)) {
+                p++;
+            }
+        } else {
+            p++;
+        }
+    }
+
+    /* If we reached NULL before we got our field fail */
+    if (field != longname_field) {
+        return NULL;
+    }
+
+    q = p;
+    while (*q != '\0' && !isspace(*q)) {
+        q++;
+    }
+
+    len = q - p;
+
+    return strndup(p, len);
+}
+
+/* sftp version 0-3 code. It is different from the v4 */
+/* maybe a paste of the draft is better than the code */
+/*
+        uint32   flags
+        uint64   size           present only if flag SSH_FILEXFER_ATTR_SIZE
+        uint32   uid            present only if flag SSH_FILEXFER_ATTR_UIDGID
+        uint32   gid            present only if flag SSH_FILEXFER_ATTR_UIDGID
+        uint32   permissions    present only if flag SSH_FILEXFER_ATTR_PERMISSIONS
+        uint32   atime          present only if flag SSH_FILEXFER_ACMODTIME
+        uint32   mtime          present only if flag SSH_FILEXFER_ACMODTIME
+        uint32   extended_count present only if flag SSH_FILEXFER_ATTR_EXTENDED
+        string   extended_type
+        string   extended_data
+        ...      more extended data (extended_type - extended_data pairs),
+                   so that number of pairs equals extended_count              */
+static sftp_attributes sftp_parse_attr_3(sftp_session sftp,
+                                         ssh_buffer buf,
+                                         int expectname)
+{
+    sftp_attributes attr;
+    int rc;
+
+    attr = calloc(1, sizeof(struct sftp_attributes_struct));
+    if (attr == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    if (expectname) {
+        rc = ssh_buffer_unpack(buf, "ss",
+                               &attr->name,
+                               &attr->longname);
+        if (rc != SSH_OK){
+            goto error;
+        }
+        SSH_LOG(SSH_LOG_DEBUG, "Name: %s", attr->name);
+
+        /* Set owner and group if we talk to openssh and have the longname */
+        if (ssh_get_openssh_version(sftp->session)) {
+            attr->owner = sftp_parse_longname(attr->longname,
+                                              SFTP_LONGNAME_OWNER);
+            if (attr->owner == NULL) {
+                goto error;
+            }
+
+            attr->group = sftp_parse_longname(attr->longname,
+                                              SFTP_LONGNAME_GROUP);
+            if (attr->group == NULL) {
+                goto error;
+            }
+        }
+    }
+
+    rc = ssh_buffer_unpack(buf, "d", &attr->flags);
+    if (rc != SSH_OK){
+        goto error;
+    }
+    SSH_LOG(SSH_LOG_DEBUG, "Flags: %.8" PRIx32, attr->flags);
+
+    if (attr->flags & SSH_FILEXFER_ATTR_SIZE) {
+        rc = ssh_buffer_unpack(buf, "q", &attr->size);
+        if(rc != SSH_OK) {
+            goto error;
+        }
+        SSH_LOG(SSH_LOG_DEBUG, "Size: %" PRIu64, (uint64_t)attr->size);
+    }
+
+    if (attr->flags & SSH_FILEXFER_ATTR_UIDGID) {
+        rc = ssh_buffer_unpack(buf, "dd",
+                               &attr->uid,
+                               &attr->gid);
+        if (rc != SSH_OK) {
+            goto error;
+        }
+    }
+
+    if (attr->flags & SSH_FILEXFER_ATTR_PERMISSIONS) {
+        rc = ssh_buffer_unpack(buf, "d", &attr->permissions);
+        if (rc != SSH_OK) {
+            goto error;
+        }
+
+        switch (attr->permissions & SSH_S_IFMT) {
+        case SSH_S_IFSOCK:
+        case SSH_S_IFBLK:
+        case SSH_S_IFCHR:
+        case SSH_S_IFIFO:
+            attr->type = SSH_FILEXFER_TYPE_SPECIAL;
+            break;
+        case SSH_S_IFLNK:
+            attr->type = SSH_FILEXFER_TYPE_SYMLINK;
+            break;
+        case SSH_S_IFREG:
+            attr->type = SSH_FILEXFER_TYPE_REGULAR;
+            break;
+        case SSH_S_IFDIR:
+            attr->type = SSH_FILEXFER_TYPE_DIRECTORY;
+            break;
+        default:
+            attr->type = SSH_FILEXFER_TYPE_UNKNOWN;
+            break;
+        }
+    }
+
+    if (attr->flags & SSH_FILEXFER_ATTR_ACMODTIME) {
+        rc = ssh_buffer_unpack(buf, "dd",
+                               &attr->atime,
+                               &attr->mtime);
+        if (rc != SSH_OK) {
+            goto error;
+        }
+    }
+
+    if (attr->flags & SSH_FILEXFER_ATTR_EXTENDED) {
+        rc = ssh_buffer_unpack(buf, "d", &attr->extended_count);
+        if (rc != SSH_OK) {
+            goto error;
+        }
+
+        if (attr->extended_count > 0) {
+            rc = ssh_buffer_unpack(buf, "ss",
+                                   &attr->extended_type,
+                                   &attr->extended_data);
+            if (rc != SSH_OK) {
+                goto error;
+            }
+            attr->extended_count--;
+        }
+        /* just ignore the remaining extensions */
+
+        while (attr->extended_count > 0) {
+            ssh_string tmp1,tmp2;
+            rc = ssh_buffer_unpack(buf, "SS", &tmp1, &tmp2);
+            if (rc != SSH_OK){
+                goto error;
+            }
+            SAFE_FREE(tmp1);
+            SAFE_FREE(tmp2);
+            attr->extended_count--;
+        }
+    }
+
+    return attr;
+
+error:
+    SSH_STRING_FREE(attr->extended_type);
+    SSH_STRING_FREE(attr->extended_data);
+    SAFE_FREE(attr->name);
+    SAFE_FREE(attr->longname);
+    SAFE_FREE(attr->owner);
+    SAFE_FREE(attr->group);
+    SAFE_FREE(attr);
+    ssh_set_error(sftp->session, SSH_FATAL, "Invalid ATTR structure");
+    sftp_set_error(sftp, SSH_FX_FAILURE);
+
+    return NULL;
+}
+
+sftp_attributes sftp_parse_attr(sftp_session session,
+                                ssh_buffer buf,
+                                int expectname)
+{
+    switch (session->version) {
+    case 4:
+        return sftp_parse_attr_4(session, buf, expectname);
+    case 3:
+    case 2:
+    case 1:
+    case 0:
+        return sftp_parse_attr_3(session, buf, expectname);
+    default:
+        ssh_set_error(session->session, SSH_FATAL,
+                      "Version %d unsupported by client",
+                      session->server_version);
+        return NULL;
+    }
+
+    return NULL;
+}
+
+void sftp_set_error(sftp_session sftp, int errnum)
+{
+    if (sftp != NULL) {
+        sftp->errnum = errnum;
+    }
+}
+
+void sftp_message_free(sftp_message msg)
+{
+    if (msg == NULL) {
+        return;
+    }
+
+    SSH_BUFFER_FREE(msg->payload);
+    SAFE_FREE(msg);
+}
+
+static sftp_request_queue request_queue_new(sftp_message msg)
+{
+    sftp_request_queue queue = NULL;
+
+    queue = calloc(1, sizeof(struct sftp_request_queue_struct));
+    if (queue == NULL) {
+        ssh_set_error_oom(msg->sftp->session);
+        sftp_set_error(msg->sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    queue->message = msg;
+
+    return queue;
+}
+
+static void request_queue_free(sftp_request_queue queue)
+{
+    if (queue == NULL) {
+        return;
+    }
+
+    ZERO_STRUCTP(queue);
+    SAFE_FREE(queue);
+}
+
+static int
+sftp_enqueue(sftp_session sftp, sftp_message msg)
+{
+    sftp_request_queue queue = NULL;
+    sftp_request_queue ptr;
+
+    queue = request_queue_new(msg);
+    if (queue == NULL) {
+        return -1;
+    }
+
+    SSH_LOG(SSH_LOG_PACKET,
+            "Queued msg id %" PRIu32 " type %d",
+            msg->id, msg->packet_type);
+
+    if(sftp->queue == NULL) {
+        sftp->queue = queue;
+    } else {
+        ptr = sftp->queue;
+        while(ptr->next) {
+            ptr=ptr->next; /* find end of linked list */
+        }
+        ptr->next = queue; /* add it on bottom */
+    }
+
+    return 0;
+}
+
+/*
+ * Pulls a message from the queue based on the ID.
+ * Returns NULL if no message has been found.
+ */
+sftp_message sftp_dequeue(sftp_session sftp, uint32_t id)
+{
+    sftp_request_queue prev = NULL;
+    sftp_request_queue queue;
+    sftp_message msg;
+
+    if(sftp->queue == NULL) {
+        return NULL;
+    }
+
+    queue = sftp->queue;
+    while (queue) {
+        if (queue->message->id == id) {
+            /* remove from queue */
+            if (prev == NULL) {
+                sftp->queue = queue->next;
+            } else {
+                prev->next = queue->next;
+            }
+            msg = queue->message;
+            request_queue_free(queue);
+            SSH_LOG(SSH_LOG_PACKET,
+                    "Dequeued msg id %" PRIu32 " type %d",
+                    msg->id,
+                    msg->packet_type);
+            return msg;
+        }
+        prev = queue;
+        queue = queue->next;
+    }
+
+    return NULL;
+}
+
+static sftp_message sftp_get_message(sftp_packet packet)
+{
+    sftp_session sftp = packet->sftp;
+    sftp_message msg = NULL;
+    struct ssh_iterator *id_it = NULL;
+    bool id_found = false;
+    int rc;
+
+    switch (packet->type) {
+    case SSH_FXP_STATUS:
+    case SSH_FXP_HANDLE:
+    case SSH_FXP_DATA:
+    case SSH_FXP_ATTRS:
+    case SSH_FXP_NAME:
+    case SSH_FXP_EXTENDED_REPLY:
+        break;
+    default:
+        ssh_set_error(packet->sftp->session,
+                      SSH_FATAL,
+                      "Unknown packet type %d",
+                      packet->type);
+        sftp_set_error(packet->sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    msg = calloc(1, sizeof(struct sftp_message_struct));
+    if (msg == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(packet->sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    msg->sftp = packet->sftp;
+    msg->packet_type = packet->type;
+
+    /* Move the payload from the packet to the message */
+    msg->payload = packet->payload;
+    packet->payload = NULL;
+
+    rc = ssh_buffer_unpack(msg->payload, "d", &msg->id);
+    if (rc != SSH_OK) {
+        ssh_set_error(packet->sftp->session, SSH_FATAL,
+                "Invalid packet %d: no ID", packet->type);
+        sftp_message_free(msg);
+        sftp_set_error(packet->sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    SSH_LOG(SSH_LOG_PACKET,
+            "Packet with id %" PRIu32 " type %d",
+            msg->id,
+            msg->packet_type);
+
+    /* Validate that this ID is in our outstanding requests list */
+    id_it = ssh_list_get_iterator(sftp->outstanding_ids);
+    for (; id_it != NULL; id_it = id_it->next) {
+        uint32_t *stored_id = (uint32_t *)id_it->data;
+        if (*stored_id == msg->id) {
+            id_found = true;
+            ssh_list_remove(sftp->outstanding_ids, id_it);
+            free(stored_id);
+            break;
+        }
+    }
+
+    if (!id_found) {
+        ssh_set_error(packet->sftp->session,
+                      SSH_FATAL,
+                      "Unknown request ID %" PRIu32,
+                      msg->id);
+        sftp_message_free(msg);
+        sftp_set_error(packet->sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    return msg;
+}
+
+int sftp_get_new_id(sftp_session sftp, uint32_t *id_out)
+{
+    uint32_t *id = NULL;
+    int rc;
+
+    if (id_out == NULL) {
+        ssh_set_error_invalid(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return SSH_ERROR;
+    }
+
+    id = malloc(sizeof(uint32_t));
+    if (id == NULL) {
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return SSH_ERROR;
+    }
+
+    *id = ++sftp->id_counter;
+    rc = ssh_list_append(sftp->outstanding_ids, id);
+    if (rc != SSH_OK) {
+        free(id);
+        ssh_set_error_oom(sftp->session);
+        sftp_set_error(sftp, SSH_FX_FAILURE);
+        return SSH_ERROR;
+    }
+
+    *id_out = *id;
+
+    return SSH_OK;
+}
+
+int sftp_read_and_dispatch(sftp_session sftp)
+{
+    sftp_packet packet = NULL;
+    sftp_message msg = NULL;
+
+    packet = sftp_packet_read(sftp);
+    if (packet == NULL) {
+        /* something nasty happened reading the packet */
+        return -1;
+    }
+
+    msg = sftp_get_message(packet);
+    if (msg == NULL) {
+        return -1;
+    }
+
+    if (sftp_enqueue(sftp, msg) < 0) {
+        sftp_message_free(msg);
+        return -1;
+    }
+
+    return 0;
+}
+
+sftp_status_message parse_status_msg(sftp_message msg)
+{
+    sftp_status_message status = NULL;
+    int rc;
+
+    if (msg->packet_type != SSH_FXP_STATUS) {
+        ssh_set_error(msg->sftp->session, SSH_FATAL,
+                      "Not a ssh_fxp_status message passed in!");
+        sftp_set_error(msg->sftp, SSH_FX_BAD_MESSAGE);
+        return NULL;
+    }
+
+    status = calloc(1, sizeof(struct sftp_status_message_struct));
+    if (status == NULL) {
+        ssh_set_error_oom(msg->sftp->session);
+        sftp_set_error(msg->sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    status->id = msg->id;
+    rc = ssh_buffer_unpack(msg->payload, "d",
+                           &status->status);
+    if (rc != SSH_OK) {
+        SAFE_FREE(status);
+        ssh_set_error(msg->sftp->session, SSH_FATAL,
+                      "Invalid SSH_FXP_STATUS message");
+        sftp_set_error(msg->sftp, SSH_FX_FAILURE);
+        return NULL;
+    }
+
+    rc = ssh_buffer_unpack(msg->payload, "ss",
+                           &status->errormsg,
+                           &status->langmsg);
+
+    if (rc != SSH_OK && msg->sftp->version >= 3) {
+        SSH_LOG(SSH_LOG_WARN,
+                "Invalid SSH_FXP_STATUS message. Missing error message.");
+    }
+
+    if (status->errormsg == NULL)
+        status->errormsg = strdup("No error message in packet");
+
+    if (status->langmsg == NULL)
+        status->langmsg = strdup("");
+
+    if (status->errormsg == NULL || status->langmsg == NULL) {
+        ssh_set_error_oom(msg->sftp->session);
+        sftp_set_error(msg->sftp, SSH_FX_FAILURE);
+        status_msg_free(status);
+        return NULL;
+    }
+
+    return status;
+}
+
+void status_msg_free(sftp_status_message status)
+{
+    if (status == NULL) {
+        return;
+    }
+
+    SAFE_FREE(status->errormsg);
+    SAFE_FREE(status->langmsg);
+    SAFE_FREE(status);
+}
+
+#endif /* WITH_SFTP */

--- a/firmware/partitions_16mb.csv
+++ b/firmware/partitions_16mb.csv
@@ -1,6 +1,6 @@
 # Name,     Type, SubType,  Offset,   Size,    Flags
 nvs,        data, nvs,      0x9000,   0x4000,
 otadata,    data, ota,      0xD000,   0x2000,
-app0,       app,  ota_0,    0x10000,  0x300000,
-spiffs,     data, spiffs,   0x310000, 0xCE0000,
+app0,       app,  ota_0,    0x10000,  0x400000,
+spiffs,     data, spiffs,   0x410000, 0xBE0000,
 coredump,   data, coredump, 0xFF0000, 0x10000,

--- a/firmware/src/screens/wifi/network/NetworkMenuScreen.cpp
+++ b/firmware/src/screens/wifi/network/NetworkMenuScreen.cpp
@@ -58,9 +58,9 @@ void NetworkMenuScreen::onItemSelected(uint8_t index) {
       case 0: _showInformation(); break;
       case 1: _showWifiQR(); break;
       case 2: Screen.push(new NetworkScannersScreen()); break;
-      case 3: Screen.push(new RemoteAccessScreen());    break;
-      case 4: Screen.push(new NetworkAttacksScreen());  break;
-      case 5: Screen.push(new NetworkPranksScreen());   break;
+      case 3: Screen.push(new NetworkAttacksScreen());  break;
+      case 4: Screen.push(new NetworkPranksScreen());   break;
+      case 5: Screen.push(new RemoteAccessScreen());    break;
       case 6: Screen.push(new NetworkServicesScreen()); break;
       case 7: Screen.push(new NetworkInternetScreen()); break;
     }

--- a/firmware/src/screens/wifi/network/NetworkMenuScreen.cpp
+++ b/firmware/src/screens/wifi/network/NetworkMenuScreen.cpp
@@ -58,11 +58,11 @@ void NetworkMenuScreen::onItemSelected(uint8_t index) {
       case 0: _showInformation(); break;
       case 1: _showWifiQR(); break;
       case 2: Screen.push(new NetworkScannersScreen()); break;
-      case 3: Screen.push(new NetworkAttacksScreen());  break;
-      case 4: Screen.push(new NetworkPranksScreen());   break;
-      case 5: Screen.push(new NetworkServicesScreen()); break;
-      case 6: Screen.push(new NetworkInternetScreen()); break;
-      case 7: Screen.push(new RemoteAccessScreen());    break;
+      case 3: Screen.push(new RemoteAccessScreen());    break;
+      case 4: Screen.push(new NetworkAttacksScreen());  break;
+      case 5: Screen.push(new NetworkPranksScreen());   break;
+      case 6: Screen.push(new NetworkServicesScreen()); break;
+      case 7: Screen.push(new NetworkInternetScreen()); break;
     }
   } else if (_state == STATE_INFORMATION) {
     _showMenu();

--- a/firmware/src/screens/wifi/network/NetworkMenuScreen.cpp
+++ b/firmware/src/screens/wifi/network/NetworkMenuScreen.cpp
@@ -11,6 +11,7 @@
 #include "screens/wifi/network/NetworkPranksScreen.h"
 #include "screens/wifi/network/NetworkServicesScreen.h"
 #include "screens/wifi/network/NetworkInternetScreen.h"
+#include "screens/wifi/network/remote/RemoteAccessScreen.h"
 #include "ui/actions/ShowStatusAction.h"
 #include "ui/actions/ShowQRCodeAction.h"
 #include <WiFi.h>
@@ -61,6 +62,7 @@ void NetworkMenuScreen::onItemSelected(uint8_t index) {
       case 4: Screen.push(new NetworkPranksScreen());   break;
       case 5: Screen.push(new NetworkServicesScreen()); break;
       case 6: Screen.push(new NetworkInternetScreen()); break;
+      case 7: Screen.push(new RemoteAccessScreen());    break;
     }
   } else if (_state == STATE_INFORMATION) {
     _showMenu();

--- a/firmware/src/screens/wifi/network/NetworkMenuScreen.h
+++ b/firmware/src/screens/wifi/network/NetworkMenuScreen.h
@@ -48,9 +48,9 @@ private:
     {"Information"},
     {"WiFi QRCode"},
     {"Scanners"},
-    {"Remote Access"},
     {"Attacks"},
     {"Pranks"},
+    {"Remote Access"},
     {"Services"},
     {"Internet"},
   };

--- a/firmware/src/screens/wifi/network/NetworkMenuScreen.h
+++ b/firmware/src/screens/wifi/network/NetworkMenuScreen.h
@@ -48,11 +48,11 @@ private:
     {"Information"},
     {"WiFi QRCode"},
     {"Scanners"},
+    {"Remote Access"},
     {"Attacks"},
     {"Pranks"},
     {"Services"},
     {"Internet"},
-    {"Remote Access"},
   };
 
   void   _showMenu();

--- a/firmware/src/screens/wifi/network/NetworkMenuScreen.h
+++ b/firmware/src/screens/wifi/network/NetworkMenuScreen.h
@@ -44,7 +44,7 @@ private:
   //
   // The HAS_NET_TOOLS gate now lives inside Attacks and Services, which is why
   // this array no longer needs a conditional size or shifted switch indices.
-  ListItem _menuItems[7] = {
+  ListItem _menuItems[8] = {
     {"Information"},
     {"WiFi QRCode"},
     {"Scanners"},
@@ -52,6 +52,7 @@ private:
     {"Pranks"},
     {"Services"},
     {"Internet"},
+    {"Remote Access"},
   };
 
   void   _showMenu();

--- a/firmware/src/screens/wifi/network/remote/FtpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/FtpClientScreen.cpp
@@ -290,8 +290,14 @@ void FtpClientScreen::_configHost() {
     IPAddress ip = WiFi.localIP();
     initial = String(ip[0]) + "." + String(ip[1]) + "." + String(ip[2]) + ".";
   }
+#ifdef DEVICE_HAS_KEYBOARD
+  const auto hostInputMode = InputTextAction::INPUT_TEXT;
+#else
+  const auto hostInputMode = InputTextAction::INPUT_IP_ADDRESS;
+#endif
+
   String value = InputTextAction::popup(
-    "Host", initial, InputTextAction::INPUT_IP_ADDRESS);
+    "Host", initial, hostInputMode);
   if (!InputTextAction::wasCancelled() && value.length()) _host = value;
   _updateLabels();
   _rebuildConfig();

--- a/firmware/src/screens/wifi/network/remote/FtpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/FtpClientScreen.cpp
@@ -1,0 +1,1483 @@
+#include "FtpClientScreen.h"
+
+#include "core/Device.h"
+#include "core/INavigation.h"
+#include "core/ScreenManager.h"
+#include "ui/actions/InputTextAction.h"
+#include "ui/actions/InputNumberAction.h"
+#include "ui/actions/InputSelectAction.h"
+#include "ui/actions/ShowStatusAction.h"
+#include "ui/views/ProgressView.h"
+
+#include <WiFi.h>
+#include <WiFiClient.h>
+#include <FS.h>
+
+const char* FtpClientScreen::title() {
+  switch (_state) {
+    case STATE_REMOTE_LOADING:
+    case STATE_REMOTE_BROWSER:
+      return _remoteMode == REMOTE_UPLOAD_DEST ? "FTP Upload" : "FTP Download";
+    case STATE_LOCAL_BROWSER:
+      return "FTP Upload";
+    case STATE_TRANSFER:
+      return _transferIsUpload ? "FTP Upload" : "FTP Download";
+    default:
+      return "FTP Client";
+  }
+}
+
+FtpClientScreen::~FtpClientScreen() {
+  _closeConnection(false);
+  uint32_t start = millis();
+  while (_ftpTask && millis() - start < 2500) delay(10);
+  if (_mutex && !_ftpTask) {
+    vSemaphoreDelete(_mutex);
+    _mutex = nullptr;
+  }
+}
+
+void FtpClientScreen::onInit() {
+  if (!_mutex) _mutex = xSemaphoreCreateMutex();
+  _state = STATE_CONFIG;
+  _updateLabels();
+  _rebuildConfig();
+}
+
+void FtpClientScreen::onUpdate() {
+  if (_state == STATE_CONNECTING) {
+    if (_workerState == WORKER_READY) {
+      _showActions();
+      return;
+    }
+    if (_workerState == WORKER_FAILED || _workerState == WORKER_CLOSED) {
+      String err = "FTP connection failed";
+      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+        if (_commandError.length()) err = _commandError;
+        xSemaphoreGive(_mutex);
+      }
+      _workerState = WORKER_IDLE;
+      _state = STATE_CONFIG;
+      _updateLabels();
+      _rebuildConfig();
+      ShowStatusAction::show(err.c_str(), 1700);
+      render();
+      return;
+    }
+    if (Uni.Nav->wasPressed() &&
+        Uni.Nav->readDirection() == INavigation::DIR_BACK) {
+      _stopRequested = true;
+    }
+    return;
+  }
+
+  if (_state == STATE_REMOTE_LOADING) {
+    if (_workerState == WORKER_FAILED || _workerState == WORKER_CLOSED) {
+      String err = "FTP session closed";
+      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+        if (_commandError.length()) err = _commandError;
+        xSemaphoreGive(_mutex);
+      }
+      ShowStatusAction::show(err.c_str(), 1500);
+      _closeConnection(true);
+      return;
+    }
+
+    if (_commandDone) {
+      bool ok = _commandOk;
+      _commandDone = false;
+      if (!ok) {
+        String err = "Directory read failed";
+        if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+          if (_commandError.length()) err = _commandError;
+          xSemaphoreGive(_mutex);
+        }
+        ShowStatusAction::show(err.c_str(), 1500);
+        _state = (_remoteMode == REMOTE_UPLOAD_DEST)
+               ? STATE_LOCAL_BROWSER : STATE_REMOTE_BROWSER;
+        render();
+        return;
+      }
+      _copyRemoteListing();
+      _state = STATE_REMOTE_BROWSER;
+      render();
+      return;
+    }
+
+    if (Uni.Nav->wasPressed() &&
+        Uni.Nav->readDirection() == INavigation::DIR_BACK) {
+      if (_remoteMode == REMOTE_UPLOAD_DEST) {
+        _state = STATE_LOCAL_BROWSER;
+        render();
+      } else {
+        _showActions();
+      }
+    }
+    return;
+  }
+
+  if (_state == STATE_TRANSFER) {
+    _updateTransferProgress();
+
+    if (_commandDone) {
+      bool ok = _commandOk;
+      String err;
+      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+        err = _commandError;
+        xSemaphoreGive(_mutex);
+      }
+      _commandDone = false;
+      ProgressView::finish();
+
+      bool upload = _transferIsUpload;
+      _state = upload ? STATE_LOCAL_BROWSER : STATE_REMOTE_BROWSER;
+      render();
+
+      if (ok) {
+        ShowStatusAction::show(upload ? "Upload complete" : "Download complete", 1400);
+      } else if (err == "Cancelled") {
+        ShowStatusAction::show(upload ? "Upload cancelled" : "Download cancelled", 1200);
+      } else {
+        ShowStatusAction::show(
+          err.length() ? err.c_str() : (upload ? "Upload failed" : "Download failed"),
+          1600);
+      }
+      render();
+      return;
+    }
+
+    if (Uni.Nav->wasPressed() &&
+        Uni.Nav->readDirection() == INavigation::DIR_BACK) {
+      _cancelTransfer = true;
+    }
+    return;
+  }
+
+  if (_state == STATE_LOCAL_BROWSER) {
+    if (Uni.Nav->isPressed() && !_holdHandled &&
+        Uni.Nav->heldDuration() >= HOLD_MS) {
+      _holdHandled = true;
+      Uni.Nav->suppressCurrentPress();
+      _holdLocalUpload(_selectedIndex);
+      return;
+    }
+    if (!Uni.Nav->isPressed()) _holdHandled = false;
+    ListScreen::onUpdate();
+    return;
+  }
+
+  if (_state == STATE_REMOTE_BROWSER) {
+    if (Uni.Nav->isPressed() && !_holdHandled &&
+        Uni.Nav->heldDuration() >= HOLD_MS) {
+      _holdHandled = true;
+      Uni.Nav->suppressCurrentPress();
+      _holdRemote(_selectedIndex);
+      return;
+    }
+    if (!Uni.Nav->isPressed()) _holdHandled = false;
+    ListScreen::onUpdate();
+    return;
+  }
+
+  ListScreen::onUpdate();
+}
+
+void FtpClientScreen::onRender() {
+  if (_state == STATE_CONNECTING || _state == STATE_REMOTE_LOADING) {
+    _renderConnecting();
+    return;
+  }
+  if (_state == STATE_TRANSFER) return;
+  if (_state == STATE_REMOTE_BROWSER) {
+    _renderRemoteBrowser();
+    return;
+  }
+  if (_state == STATE_LOCAL_BROWSER) {
+    _renderLocalBrowser();
+    return;
+  }
+  ListScreen::onRender();
+}
+
+void FtpClientScreen::onItemSelected(uint8_t index) {
+  if (_state == STATE_ACTION) {
+    if (index == 0) _beginDownload();
+    else if (index == 1) _beginUpload();
+    return;
+  }
+
+  if (_state == STATE_REMOTE_BROWSER) {
+    _selectRemote(index);
+    return;
+  }
+
+  if (_state == STATE_LOCAL_BROWSER) {
+    _selectLocalUpload(index);
+    return;
+  }
+
+  if (_state != STATE_CONFIG) return;
+
+  switch (index) {
+    case 0: _configHost(); break;
+    case 1: _configPort(); break;
+    case 2: _configUsername(); break;
+    case 3: _configPassword(); break;
+    case 4: _connect(); break;
+    default: break;
+  }
+}
+
+void FtpClientScreen::onBack() {
+  if (_state == STATE_ACTION) {
+    _closeConnection(false);
+    Screen.goBack();
+    return;
+  }
+  if (_state == STATE_CONNECTING || _state == STATE_REMOTE_LOADING) {
+    _stopRequested = true;
+    return;
+  }
+  if (_state == STATE_TRANSFER) {
+    _cancelTransfer = true;
+    return;
+  }
+  if (_state == STATE_REMOTE_BROWSER) {
+    if (_remoteMode == REMOTE_UPLOAD_DEST) {
+      _state = STATE_LOCAL_BROWSER;
+      render();
+    } else {
+      _showActions();
+    }
+    return;
+  }
+  if (_state == STATE_LOCAL_BROWSER) {
+    _showActions();
+    return;
+  }
+  Screen.goBack();
+}
+
+void FtpClientScreen::_updateLabels() {
+  snprintf(_hostLabel, sizeof(_hostLabel), "%s", _host.length() ? _host.c_str() : "-");
+  snprintf(_portLabel, sizeof(_portLabel), "%d", _port);
+  snprintf(_userLabel, sizeof(_userLabel), "%s",
+           _username.length() ? _username.c_str() : "-");
+  snprintf(_passwordLabel, sizeof(_passwordLabel), "%s",
+           _password.length() ? "********" : "-");
+}
+
+void FtpClientScreen::_rebuildConfig() {
+  uint8_t sel = min<uint8_t>(_selectedIndex, 4);
+  _configItems[0] = {"Host", _hostLabel};
+  _configItems[1] = {"Port", _portLabel};
+  _configItems[2] = {"Username", _userLabel};
+  _configItems[3] = {"Password", _passwordLabel};
+  _configItems[4] = {"Connect", nullptr};
+  setItems(_configItems, 5, sel);
+}
+
+void FtpClientScreen::_showActions() {
+  _state = STATE_ACTION;
+  setItems(_actionItems, 2, 0);
+  render();
+}
+
+void FtpClientScreen::_configHost() {
+  String initial = _host;
+  if (!initial.length() && WiFi.status() == WL_CONNECTED) {
+    IPAddress ip = WiFi.localIP();
+    initial = String(ip[0]) + "." + String(ip[1]) + "." + String(ip[2]) + ".";
+  }
+  String value = InputTextAction::popup(
+    "Host", initial, InputTextAction::INPUT_IP_ADDRESS);
+  if (!InputTextAction::wasCancelled() && value.length()) _host = value;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void FtpClientScreen::_configPort() {
+  int value = InputNumberAction::popup("Port", 1, 65535, _port);
+  if (!InputNumberAction::wasCancelled()) _port = value;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void FtpClientScreen::_configUsername() {
+  String value = InputTextAction::popup(
+    "Username", _username, InputTextAction::INPUT_TEXT);
+  if (!InputTextAction::wasCancelled()) _username = value;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void FtpClientScreen::_configPassword() {
+  String value = InputTextAction::popup(
+    "Password", "", InputTextAction::INPUT_TEXT);
+  if (!InputTextAction::wasCancelled()) _password = value;
+  _selectedIndex = 3;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void FtpClientScreen::_connect() {
+  if (!_host.length()) {
+    ShowStatusAction::show("Host required", 1200); render(); return;
+  }
+  if (!_username.length()) {
+    ShowStatusAction::show("Username required", 1200); render(); return;
+  }
+  if (WiFi.status() != WL_CONNECTED) {
+    ShowStatusAction::show("WiFi not connected", 1500); render(); return;
+  }
+
+  if (!_mutex) _mutex = xSemaphoreCreateMutex();
+  if (!_mutex || !_startWorker()) {
+    ShowStatusAction::show("FTP task failed", 1500);
+    render();
+    return;
+  }
+
+  _state = STATE_CONNECTING;
+  render();
+}
+
+void FtpClientScreen::_closeConnection(bool returnToConfig) {
+  _stopRequested = true;
+  _cancelTransfer = true;
+
+  uint32_t start = millis();
+  while (_ftpTask && millis() - start < 800) delay(5);
+
+  if (returnToConfig) {
+    _state = STATE_CONFIG;
+    _updateLabels();
+    _rebuildConfig();
+    render();
+  }
+}
+
+void FtpClientScreen::_beginDownload() {
+  _remoteMode = REMOTE_DOWNLOAD;
+  _requestList(".");
+}
+
+void FtpClientScreen::_beginUpload() {
+  if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+    ShowStatusAction::show("Storage not available", 1500);
+    render();
+    return;
+  }
+  _uploadLocalPath = "";
+  _uploadName = "";
+  _uploadIsDir = false;
+  _localBrowser.root = "/";
+  _loadLocalUploadDir("/");
+}
+
+void FtpClientScreen::_loadLocalUploadDir(const String& path) {
+  _localBrowsePath = path;
+  uint8_t n = _localBrowser.load(this, path, {}, "SD");
+  _state = STATE_LOCAL_BROWSER;
+  setItems(_localBrowser.items(), n);
+  render();
+}
+
+void FtpClientScreen::_selectLocalUpload(uint8_t index) {
+  if (index >= _localBrowser.count()) return;
+  const auto& e = _localBrowser.entry(index);
+  if (e.isDir) {
+    _loadLocalUploadDir(e.path);
+    return;
+  }
+  _chooseUploadSource(e.path, e.name, false);
+}
+
+void FtpClientScreen::_holdLocalUpload(uint8_t index) {
+  if (index >= _localBrowser.count()) return;
+  const auto& e = _localBrowser.entry(index);
+  if (!e.isDir || e.name == "..") return;
+  _chooseUploadSource(e.path, e.name, true);
+}
+
+void FtpClientScreen::_chooseUploadSource(const String& path,
+                                          const String& name,
+                                          bool isDir) {
+  _uploadLocalPath = path;
+  _uploadName = name;
+  _uploadIsDir = isDir;
+  _chooseUploadDestinationMode();
+}
+
+void FtpClientScreen::_chooseUploadDestinationMode() {
+  static const InputSelectAction::Option opts[] = {
+    {"Downloads", "downloads"},
+    {"Browse", "browse"},
+  };
+
+  const char* result = InputSelectAction::popup(
+    "Upload Destination", opts, 2, "downloads");
+
+  if (!result) {
+    _state = STATE_LOCAL_BROWSER;
+    render();
+    return;
+  }
+
+  if (strcmp(result, "downloads") == 0) {
+    _chooseUploadDestination("Downloads");
+    return;
+  }
+
+  _remoteMode = REMOTE_UPLOAD_DEST;
+  _requestList(".");
+}
+
+void FtpClientScreen::_requestList(const String& path) {
+  if (_workerState != WORKER_READY || !_mutex) return;
+
+  if (xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _commandPath = path;
+    _commandError = "";
+    xSemaphoreGive(_mutex);
+  }
+
+  _remotePath = path;
+  _commandDone = false;
+  _commandOk = false;
+  _command = CMD_LIST;
+  _state = STATE_REMOTE_LOADING;
+  render();
+}
+
+void FtpClientScreen::_copyRemoteListing() {
+  SharedRemoteEntry temp[MAX_REMOTE_ENTRIES];
+  uint8_t count = 0;
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+    count = _sharedEntryCount;
+    for (uint8_t i = 0; i < count; ++i) temp[i] = _sharedEntries[i];
+    xSemaphoreGive(_mutex);
+  }
+
+  uint8_t out = 0;
+  if (_remoteMode == REMOTE_UPLOAD_DEST) {
+    _remoteNames[out] = ".";
+    _remoteSubs[out] = "UPLOAD HERE";
+    _remotePaths[out] = _remotePath;
+    _remoteIsDir[out] = true;
+    _remoteSizes[out] = 0;
+    _remoteItems[out] = {_remoteNames[out].c_str(), _remoteSubs[out].c_str()};
+    out++;
+  }
+
+  if (_remotePath != ".") {
+    _remoteNames[out] = "..";
+    _remoteSubs[out] = "DIR";
+    _remotePaths[out] = _parentRemotePath(_remotePath);
+    _remoteIsDir[out] = true;
+    _remoteSizes[out] = 0;
+    _remoteItems[out] = {_remoteNames[out].c_str(), _remoteSubs[out].c_str()};
+    out++;
+  }
+
+  for (uint8_t i = 0; i < count && out < MAX_REMOTE_ENTRIES + 2; ++i, ++out) {
+    _remoteNames[out] = temp[i].name;
+    _remotePaths[out] = temp[i].path;
+    _remoteIsDir[out] = temp[i].isDir;
+    _remoteSizes[out] = temp[i].size;
+    if (temp[i].isDir) {
+      _remoteSubs[out] = "DIR";
+    } else if (temp[i].size >= 1024 * 1024) {
+      _remoteSubs[out] = String((double)temp[i].size / (1024.0 * 1024.0), 1) + " MB";
+    } else if (temp[i].size >= 1024) {
+      _remoteSubs[out] = String((double)temp[i].size / 1024.0, 1) + " KB";
+    } else {
+      _remoteSubs[out] = String((unsigned long)temp[i].size) + " B";
+    }
+    _remoteItems[out] = {_remoteNames[out].c_str(), _remoteSubs[out].c_str()};
+  }
+
+  _remoteCount = out;
+  setItems(_remoteItems, _remoteCount, 0);
+}
+
+void FtpClientScreen::_selectRemote(uint8_t index) {
+  if (index >= _remoteCount) return;
+
+  if (_remoteMode == REMOTE_UPLOAD_DEST) {
+    if (_remoteNames[index] == ".") {
+      _chooseUploadDestination(_remotePaths[index]);
+    } else if (_remoteIsDir[index]) {
+      _requestList(_remotePaths[index]);
+    }
+    return;
+  }
+
+  if (_remoteIsDir[index]) {
+    _requestList(_remotePaths[index]);
+    return;
+  }
+
+  if (!_confirmTransfer("Download file?")) {
+    render();
+    return;
+  }
+  _requestDownload(_remotePaths[index], false);
+}
+
+void FtpClientScreen::_holdRemote(uint8_t index) {
+  if (index >= _remoteCount || !_remoteIsDir[index]) return;
+
+  if (_remoteMode == REMOTE_UPLOAD_DEST) {
+    if (_remoteNames[index] == "..") return;
+    _chooseUploadDestination(_remotePaths[index]);
+    return;
+  }
+
+  if (_remoteNames[index] == "..") return;
+  if (!_confirmTransfer("Download directory?")) {
+    render();
+    return;
+  }
+  _requestDownload(_remotePaths[index], true);
+}
+
+void FtpClientScreen::_chooseUploadDestination(const String& remoteDir) {
+  if (!_confirmTransfer(_uploadIsDir ? "Upload directory?" : "Upload file?")) {
+    _state = STATE_LOCAL_BROWSER;
+    render();
+    return;
+  }
+  _requestUpload(remoteDir);
+}
+
+bool FtpClientScreen::_confirmTransfer(const char* title) {
+  InputSelectAction::Option opts[] = {
+    {"Yes", "yes"},
+    {"No", "no"},
+  };
+  Uni.Lcd.setTextFont(1);
+  const char* result = InputSelectAction::popup(title, opts, 2, "yes");
+  return result && strcmp(result, "yes") == 0;
+}
+
+void FtpClientScreen::_requestDownload(const String& remotePath, bool directory) {
+  if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+    ShowStatusAction::show("Storage not available", 1500);
+    render();
+    return;
+  }
+  Uni.Storage->makeDir("/unigeek");
+  Uni.Storage->makeDir("/unigeek/wifi");
+  Uni.Storage->makeDir("/unigeek/wifi/remote");
+  Uni.Storage->makeDir("/unigeek/wifi/remote/ftp");
+  Uni.Storage->makeDir(DOWNLOAD_DIR);
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _commandPath = remotePath;
+    _commandError = "";
+    _progressDone = 0;
+    _progressTotal = 0;
+    _progressFilesDone = 0;
+    _progressFilesTotal = 0;
+    _progressName = _baseName(remotePath);
+    xSemaphoreGive(_mutex);
+  }
+
+  _transferIsUpload = false;
+  _cancelTransfer = false;
+  _commandDone = false;
+  _commandOk = false;
+  _command = directory ? CMD_DOWNLOAD_DIR : CMD_DOWNLOAD_FILE;
+  _state = STATE_TRANSFER;
+
+  ProgressView::init();
+  ProgressView::progress(
+    directory ? "Preparing directory..." : _progressName.c_str(), 0);
+}
+
+void FtpClientScreen::_requestUpload(const String& remoteDir) {
+  if (!_uploadLocalPath.length()) return;
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _commandPath = _uploadLocalPath;
+    _commandPath2 = remoteDir;
+    _commandError = "";
+    _progressDone = 0;
+    _progressTotal = 0;
+    _progressFilesDone = 0;
+    _progressFilesTotal = 0;
+    _progressName = _uploadName;
+    xSemaphoreGive(_mutex);
+  }
+
+  _transferIsUpload = true;
+  _cancelTransfer = false;
+  _commandDone = false;
+  _commandOk = false;
+  _command = _uploadIsDir ? CMD_UPLOAD_DIR : CMD_UPLOAD_FILE;
+  _state = STATE_TRANSFER;
+
+  ProgressView::init();
+  ProgressView::progress(
+    _uploadIsDir ? "Preparing directory..." : _uploadName.c_str(), 0);
+}
+
+void FtpClientScreen::_updateTransferProgress() {
+  uint64_t done = 0, total = 0;
+  uint32_t filesDone = 0, filesTotal = 0;
+  String name;
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+    done = _progressDone;
+    total = _progressTotal;
+    filesDone = _progressFilesDone;
+    filesTotal = _progressFilesTotal;
+    name = _progressName;
+    xSemaphoreGive(_mutex);
+  }
+
+  uint8_t pct = total ? (uint8_t)min<uint64_t>(100, (done * 100) / total) : 0;
+  String msg;
+  if (filesTotal > 1)
+    msg = name + "\n" + String(filesDone) + "/" + String(filesTotal) + " files";
+  else
+    msg = name.length() ? name : (_transferIsUpload ? "Uploading..." : "Downloading...");
+
+  ProgressView::progress(msg.c_str(), pct);
+}
+
+String FtpClientScreen::_parentRemotePath(const String& path) const {
+  if (path == "." || path.length() == 0) return ".";
+  int slash = path.lastIndexOf('/');
+  if (slash < 0) return ".";
+  if (slash == 0) return "/";
+  String parent = path.substring(0, slash);
+  return parent.length() ? parent : ".";
+}
+
+String FtpClientScreen::_baseName(const String& path) const {
+  String clean = path;
+  while (clean.length() > 1 && clean.endsWith("/"))
+    clean.remove(clean.length() - 1);
+  int slash = clean.lastIndexOf('/');
+  return slash >= 0 ? clean.substring(slash + 1) : clean;
+}
+
+String FtpClientScreen::_joinRemote(const String& dir, const String& name) const {
+  if (dir == "/" ) return "/" + name;
+  if (dir == "." || dir.length() == 0) return name;
+  return dir + "/" + name;
+}
+
+bool FtpClientScreen::_startWorker() {
+  if (_ftpTask) return false;
+
+  _stopRequested = false;
+  _cancelTransfer = false;
+  _workerState = WORKER_CONNECTING;
+  _command = CMD_NONE;
+  _commandDone = false;
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _commandError = "";
+    xSemaphoreGive(_mutex);
+  }
+
+  BaseType_t ok;
+#if defined(SOC_CPU_CORES_NUM) && SOC_CPU_CORES_NUM > 1
+  ok = xTaskCreatePinnedToCore(
+    _workerEntry, "UG FTP", FTP_TASK_STACK_SIZE, this, 1, &_ftpTask, 1);
+#else
+  ok = xTaskCreate(
+    _workerEntry, "UG FTP", FTP_TASK_STACK_SIZE, this, 1, &_ftpTask);
+#endif
+
+  if (ok != pdPASS) {
+    _ftpTask = nullptr;
+    _workerState = WORKER_IDLE;
+    return false;
+  }
+  return true;
+}
+
+void FtpClientScreen::_workerEntry(void* arg) {
+  static_cast<FtpClientScreen*>(arg)->_worker();
+}
+
+void FtpClientScreen::_setWorkerError(const char* message) {
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+    _commandError = message ? message : "FTP failed";
+    xSemaphoreGive(_mutex);
+  }
+  _workerState = WORKER_FAILED;
+}
+
+bool FtpClientScreen::_ftpReadReply(void* controlOpaque, int& code,
+                                    String& text, uint32_t timeoutMs) {
+  WiFiClient& control = *reinterpret_cast<WiFiClient*>(controlOpaque);
+  code = 0;
+  text = "";
+  String line;
+  int multiCode = 0;
+  uint32_t start = millis();
+
+  while (!_stopRequested && millis() - start < timeoutMs) {
+    while (control.available()) {
+      char c = (char)control.read();
+      if (c == '\r') continue;
+      if (c != '\n') {
+        if (line.length() < 512) line += c;
+        continue;
+      }
+
+      if (line.length() >= 3 &&
+          isDigit(line[0]) && isDigit(line[1]) && isDigit(line[2])) {
+        int thisCode = (line[0]-'0')*100 + (line[1]-'0')*10 + (line[2]-'0');
+        if (text.length()) text += "\n";
+        text += line;
+
+        if (multiCode == 0 && line.length() > 3 && line[3] == '-') {
+          multiCode = thisCode;
+        } else if (multiCode != 0) {
+          if (thisCode == multiCode && line.length() > 3 && line[3] == ' ') {
+            code = thisCode;
+            return true;
+          }
+        } else {
+          code = thisCode;
+          return true;
+        }
+      } else if (line.length()) {
+        if (text.length()) text += "\n";
+        text += line;
+      }
+      line = "";
+    }
+
+    if (!control.connected() && !control.available()) break;
+    delay(5);
+  }
+  return false;
+}
+
+bool FtpClientScreen::_ftpCommand(void* controlOpaque, const String& command,
+                                  int& code, String& text) {
+  WiFiClient& control = *reinterpret_cast<WiFiClient*>(controlOpaque);
+  control.print(command);
+  control.print("\r\n");
+  return _ftpReadReply(controlOpaque, code, text);
+}
+
+bool FtpClientScreen::_ftpOpenPassive(void* controlOpaque, void* dataOpaque) {
+  WiFiClient& data = *reinterpret_cast<WiFiClient*>(dataOpaque);
+  int code = 0;
+  String reply;
+  if (!_ftpCommand(controlOpaque, "PASV", code, reply) || code != 227) return false;
+
+  int l = reply.indexOf('(');
+  int r = reply.indexOf(')', l + 1);
+  if (l < 0 || r < 0) return false;
+
+  String tuple = reply.substring(l + 1, r);
+  int nums[6] = {};
+  int n = 0;
+  int start = 0;
+  while (n < 6) {
+    int comma = tuple.indexOf(',', start);
+    String part = comma >= 0 ? tuple.substring(start, comma) : tuple.substring(start);
+    part.trim();
+    nums[n++] = part.toInt();
+    if (comma < 0) break;
+    start = comma + 1;
+  }
+  if (n != 6) return false;
+
+  IPAddress ip(nums[0], nums[1], nums[2], nums[3]);
+  uint16_t port = (uint16_t)(nums[4] * 256 + nums[5]);
+  return data.connect(ip, port);
+}
+
+bool FtpClientScreen::_parseMlsdLine(const String& raw,
+                                     const String& parent,
+                                     SharedRemoteEntry& out) {
+  String line = raw;
+  line.trim();
+  int space = line.indexOf(' ');
+  if (space <= 0) return false;
+
+  String facts = line.substring(0, space);
+  String name = line.substring(space + 1);
+  name.trim();
+  if (!name.length() || name == "." || name == "..") return false;
+
+  String type;
+  uint64_t size = 0;
+  int pos = 0;
+  while (pos < (int)facts.length()) {
+    int semi = facts.indexOf(';', pos);
+    if (semi < 0) semi = facts.length();
+    String fact = facts.substring(pos, semi);
+    int eq = fact.indexOf('=');
+    if (eq > 0) {
+      String key = fact.substring(0, eq);
+      String value = fact.substring(eq + 1);
+      key.toLowerCase();
+      if (key == "type") type = value;
+      else if (key == "size") size = strtoull(value.c_str(), nullptr, 10);
+    }
+    pos = semi + 1;
+  }
+
+  type.toLowerCase();
+  if (type == "cdir" || type == "pdir") return false;
+
+  out.name = name;
+  out.path = _joinRemote(parent, name);
+  out.isDir = type == "dir";
+  out.size = size;
+  return out.isDir || type == "file" || type.length() == 0;
+}
+
+bool FtpClientScreen::_parseListLine(const String& raw,
+                                     const String& parent,
+                                     SharedRemoteEntry& out) {
+  String line = raw;
+  line.trim();
+  if (line.length() < 10) return false;
+
+  // Unix-style LIST fallback:
+  // drwxr-xr-x 1 user group 4096 Jan 01 12:00 name with spaces
+  char first = line[0];
+  if (first != 'd' && first != '-' && first != 'l') return false;
+
+  int starts[9] = {};
+  int fields = 0;
+  bool inField = false;
+  for (int i = 0; i < (int)line.length() && fields < 9; ++i) {
+    if (line[i] != ' ' && !inField) {
+      starts[fields++] = i;
+      inField = true;
+    } else if (line[i] == ' ') {
+      inField = false;
+    }
+  }
+  if (fields < 9) return false;
+
+  int sizeStart = starts[4];
+  int sizeEnd = line.indexOf(' ', sizeStart);
+  String sizeText = sizeEnd > sizeStart ? line.substring(sizeStart, sizeEnd) : "0";
+
+  String name = line.substring(starts[8]);
+  if (first == 'l') {
+    int arrow = name.indexOf(" -> ");
+    if (arrow > 0) name = name.substring(0, arrow);
+  }
+  name.trim();
+  if (!name.length() || name == "." || name == "..") return false;
+
+  out.name = name;
+  out.path = _joinRemote(parent, name);
+  out.isDir = first == 'd';
+  out.size = strtoull(sizeText.c_str(), nullptr, 10);
+  return true;
+}
+
+bool FtpClientScreen::_ftpList(void* controlOpaque, const String& path,
+                               SharedRemoteEntry* out, uint8_t& count) {
+  WiFiClient data;
+  int code = 0;
+  String reply;
+
+  if (!_ftpOpenPassive(controlOpaque, &data)) return false;
+
+  String command = "MLSD";
+  if (path.length() && path != ".") command += " " + path;
+
+  WiFiClient& control = *reinterpret_cast<WiFiClient*>(controlOpaque);
+  control.print(command + "\r\n");
+  if (!_ftpReadReply(controlOpaque, code, reply) || (code != 125 && code != 150)) {
+    data.stop();
+
+    // Fallback for servers without MLSD.
+    if (!_ftpOpenPassive(controlOpaque, &data)) return false;
+    // Request hidden entries as well on servers using traditional LIST.
+    command = "LIST -a";
+    if (path.length() && path != ".") command += " " + path;
+    control.print(command + "\r\n");
+    if (!_ftpReadReply(controlOpaque, code, reply) || (code != 125 && code != 150)) {
+      data.stop();
+      return false;
+    }
+
+    String payload;
+    uint32_t lastData = millis();
+    while (!_stopRequested && (data.connected() || data.available())) {
+      while (data.available()) {
+        payload += (char)data.read();
+        lastData = millis();
+      }
+      if (millis() - lastData > REPLY_TIMEOUT_MS) break;
+      delay(2);
+    }
+    data.stop();
+
+    count = 0;
+    int pos = 0;
+    while (pos < (int)payload.length() && count < MAX_REMOTE_ENTRIES) {
+      int nl = payload.indexOf('\n', pos);
+      if (nl < 0) nl = payload.length();
+      String line = payload.substring(pos, nl);
+      line.replace("\r", "");
+      SharedRemoteEntry e;
+      if (_parseListLine(line, path, e)) out[count++] = e;
+      pos = nl + 1;
+    }
+
+    _ftpReadReply(controlOpaque, code, reply);
+    return true;
+  }
+
+  String payload;
+  uint32_t lastData = millis();
+  while (!_stopRequested && (data.connected() || data.available())) {
+    while (data.available()) {
+      payload += (char)data.read();
+      lastData = millis();
+    }
+    if (millis() - lastData > REPLY_TIMEOUT_MS) break;
+    delay(2);
+  }
+  data.stop();
+
+  count = 0;
+  int pos = 0;
+  while (pos < (int)payload.length() && count < MAX_REMOTE_ENTRIES) {
+    int nl = payload.indexOf('\n', pos);
+    if (nl < 0) nl = payload.length();
+    String line = payload.substring(pos, nl);
+    line.replace("\r", "");
+    SharedRemoteEntry e;
+    if (_parseMlsdLine(line, path, e)) out[count++] = e;
+    pos = nl + 1;
+  }
+
+  _ftpReadReply(controlOpaque, code, reply);
+
+  // dirs first, alphabetical
+  for (uint8_t i = 1; i < count; ++i) {
+    SharedRemoteEntry key = out[i];
+    int j = i - 1;
+    while (j >= 0) {
+      bool move = false;
+      if (out[j].isDir != key.isDir)
+        move = !out[j].isDir && key.isDir;
+      else
+        move = strcasecmp(out[j].name.c_str(), key.name.c_str()) > 0;
+      if (!move) break;
+      out[j + 1] = out[j];
+      --j;
+    }
+    out[j + 1] = key;
+  }
+  return true;
+}
+
+bool FtpClientScreen::_workerList(void* controlOpaque, const String& path) {
+  SharedRemoteEntry temp[MAX_REMOTE_ENTRIES];
+  uint8_t count = 0;
+  if (!_ftpList(controlOpaque, path, temp, count)) {
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      _commandError = "FTP list failed";
+      xSemaphoreGive(_mutex);
+    }
+    return false;
+  }
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+    _sharedEntryCount = count;
+    for (uint8_t i = 0; i < count; ++i) _sharedEntries[i] = temp[i];
+    xSemaphoreGive(_mutex);
+  }
+  return true;
+}
+
+bool FtpClientScreen::_workerDownloadFile(void* controlOpaque,
+                                          const String& remotePath,
+                                          const String& localPath,
+                                          uint64_t knownSize) {
+  WiFiClient& control = *reinterpret_cast<WiFiClient*>(controlOpaque);
+  WiFiClient data;
+  int code = 0;
+  String reply;
+
+  uint64_t size = knownSize;
+  if (!size && _ftpCommand(controlOpaque, "SIZE " + remotePath, code, reply) && code == 213) {
+    int nl = reply.lastIndexOf('\n');
+    String last = nl >= 0 ? reply.substring(nl + 1) : reply;
+    if (last.length() > 4) size = strtoull(last.substring(4).c_str(), nullptr, 10);
+  }
+
+  if (!_ftpOpenPassive(controlOpaque, &data)) return false;
+  control.print("RETR " + remotePath + "\r\n");
+  if (!_ftpReadReply(controlOpaque, code, reply) || (code != 125 && code != 150)) {
+    data.stop();
+    return false;
+  }
+
+  fs::File local = Uni.Storage->open(localPath.c_str(), "w");
+  if (!local) {
+    data.stop();
+    return false;
+  }
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+    if (_progressTotal == 0) _progressTotal = size;
+    _progressName = _baseName(remotePath);
+    xSemaphoreGive(_mutex);
+  }
+
+  uint8_t buf[4096];
+  bool ok = true;
+  uint32_t lastData = millis();
+
+  while (!_stopRequested && !_cancelTransfer &&
+         (data.connected() || data.available())) {
+    int avail = data.available();
+    if (avail > 0) {
+      int n = data.read(buf, min<int>(avail, sizeof(buf)));
+      if (n < 0) { ok = false; break; }
+      if (n > 0) {
+        if (local.write(buf, n) != (size_t)n) { ok = false; break; }
+        lastData = millis();
+        if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+          _progressDone += n;
+          xSemaphoreGive(_mutex);
+        }
+      }
+    } else {
+      if (millis() - lastData > REPLY_TIMEOUT_MS) { ok = false; break; }
+      delay(2);
+    }
+  }
+
+  local.close();
+  data.stop();
+  _ftpReadReply(controlOpaque, code, reply);
+
+  if (_cancelTransfer || _stopRequested) return false;
+  if (ok && _mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+    _progressFilesDone++;
+    xSemaphoreGive(_mutex);
+  }
+  return ok;
+}
+
+bool FtpClientScreen::_workerCalcRemoteDir(void* controlOpaque,
+                                           const String& remotePath,
+                                           uint64_t& bytes,
+                                           uint32_t& files,
+                                           int depth) {
+  if (depth > 12 || _cancelTransfer || _stopRequested) return false;
+  SharedRemoteEntry entries[MAX_REMOTE_ENTRIES];
+  uint8_t count = 0;
+  if (!_ftpList(controlOpaque, remotePath, entries, count)) return false;
+
+  for (uint8_t i = 0; i < count; ++i) {
+    if (entries[i].isDir) {
+      if (!_workerCalcRemoteDir(controlOpaque, entries[i].path,
+                                bytes, files, depth + 1))
+        return false;
+    } else {
+      bytes += entries[i].size;
+      files++;
+    }
+  }
+  return !_cancelTransfer && !_stopRequested;
+}
+
+bool FtpClientScreen::_workerDownloadTree(void* controlOpaque,
+                                          const String& remotePath,
+                                          const String& localPath,
+                                          int depth) {
+  if (depth > 12 || _cancelTransfer || _stopRequested) return false;
+  Uni.Storage->makeDir(localPath.c_str());
+
+  SharedRemoteEntry entries[MAX_REMOTE_ENTRIES];
+  uint8_t count = 0;
+  if (!_ftpList(controlOpaque, remotePath, entries, count)) return false;
+
+  for (uint8_t i = 0; i < count; ++i) {
+    String localChild = localPath + "/" + entries[i].name;
+    if (entries[i].isDir) {
+      if (!_workerDownloadTree(controlOpaque, entries[i].path,
+                               localChild, depth + 1))
+        return false;
+    } else {
+      if (!_workerDownloadFile(controlOpaque, entries[i].path,
+                               localChild, entries[i].size))
+        return false;
+    }
+  }
+  return !_cancelTransfer && !_stopRequested;
+}
+
+bool FtpClientScreen::_workerDownloadDir(void* controlOpaque,
+                                         const String& remotePath,
+                                         const String& localPath) {
+  uint64_t bytes = 0;
+  uint32_t files = 0;
+  if (!_workerCalcRemoteDir(controlOpaque, remotePath, bytes, files, 0)) return false;
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _progressTotal = bytes;
+    _progressFilesTotal = files;
+    _progressDone = 0;
+    _progressFilesDone = 0;
+    _progressName = _baseName(remotePath);
+    xSemaphoreGive(_mutex);
+  }
+
+  return _workerDownloadTree(controlOpaque, remotePath, localPath, 0);
+}
+
+bool FtpClientScreen::_workerEnsureRemoteDir(void* controlOpaque,
+                                              const String& remotePath) {
+  int code = 0;
+  String reply;
+  if (_ftpCommand(controlOpaque, "MKD " + remotePath, code, reply) &&
+      (code == 257 || code == 250))
+    return true;
+
+  // If MKD failed because the directory already exists, verify it with CWD.
+  // Preserve and restore the control connection's working directory because
+  // all relative paths in the UI are defined from the login directory.
+  String original;
+  if (_ftpCommand(controlOpaque, "PWD", code, reply) && code == 257) {
+    int q1 = reply.indexOf('"');
+    int q2 = q1 >= 0 ? reply.indexOf('"', q1 + 1) : -1;
+    if (q1 >= 0 && q2 > q1) original = reply.substring(q1 + 1, q2);
+  }
+
+  if (!_ftpCommand(controlOpaque, "CWD " + remotePath, code, reply) || code != 250)
+    return false;
+
+  bool restored = true;
+  if (original.length()) {
+    restored = _ftpCommand(controlOpaque, "CWD " + original, code, reply) &&
+               code == 250;
+  }
+  return restored;
+}
+
+bool FtpClientScreen::_workerUploadFile(void* controlOpaque,
+                                        const String& localPath,
+                                        const String& remotePath,
+                                        uint64_t knownSize) {
+  WiFiClient& control = *reinterpret_cast<WiFiClient*>(controlOpaque);
+  WiFiClient data;
+  int code = 0;
+  String reply;
+
+  fs::File local = Uni.Storage->open(localPath.c_str(), "r");
+  if (!local) return false;
+
+  if (!_ftpOpenPassive(controlOpaque, &data)) {
+    local.close();
+    return false;
+  }
+
+  control.print("STOR " + remotePath + "\r\n");
+  if (!_ftpReadReply(controlOpaque, code, reply) || (code != 125 && code != 150)) {
+    data.stop();
+    local.close();
+    return false;
+  }
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+    if (_progressTotal == 0) _progressTotal = knownSize;
+    _progressName = _baseName(localPath);
+    xSemaphoreGive(_mutex);
+  }
+
+  uint8_t buf[4096];
+  bool ok = true;
+
+  while (!_stopRequested && !_cancelTransfer && local.available()) {
+    size_t n = local.read(buf, sizeof(buf));
+    if (!n) break;
+    size_t sent = 0;
+    while (sent < n && !_stopRequested && !_cancelTransfer) {
+      size_t w = data.write(buf + sent, n - sent);
+      if (w == 0) { ok = false; break; }
+      sent += w;
+      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+        _progressDone += w;
+        xSemaphoreGive(_mutex);
+      }
+    }
+    if (!ok) break;
+  }
+
+  data.stop();
+  local.close();
+  _ftpReadReply(controlOpaque, code, reply);
+
+  if (_cancelTransfer || _stopRequested) return false;
+  if (ok && _mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+    _progressFilesDone++;
+    xSemaphoreGive(_mutex);
+  }
+  return ok;
+}
+
+bool FtpClientScreen::_workerCalcLocalDir(const String& localPath,
+                                          uint64_t& bytes,
+                                          uint32_t& files,
+                                          int depth) {
+  if (depth > 12 || _cancelTransfer || _stopRequested) return false;
+  fs::File dir = Uni.Storage->open(localPath.c_str(), "r");
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    return false;
+  }
+
+  fs::File child = dir.openNextFile();
+  while (child && !_cancelTransfer && !_stopRequested) {
+    String name = _baseName(String(child.name()));
+    String childPath = localPath;
+    if (!childPath.endsWith("/")) childPath += "/";
+    childPath += name;
+
+    if (child.isDirectory()) {
+      child.close();
+      if (!_workerCalcLocalDir(childPath, bytes, files, depth + 1)) {
+        dir.close();
+        return false;
+      }
+    } else {
+      bytes += child.size();
+      files++;
+      child.close();
+    }
+    child = dir.openNextFile();
+  }
+  if (child) child.close();
+  dir.close();
+  return !_cancelTransfer && !_stopRequested;
+}
+
+bool FtpClientScreen::_workerUploadTree(void* controlOpaque,
+                                        const String& localPath,
+                                        const String& remotePath,
+                                        int depth) {
+  if (depth > 12 || _cancelTransfer || _stopRequested) return false;
+  if (!_workerEnsureRemoteDir(controlOpaque, remotePath)) return false;
+
+  fs::File dir = Uni.Storage->open(localPath.c_str(), "r");
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    return false;
+  }
+
+  fs::File child = dir.openNextFile();
+  while (child && !_cancelTransfer && !_stopRequested) {
+    String name = _baseName(String(child.name()));
+
+    String localChild = localPath;
+    if (!localChild.endsWith("/")) localChild += "/";
+    localChild += name;
+
+    String remoteChild = _joinRemote(remotePath, name);
+
+    if (child.isDirectory()) {
+      child.close();
+      if (!_workerUploadTree(controlOpaque, localChild, remoteChild, depth + 1)) {
+        dir.close();
+        return false;
+      }
+    } else {
+      uint64_t size = child.size();
+      child.close();
+      if (!_workerUploadFile(controlOpaque, localChild, remoteChild, size)) {
+        dir.close();
+        return false;
+      }
+    }
+    child = dir.openNextFile();
+  }
+  if (child) child.close();
+  dir.close();
+  return !_cancelTransfer && !_stopRequested;
+}
+
+bool FtpClientScreen::_workerUploadDir(void* controlOpaque,
+                                       const String& localPath,
+                                       const String& remotePath) {
+  uint64_t bytes = 0;
+  uint32_t files = 0;
+  if (!_workerCalcLocalDir(localPath, bytes, files, 0)) return false;
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _progressTotal = bytes;
+    _progressFilesTotal = files;
+    _progressDone = 0;
+    _progressFilesDone = 0;
+    _progressName = _baseName(localPath);
+    xSemaphoreGive(_mutex);
+  }
+
+  return _workerUploadTree(controlOpaque, localPath, remotePath, 0);
+}
+
+void FtpClientScreen::_worker() {
+  WiFiClient control;
+  String host = _host;
+  String user = _username;
+  String password = _password;
+  int port = _port;
+
+  if (!control.connect(host.c_str(), port)) {
+    _setWorkerError("FTP connect failed");
+    goto cleanup;
+  }
+
+  {
+    int code = 0;
+    String reply;
+    if (!_ftpReadReply(&control, code, reply) || code != 220) {
+      _setWorkerError("FTP greeting failed");
+      goto cleanup;
+    }
+
+    if (!_ftpCommand(&control, "USER " + user, code, reply)) {
+      _setWorkerError("FTP USER failed");
+      goto cleanup;
+    }
+
+    if (code == 331) {
+      if (!_ftpCommand(&control, "PASS " + password, code, reply) ||
+          (code != 230 && code != 202)) {
+        _setWorkerError("FTP authentication failed");
+        goto cleanup;
+      }
+    } else if (code != 230) {
+      _setWorkerError("FTP authentication failed");
+      goto cleanup;
+    }
+
+    // Binary mode is required for arbitrary files.
+    if (!_ftpCommand(&control, "TYPE I", code, reply) || code != 200) {
+      _setWorkerError("FTP binary mode failed");
+      goto cleanup;
+    }
+  }
+
+  password = "";
+  _workerState = WORKER_READY;
+
+  while (!_stopRequested && control.connected()) {
+    WorkerCommand cmd = _command;
+    if (cmd == CMD_NONE) {
+      vTaskDelay(pdMS_TO_TICKS(10));
+      continue;
+    }
+
+    String path;
+    String path2;
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      path = _commandPath;
+      path2 = _commandPath2;
+      _commandError = "";
+      xSemaphoreGive(_mutex);
+    }
+
+    _command = CMD_NONE;
+    _commandDone = false;
+    _commandOk = false;
+    _cancelTransfer = false;
+
+    bool ok = false;
+    if (cmd == CMD_LIST) {
+      ok = _workerList(&control, path);
+    } else if (cmd == CMD_DOWNLOAD_FILE) {
+      String local = String(DOWNLOAD_DIR) + "/" + _baseName(path);
+      ok = _workerDownloadFile(&control, path, local, 0);
+    } else if (cmd == CMD_DOWNLOAD_DIR) {
+      String local = String(DOWNLOAD_DIR) + "/" + _baseName(path);
+      ok = _workerDownloadDir(&control, path, local);
+    } else if (cmd == CMD_UPLOAD_FILE) {
+      if (_workerEnsureRemoteDir(&control, path2)) {
+        String remote = _joinRemote(path2, _baseName(path));
+        fs::File f = Uni.Storage->open(path.c_str(), "r");
+        uint64_t size = f ? (uint64_t)f.size() : 0;
+        if (f) f.close();
+        ok = _workerUploadFile(&control, path, remote, size);
+      }
+    } else if (cmd == CMD_UPLOAD_DIR) {
+      if (_workerEnsureRemoteDir(&control, path2)) {
+        String remote = _joinRemote(path2, _baseName(path));
+        ok = _workerUploadDir(&control, path, remote);
+      }
+    }
+
+    if (_cancelTransfer && cmd != CMD_LIST) {
+      ok = false;
+      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+        _commandError = "Cancelled";
+        xSemaphoreGive(_mutex);
+      }
+    } else if (!ok && _mutex &&
+               xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      if (!_commandError.length()) _commandError = "FTP operation failed";
+      xSemaphoreGive(_mutex);
+    }
+
+    _commandOk = ok;
+    _commandDone = true;
+  }
+
+  if (!_stopRequested && !control.connected())
+    _workerState = WORKER_CLOSED;
+
+cleanup:
+  if (control.connected()) {
+    int code = 0;
+    String reply;
+    _ftpCommand(&control, "QUIT", code, reply);
+  }
+  control.stop();
+  password = "";
+  if (_workerState != WORKER_FAILED) _workerState = WORKER_CLOSED;
+  _ftpTask = nullptr;
+  vTaskDelete(nullptr);
+}
+
+void FtpClientScreen::_renderConnecting() {
+  auto& lcd = Uni.Lcd;
+  int x = bodyX(), y = bodyY(), w = bodyW(), h = bodyH();
+  lcd.fillRect(x, y, w, h, TFT_BLACK);
+  lcd.setTextFont(1);
+  lcd.setTextSize(1);
+  lcd.setTextDatum(MC_DATUM);
+  lcd.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+
+  String msg = (_state == STATE_REMOTE_LOADING)
+             ? "Loading remote files..."
+             : "Connecting to " + _host + ":" + String(_port) + "...";
+  lcd.drawString(msg.c_str(), x + w / 2, y + h / 2);
+  lcd.setTextDatum(TL_DATUM);
+}
+
+void FtpClientScreen::_renderRemoteBrowser() {
+  ListScreen::onRender();
+}
+
+void FtpClientScreen::_renderLocalBrowser() {
+  ListScreen::onRender();
+}

--- a/firmware/src/screens/wifi/network/remote/FtpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/FtpClientScreen.cpp
@@ -12,6 +12,7 @@
 #include <WiFi.h>
 #include <WiFiClient.h>
 #include <FS.h>
+#include <new>
 
 const char* FtpClientScreen::title() {
   switch (_state) {
@@ -888,6 +889,37 @@ bool FtpClientScreen::_parseListLine(const String& raw,
   return true;
 }
 
+static bool _ftpReadDataPayload(WiFiClient& data,
+                                String& payload,
+                                volatile bool& stopRequested,
+                                size_t maxBytes,
+                                uint32_t timeoutMs) {
+  payload = "";
+  payload.reserve(min<size_t>(4096, maxBytes));
+
+  uint8_t buf[512];
+  uint32_t lastData = millis();
+
+  while (!stopRequested && (data.connected() || data.available())) {
+    int avail = data.available();
+    if (avail > 0) {
+      int n = data.read(buf, min<int>(avail, sizeof(buf)));
+      if (n < 0) return false;
+      if (n == 0) continue;
+
+      if (payload.length() + (size_t)n > maxBytes) return false;
+      payload.concat(reinterpret_cast<const char*>(buf), (unsigned int)n);
+      lastData = millis();
+      continue;
+    }
+
+    if (millis() - lastData > timeoutMs) return false;
+    delay(2);
+  }
+
+  return !stopRequested;
+}
+
 bool FtpClientScreen::_ftpList(void* controlOpaque, const String& path,
                                SharedRemoteEntry* out, uint8_t& count) {
   WiFiClient data;
@@ -916,16 +948,10 @@ bool FtpClientScreen::_ftpList(void* controlOpaque, const String& path,
     }
 
     String payload;
-    uint32_t lastData = millis();
-    while (!_stopRequested && (data.connected() || data.available())) {
-      while (data.available()) {
-        payload += (char)data.read();
-        lastData = millis();
-      }
-      if (millis() - lastData > REPLY_TIMEOUT_MS) break;
-      delay(2);
-    }
+    bool dataOk = _ftpReadDataPayload(
+      data, payload, _stopRequested, MAX_LIST_PAYLOAD_BYTES, DATA_STALL_TIMEOUT_MS);
     data.stop();
+    if (!dataOk) return false;
 
     count = 0;
     int pos = 0;
@@ -939,21 +965,17 @@ bool FtpClientScreen::_ftpList(void* controlOpaque, const String& path,
       pos = nl + 1;
     }
 
-    _ftpReadReply(controlOpaque, code, reply);
+    if (!_ftpReadReply(controlOpaque, code, reply) ||
+        (code != 226 && code != 250))
+      return false;
     return true;
   }
 
   String payload;
-  uint32_t lastData = millis();
-  while (!_stopRequested && (data.connected() || data.available())) {
-    while (data.available()) {
-      payload += (char)data.read();
-      lastData = millis();
-    }
-    if (millis() - lastData > REPLY_TIMEOUT_MS) break;
-    delay(2);
-  }
+  bool dataOk = _ftpReadDataPayload(
+    data, payload, _stopRequested, MAX_LIST_PAYLOAD_BYTES, DATA_STALL_TIMEOUT_MS);
   data.stop();
+  if (!dataOk) return false;
 
   count = 0;
   int pos = 0;
@@ -967,7 +989,9 @@ bool FtpClientScreen::_ftpList(void* controlOpaque, const String& path,
     pos = nl + 1;
   }
 
-  _ftpReadReply(controlOpaque, code, reply);
+  if (!_ftpReadReply(controlOpaque, code, reply) ||
+      (code != 226 && code != 250))
+    return false;
 
   // dirs first, alphabetical
   for (uint8_t i = 1; i < count; ++i) {
@@ -1017,15 +1041,18 @@ bool FtpClientScreen::_workerDownloadFile(void* controlOpaque,
   String reply;
 
   uint64_t size = knownSize;
-  if (!size && _ftpCommand(controlOpaque, "SIZE " + remotePath, code, reply) && code == 213) {
+  if (!size && _ftpCommand(controlOpaque, "SIZE " + remotePath, code, reply) &&
+      code == 213) {
     int nl = reply.lastIndexOf('\n');
     String last = nl >= 0 ? reply.substring(nl + 1) : reply;
-    if (last.length() > 4) size = strtoull(last.substring(4).c_str(), nullptr, 10);
+    if (last.length() > 4)
+      size = strtoull(last.substring(4).c_str(), nullptr, 10);
   }
 
   if (!_ftpOpenPassive(controlOpaque, &data)) return false;
   control.print("RETR " + remotePath + "\r\n");
-  if (!_ftpReadReply(controlOpaque, code, reply) || (code != 125 && code != 150)) {
+  if (!_ftpReadReply(controlOpaque, code, reply) ||
+      (code != 125 && code != 150)) {
     data.stop();
     return false;
   }
@@ -1044,6 +1071,7 @@ bool FtpClientScreen::_workerDownloadFile(void* controlOpaque,
 
   uint8_t buf[4096];
   bool ok = true;
+  uint64_t received = 0;
   uint32_t lastData = millis();
 
   while (!_stopRequested && !_cancelTransfer &&
@@ -1051,31 +1079,54 @@ bool FtpClientScreen::_workerDownloadFile(void* controlOpaque,
     int avail = data.available();
     if (avail > 0) {
       int n = data.read(buf, min<int>(avail, sizeof(buf)));
-      if (n < 0) { ok = false; break; }
+      if (n < 0) {
+        ok = false;
+        break;
+      }
+
       if (n > 0) {
-        if (local.write(buf, n) != (size_t)n) { ok = false; break; }
+        if (local.write(buf, n) != (size_t)n) {
+          ok = false;
+          break;
+        }
+
+        received += (uint64_t)n;
         lastData = millis();
+
         if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
           _progressDone += n;
           xSemaphoreGive(_mutex);
         }
       }
     } else {
-      if (millis() - lastData > REPLY_TIMEOUT_MS) { ok = false; break; }
+      if (millis() - lastData > DATA_STALL_TIMEOUT_MS) {
+        ok = false;
+        break;
+      }
       delay(2);
     }
   }
 
   local.close();
   data.stop();
-  _ftpReadReply(controlOpaque, code, reply);
 
-  if (_cancelTransfer || _stopRequested) return false;
-  if (ok && _mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+  bool completed = _ftpReadReply(controlOpaque, code, reply) &&
+                   (code == 226 || code == 250);
+
+  if (_cancelTransfer || _stopRequested) ok = false;
+  if (!completed) ok = false;
+  if (size && received != size) ok = false;
+
+  if (!ok) {
+    Uni.Storage->deleteFile(localPath.c_str());
+    return false;
+  }
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
     _progressFilesDone++;
     xSemaphoreGive(_mutex);
   }
-  return ok;
+  return true;
 }
 
 bool FtpClientScreen::_workerCalcRemoteDir(void* controlOpaque,
@@ -1084,20 +1135,36 @@ bool FtpClientScreen::_workerCalcRemoteDir(void* controlOpaque,
                                            uint32_t& files,
                                            int depth) {
   if (depth > 12 || _cancelTransfer || _stopRequested) return false;
-  SharedRemoteEntry entries[MAX_REMOTE_ENTRIES];
+  SharedRemoteEntry* entries =
+      new (std::nothrow) SharedRemoteEntry[MAX_REMOTE_ENTRIES];
+  if (!entries) return false;
+
   uint8_t count = 0;
-  if (!_ftpList(controlOpaque, remotePath, entries, count)) return false;
+  if (!_ftpList(controlOpaque, remotePath, entries, count)) {
+    delete[] entries;
+    return false;
+  }
 
   for (uint8_t i = 0; i < count; ++i) {
+    if (_cancelTransfer || _stopRequested) {
+      delete[] entries;
+      return false;
+    }
+
     if (entries[i].isDir) {
-      if (!_workerCalcRemoteDir(controlOpaque, entries[i].path,
-                                bytes, files, depth + 1))
+      String child = entries[i].path;
+      if (!_workerCalcRemoteDir(controlOpaque, child,
+                                bytes, files, depth + 1)) {
+        delete[] entries;
         return false;
+      }
     } else {
       bytes += entries[i].size;
       files++;
     }
   }
+
+  delete[] entries;
   return !_cancelTransfer && !_stopRequested;
 }
 
@@ -1108,22 +1175,43 @@ bool FtpClientScreen::_workerDownloadTree(void* controlOpaque,
   if (depth > 12 || _cancelTransfer || _stopRequested) return false;
   Uni.Storage->makeDir(localPath.c_str());
 
-  SharedRemoteEntry entries[MAX_REMOTE_ENTRIES];
+  SharedRemoteEntry* entries =
+      new (std::nothrow) SharedRemoteEntry[MAX_REMOTE_ENTRIES];
+  if (!entries) return false;
+
   uint8_t count = 0;
-  if (!_ftpList(controlOpaque, remotePath, entries, count)) return false;
+  if (!_ftpList(controlOpaque, remotePath, entries, count)) {
+    delete[] entries;
+    return false;
+  }
 
   for (uint8_t i = 0; i < count; ++i) {
+    if (_cancelTransfer || _stopRequested) {
+      delete[] entries;
+      return false;
+    }
+
     String localChild = localPath + "/" + entries[i].name;
-    if (entries[i].isDir) {
-      if (!_workerDownloadTree(controlOpaque, entries[i].path,
-                               localChild, depth + 1))
+    String remoteChild = entries[i].path;
+    bool isDir = entries[i].isDir;
+    uint64_t childSize = entries[i].size;
+
+    if (isDir) {
+      if (!_workerDownloadTree(controlOpaque, remoteChild,
+                               localChild, depth + 1)) {
+        delete[] entries;
         return false;
+      }
     } else {
-      if (!_workerDownloadFile(controlOpaque, entries[i].path,
-                               localChild, entries[i].size))
+      if (!_workerDownloadFile(controlOpaque, remoteChild,
+                               localChild, childSize)) {
+        delete[] entries;
         return false;
+      }
     }
   }
+
+  delete[] entries;
   return !_cancelTransfer && !_stopRequested;
 }
 
@@ -1193,7 +1281,8 @@ bool FtpClientScreen::_workerUploadFile(void* controlOpaque,
   }
 
   control.print("STOR " + remotePath + "\r\n");
-  if (!_ftpReadReply(controlOpaque, code, reply) || (code != 125 && code != 150)) {
+  if (!_ftpReadReply(controlOpaque, code, reply) ||
+      (code != 125 && code != 150)) {
     data.stop();
     local.close();
     return false;
@@ -1207,33 +1296,55 @@ bool FtpClientScreen::_workerUploadFile(void* controlOpaque,
 
   uint8_t buf[4096];
   bool ok = true;
+  uint64_t sentTotal = 0;
+  uint32_t lastProgress = millis();
 
   while (!_stopRequested && !_cancelTransfer && local.available()) {
     size_t n = local.read(buf, sizeof(buf));
     if (!n) break;
+
     size_t sent = 0;
     while (sent < n && !_stopRequested && !_cancelTransfer) {
       size_t w = data.write(buf + sent, n - sent);
-      if (w == 0) { ok = false; break; }
-      sent += w;
-      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
-        _progressDone += w;
-        xSemaphoreGive(_mutex);
+
+      if (w > 0) {
+        sent += w;
+        sentTotal += w;
+        lastProgress = millis();
+
+        if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+          _progressDone += w;
+          xSemaphoreGive(_mutex);
+        }
+        continue;
       }
+
+      if (!data.connected() ||
+          millis() - lastProgress > DATA_STALL_TIMEOUT_MS) {
+        ok = false;
+        break;
+      }
+      delay(2);
     }
+
     if (!ok) break;
   }
 
   data.stop();
   local.close();
-  _ftpReadReply(controlOpaque, code, reply);
+
+  bool completed = _ftpReadReply(controlOpaque, code, reply) &&
+                   (code == 226 || code == 250);
 
   if (_cancelTransfer || _stopRequested) return false;
-  if (ok && _mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+  if (!ok || !completed) return false;
+  if (knownSize && sentTotal != knownSize) return false;
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
     _progressFilesDone++;
     xSemaphoreGive(_mutex);
   }
-  return ok;
+  return true;
 }
 
 bool FtpClientScreen::_workerCalcLocalDir(const String& localPath,

--- a/firmware/src/screens/wifi/network/remote/FtpClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/FtpClientScreen.h
@@ -3,12 +3,12 @@
 #include "ui/templates/ListScreen.h"
 #include "ui/views/BrowseFileView.h"
 
-class SftpClientScreen : public ListScreen
+class FtpClientScreen : public ListScreen
 {
 public:
   const char* title() override;
   bool inhibitPowerOff() override { return _state == STATE_TRANSFER; }
-  ~SftpClientScreen();
+  ~FtpClientScreen();
 
   void onInit() override;
   void onUpdate() override;
@@ -18,28 +18,18 @@ public:
 
 private:
   enum State : uint8_t {
-    STATE_ACTION,
     STATE_CONFIG,
-    STATE_SELECT_AUTH,
-    STATE_SELECT_KEY,
     STATE_CONNECTING,
-    STATE_HOSTKEY_CONFIRM,
+    STATE_ACTION,
     STATE_REMOTE_LOADING,
     STATE_REMOTE_BROWSER,
     STATE_LOCAL_BROWSER,
     STATE_TRANSFER
   };
 
-  enum AuthMode : uint8_t {
-    AUTH_NONE,
-    AUTH_PASSWORD,
-    AUTH_PRIVATE_KEY
-  };
-
   enum WorkerState : uint8_t {
     WORKER_IDLE,
     WORKER_CONNECTING,
-    WORKER_WAIT_HOSTKEY,
     WORKER_READY,
     WORKER_FAILED,
     WORKER_CLOSED
@@ -54,6 +44,11 @@ private:
     CMD_UPLOAD_DIR
   };
 
+  enum RemoteMode : uint8_t {
+    REMOTE_DOWNLOAD,
+    REMOTE_UPLOAD_DEST
+  };
+
   struct SharedRemoteEntry {
     String name;
     String path;
@@ -61,51 +56,37 @@ private:
     uint64_t size = 0;
   };
 
-  enum RemoteMode : uint8_t {
-    REMOTE_DOWNLOAD,
-    REMOTE_UPLOAD_DEST
-  };
-
   static constexpr uint8_t MAX_REMOTE_ENTRIES = 96;
-  static constexpr uint32_t SFTP_TASK_STACK_SIZE = 28672;
+  static constexpr uint32_t FTP_TASK_STACK_SIZE = 24576;
   static constexpr uint32_t HOLD_MS = 900;
-  static constexpr const char* DOWNLOAD_DIR = "/unigeek/wifi/remote/sftp/downloads";
+  static constexpr uint32_t REPLY_TIMEOUT_MS = 12000;
+  static constexpr const char* DOWNLOAD_DIR = "/unigeek/wifi/remote/ftp/downloads";
 
-  State _state = STATE_ACTION;
-  AuthMode _authMode = AUTH_NONE;
+  State _state = STATE_CONFIG;
+  RemoteMode _remoteMode = REMOTE_DOWNLOAD;
 
   String _host;
   String _username;
   String _password;
-  String _keyPath;
-  String _keyData;
-  int _port = 22;
+  int _port = 21;
 
   char _hostLabel[40] = {};
   char _portLabel[16] = {};
   char _userLabel[32] = {};
-  char _authLabel[20] = "-";
   char _passwordLabel[16] = "-";
-  char _keyLabel[32] = {};
 
+  ListItem _configItems[5];
   ListItem _actionItems[2] = {
     {"Download", nullptr},
     {"Upload", nullptr},
   };
-  ListItem _configItems[6];
-  ListItem _authItems[2] = {
-    {"Password", nullptr},
-    {"Private Key", nullptr},
-  };
 
   BrowseFileView _localBrowser;
-  String _localBrowsePath = "/unigeek/wifi/remote/ssh";
+  String _localBrowsePath = "/";
   String _uploadLocalPath;
   String _uploadName;
   bool _uploadIsDir = false;
 
-  // Remote-browser UI snapshot. The worker writes _sharedEntries; the UI copies
-  // them into these arrays after a LIST command completes.
   SharedRemoteEntry _sharedEntries[MAX_REMOTE_ENTRIES];
   uint8_t _sharedEntryCount = 0;
 
@@ -117,11 +98,10 @@ private:
   ListItem _remoteItems[MAX_REMOTE_ENTRIES + 2];
   uint8_t _remoteCount = 0;
   String _remotePath = ".";
-  RemoteMode _remoteMode = REMOTE_DOWNLOAD;
   bool _holdHandled = false;
   bool _transferIsUpload = false;
 
-  TaskHandle_t _sftpTask = nullptr;
+  TaskHandle_t _ftpTask = nullptr;
   SemaphoreHandle_t _mutex = nullptr;
   volatile WorkerState _workerState = WORKER_IDLE;
   volatile WorkerCommand _command = CMD_NONE;
@@ -133,9 +113,6 @@ private:
   String _commandPath;
   String _commandPath2;
   String _commandError;
-  String _hostFingerprint;
-  volatile int8_t _hostKeyDecision = 0; // 0 pending, 1 trust, -1 cancel
-  uint8_t _hostKeySelection = 0;
 
   uint64_t _progressDone = 0;
   uint64_t _progressTotal = 0;
@@ -146,17 +123,15 @@ private:
   void _updateLabels();
   void _rebuildConfig();
   void _showActions();
-  void _beginDownload();
-  void _beginUpload();
   void _configHost();
   void _configPort();
   void _configUsername();
   void _configPassword();
-  void _selectAuthMenu();
-  void _selectAuth(uint8_t index);
-  void _openKeyPicker();
-  void _loadKeyDir(const String& path);
-  void _selectKey(uint8_t index);
+  void _connect();
+  void _closeConnection(bool returnToConfig = false);
+
+  void _beginDownload();
+  void _beginUpload();
 
   void _loadLocalUploadDir(const String& path);
   void _selectLocalUpload(uint8_t index);
@@ -164,49 +139,60 @@ private:
   void _chooseUploadSource(const String& path, const String& name, bool isDir);
   void _chooseUploadDestinationMode();
 
-  void _connect();
-  bool _startWorker();
-  static void _workerEntry(void* arg);
-  void _worker();
-  void _setWorkerError(const char* message);
-  void _closeConnection(bool returnToActions = true);
-
   void _requestList(const String& path);
   void _copyRemoteListing();
   void _selectRemote(uint8_t index);
   void _holdRemote(uint8_t index);
   void _chooseUploadDestination(const String& remoteDir);
-  String _parentRemotePath(const String& path) const;
-  String _baseName(const String& path) const;
 
-  bool _confirmTransfer(const char* title, const String& name);
+  bool _confirmTransfer(const char* title);
   void _requestDownload(const String& remotePath, bool directory);
   void _requestUpload(const String& remoteDir);
   void _updateTransferProgress();
 
-  void _acceptHostKey(bool trust);
-  void _renderConnecting();
-  void _renderHostKeyConfirm();
-  void _renderRemoteBrowser();
-  void _renderLocalBrowser();
+  String _parentRemotePath(const String& path) const;
+  String _baseName(const String& path) const;
+  String _joinRemote(const String& dir, const String& name) const;
 
-  // Worker-only helpers. libssh/SFTP objects never leave the worker task.
-  bool _workerList(void* sftpOpaque, const String& path);
-  bool _workerDownloadFile(void* sftpOpaque, const String& remotePath,
+  bool _startWorker();
+  static void _workerEntry(void* arg);
+  void _worker();
+  void _setWorkerError(const char* message);
+
+  // Worker-only FTP helpers.
+  bool _ftpReadReply(void* controlOpaque, int& code, String& text,
+                     uint32_t timeoutMs = REPLY_TIMEOUT_MS);
+  bool _ftpCommand(void* controlOpaque, const String& command,
+                   int& code, String& text);
+  bool _ftpOpenPassive(void* controlOpaque, void* dataOpaque);
+  bool _ftpList(void* controlOpaque, const String& path,
+                SharedRemoteEntry* out, uint8_t& count);
+  bool _parseMlsdLine(const String& line, const String& parent,
+                      SharedRemoteEntry& out);
+  bool _parseListLine(const String& line, const String& parent,
+                      SharedRemoteEntry& out);
+
+  bool _workerList(void* controlOpaque, const String& path);
+  bool _workerDownloadFile(void* controlOpaque, const String& remotePath,
                            const String& localPath, uint64_t knownSize);
-  bool _workerDownloadDir(void* sftpOpaque, const String& remotePath,
+  bool _workerDownloadDir(void* controlOpaque, const String& remotePath,
                           const String& localPath);
-  bool _workerCalcDir(void* sftpOpaque, const String& remotePath,
-                      uint64_t& bytes, uint32_t& files, int depth);
-  bool _workerDownloadTree(void* sftpOpaque, const String& remotePath,
+  bool _workerCalcRemoteDir(void* controlOpaque, const String& remotePath,
+                            uint64_t& bytes, uint32_t& files, int depth);
+  bool _workerDownloadTree(void* controlOpaque, const String& remotePath,
                            const String& localPath, int depth);
-  bool _workerUploadFile(void* sftpOpaque, const String& localPath,
+
+  bool _workerUploadFile(void* controlOpaque, const String& localPath,
                          const String& remotePath, uint64_t knownSize);
-  bool _workerUploadDir(void* sftpOpaque, const String& localPath,
+  bool _workerUploadDir(void* controlOpaque, const String& localPath,
                         const String& remotePath);
   bool _workerCalcLocalDir(const String& localPath,
                            uint64_t& bytes, uint32_t& files, int depth);
-  bool _workerUploadTree(void* sftpOpaque, const String& localPath,
+  bool _workerUploadTree(void* controlOpaque, const String& localPath,
                          const String& remotePath, int depth);
-  bool _workerEnsureRemoteDir(void* sftpOpaque, const String& remotePath);
+  bool _workerEnsureRemoteDir(void* controlOpaque, const String& remotePath);
+
+  void _renderConnecting();
+  void _renderRemoteBrowser();
+  void _renderLocalBrowser();
 };

--- a/firmware/src/screens/wifi/network/remote/FtpClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/FtpClientScreen.h
@@ -60,6 +60,8 @@ private:
   static constexpr uint32_t FTP_TASK_STACK_SIZE = 24576;
   static constexpr uint32_t HOLD_MS = 900;
   static constexpr uint32_t REPLY_TIMEOUT_MS = 12000;
+  static constexpr uint32_t DATA_STALL_TIMEOUT_MS = 12000;
+  static constexpr size_t MAX_LIST_PAYLOAD_BYTES = 65536;
   static constexpr const char* DOWNLOAD_DIR = "/unigeek/wifi/remote/ftp/downloads";
 
   State _state = STATE_CONFIG;

--- a/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.cpp
@@ -4,6 +4,7 @@
 #include "screens/wifi/network/remote/TelnetClientScreen.h"
 #include "screens/wifi/network/remote/SshClientScreen.h"
 #include "screens/wifi/network/remote/SftpClientScreen.h"
+#include "screens/wifi/network/remote/FtpClientScreen.h"
 
 void RemoteAccessScreen::onInit() {
   setItems(_items);
@@ -14,7 +15,8 @@ void RemoteAccessScreen::onItemSelected(uint8_t index) {
     case 0: Screen.push(new TcpClientScreen());    break;
     case 1: Screen.push(new TelnetClientScreen()); break;
     case 2: Screen.push(new SshClientScreen());    break;
-    case 3: Screen.push(new SftpClientScreen());   break;
+    case 3: Screen.push(new FtpClientScreen());     break;
+    case 4: Screen.push(new SftpClientScreen());    break;
     default: break;
   }
 }

--- a/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.cpp
@@ -1,0 +1,22 @@
+#include "RemoteAccessScreen.h"
+#include "core/ScreenManager.h"
+#include "screens/wifi/network/remote/TcpClientScreen.h"
+#include "screens/wifi/network/remote/TelnetClientScreen.h"
+#include "screens/wifi/network/remote/SshClientScreen.h"
+
+void RemoteAccessScreen::onInit() {
+  setItems(_items);
+}
+
+void RemoteAccessScreen::onItemSelected(uint8_t index) {
+  switch (index) {
+    case 0: Screen.push(new TcpClientScreen());    break;
+    case 1: Screen.push(new TelnetClientScreen()); break;
+    case 2: Screen.push(new SshClientScreen());    break;
+    default: break;
+  }
+}
+
+void RemoteAccessScreen::onBack() {
+  Screen.goBack();
+}

--- a/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.cpp
@@ -5,6 +5,7 @@
 #include "screens/wifi/network/remote/SshClientScreen.h"
 #include "screens/wifi/network/remote/SftpClientScreen.h"
 #include "screens/wifi/network/remote/FtpClientScreen.h"
+#include "screens/wifi/network/remote/WebDavClientScreen.h"
 
 void RemoteAccessScreen::onInit() {
   setItems(_items);
@@ -17,6 +18,7 @@ void RemoteAccessScreen::onItemSelected(uint8_t index) {
     case 2: Screen.push(new SshClientScreen());    break;
     case 3: Screen.push(new FtpClientScreen());     break;
     case 4: Screen.push(new SftpClientScreen());    break;
+    case 5: Screen.push(new WebDavClientScreen());  break;
     default: break;
   }
 }

--- a/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.cpp
@@ -3,6 +3,7 @@
 #include "screens/wifi/network/remote/TcpClientScreen.h"
 #include "screens/wifi/network/remote/TelnetClientScreen.h"
 #include "screens/wifi/network/remote/SshClientScreen.h"
+#include "screens/wifi/network/remote/SftpClientScreen.h"
 
 void RemoteAccessScreen::onInit() {
   setItems(_items);
@@ -13,6 +14,7 @@ void RemoteAccessScreen::onItemSelected(uint8_t index) {
     case 0: Screen.push(new TcpClientScreen());    break;
     case 1: Screen.push(new TelnetClientScreen()); break;
     case 2: Screen.push(new SshClientScreen());    break;
+    case 3: Screen.push(new SftpClientScreen());   break;
     default: break;
   }
 }

--- a/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.h
+++ b/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.h
@@ -12,9 +12,10 @@ public:
   void onBack() override;
 
 private:
-  ListItem _items[3] = {
+  ListItem _items[4] = {
     {"TCP Client"},
     {"Telnet Client"},
     {"SSH Client"},
+    {"SFTP Client"},
   };
 };

--- a/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.h
+++ b/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.h
@@ -12,11 +12,12 @@ public:
   void onBack() override;
 
 private:
-  ListItem _items[5] = {
+  ListItem _items[6] = {
     {"TCP Client"},
     {"Telnet Client"},
     {"SSH Client"},
     {"FTP Client"},
     {"SFTP Client"},
+    {"WebDAV Client"},
   };
 };

--- a/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.h
+++ b/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+
+class RemoteAccessScreen : public ListScreen
+{
+public:
+  const char* title() override { return "Remote Access"; }
+
+  void onInit() override;
+  void onItemSelected(uint8_t index) override;
+  void onBack() override;
+
+private:
+  ListItem _items[3] = {
+    {"TCP Client"},
+    {"Telnet Client"},
+    {"SSH Client"},
+  };
+};

--- a/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.h
+++ b/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.h
@@ -12,10 +12,11 @@ public:
   void onBack() override;
 
 private:
-  ListItem _items[4] = {
+  ListItem _items[5] = {
     {"TCP Client"},
     {"Telnet Client"},
     {"SSH Client"},
+    {"FTP Client"},
     {"SFTP Client"},
   };
 };

--- a/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.h
+++ b/firmware/src/screens/wifi/network/remote/RemoteAccessScreen.h
@@ -13,11 +13,11 @@ public:
 
 private:
   ListItem _items[6] = {
-    {"TCP Client"},
-    {"Telnet Client"},
-    {"SSH Client"},
-    {"FTP Client"},
-    {"SFTP Client"},
-    {"WebDAV Client"},
+    {"TCP"},
+    {"Telnet"},
+    {"SSH"},
+    {"FTP"},
+    {"SFTP"},
+    {"WebDAV"},
   };
 };

--- a/firmware/src/screens/wifi/network/remote/SftpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SftpClientScreen.cpp
@@ -1,0 +1,1307 @@
+#include "SftpClientScreen.h"
+
+#include "core/Device.h"
+#include "core/INavigation.h"
+#include "core/ScreenManager.h"
+#include "ui/actions/InputTextAction.h"
+#include "ui/actions/InputNumberAction.h"
+#include "ui/actions/InputSelectAction.h"
+#include "ui/actions/ShowStatusAction.h"
+#include "ui/views/ProgressView.h"
+
+#include <WiFi.h>
+#include <FS.h>
+#include <fcntl.h>
+#include <libssh/libssh.h>
+#include <libssh/sftp.h>
+
+const char* SftpClientScreen::title() {
+  switch (_state) {
+    case STATE_CONFIG:
+    case STATE_SELECT_AUTH:
+    case STATE_SELECT_KEY:
+    case STATE_CONNECTING:
+    case STATE_HOSTKEY_CONFIRM:
+      return "SFTP Client";
+    case STATE_REMOTE_LOADING:
+    case STATE_REMOTE_BROWSER:
+    case STATE_TRANSFER:
+      return "SFTP Download";
+    case STATE_ACTION:
+    default:
+      return "SFTP Client";
+  }
+}
+
+SftpClientScreen::~SftpClientScreen() {
+  _closeConnection(false);
+
+  uint32_t start = millis();
+  while (_sftpTask && millis() - start < 3000) delay(10);
+
+  if (_mutex && !_sftpTask) {
+    vSemaphoreDelete(_mutex);
+    _mutex = nullptr;
+  }
+}
+
+void SftpClientScreen::onInit() {
+  if (!_mutex) _mutex = xSemaphoreCreateMutex();
+
+  // A new SFTP session starts at connection configuration. The action hub is
+  // shown only after the SSH/SFTP session is established successfully.
+  _state = STATE_CONFIG;
+  _updateLabels();
+  _rebuildConfig();
+}
+
+void SftpClientScreen::onUpdate() {
+  if (_state == STATE_HOSTKEY_CONFIRM) {
+    if (!Uni.Nav->wasPressed()) return;
+    auto dir = Uni.Nav->readDirection();
+
+    if (dir == INavigation::DIR_BACK) {
+      _acceptHostKey(false);
+      return;
+    }
+    if (dir == INavigation::DIR_UP || dir == INavigation::DIR_DOWN ||
+        dir == INavigation::DIR_LEFT || dir == INavigation::DIR_RIGHT) {
+      _hostKeySelection = _hostKeySelection ? 0 : 1;
+      render();
+      return;
+    }
+    if (dir == INavigation::DIR_PRESS) {
+      _acceptHostKey(_hostKeySelection == 0);
+      return;
+    }
+    return;
+  }
+
+  if (_state == STATE_CONNECTING) {
+    if (_workerState == WORKER_WAIT_HOSTKEY) {
+      _hostKeySelection = 0;
+      _state = STATE_HOSTKEY_CONFIRM;
+      render();
+      return;
+    }
+
+    if (_workerState == WORKER_READY) {
+      // Keep the configured credential/session data available while the user
+      // moves between Download and Upload. Sensitive worker-local copies are
+      // still cleared by the worker immediately after authentication.
+      _showActions();
+      return;
+    }
+
+    if (_workerState == WORKER_FAILED || _workerState == WORKER_CLOSED) {
+      String err = "SFTP connection failed";
+      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+        if (_commandError.length()) err = _commandError;
+        xSemaphoreGive(_mutex);
+      }
+      _password = "";
+      _keyData = "";
+      _workerState = WORKER_IDLE;
+      _state = STATE_CONFIG;
+      _updateLabels();
+      _rebuildConfig();
+      ShowStatusAction::show(err.c_str(), 1800);
+      render();
+      return;
+    }
+
+    if (Uni.Nav->wasPressed() &&
+        Uni.Nav->readDirection() == INavigation::DIR_BACK) {
+      _stopRequested = true;
+      _hostKeyDecision = -1;
+    }
+    return;
+  }
+
+  if (_state == STATE_REMOTE_LOADING) {
+    if (_workerState == WORKER_FAILED || _workerState == WORKER_CLOSED) {
+      String err = "SFTP list failed";
+      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+        if (_commandError.length()) err = _commandError;
+        xSemaphoreGive(_mutex);
+      }
+      ShowStatusAction::show(err.c_str(), 1500);
+      _closeConnection(true);
+      return;
+    }
+
+    if (_commandDone) {
+      bool ok = _commandOk;
+      _commandDone = false;
+      if (!ok) {
+        String err = "Directory read failed";
+        if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+          if (_commandError.length()) err = _commandError;
+          xSemaphoreGive(_mutex);
+        }
+        ShowStatusAction::show(err.c_str(), 1500);
+        _state = STATE_REMOTE_BROWSER;
+        render();
+        return;
+      }
+
+      _copyRemoteListing();
+      _state = STATE_REMOTE_BROWSER;
+      render();
+    }
+
+    if (Uni.Nav->wasPressed() &&
+        Uni.Nav->readDirection() == INavigation::DIR_BACK) {
+      _closeConnection(true);
+    }
+    return;
+  }
+
+  if (_state == STATE_TRANSFER) {
+    _updateTransferProgress();
+
+    if (_commandDone) {
+      bool ok = _commandOk;
+      String err;
+      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+        err = _commandError;
+        xSemaphoreGive(_mutex);
+      }
+      _commandDone = false;
+      ProgressView::finish();
+      _state = STATE_REMOTE_BROWSER;
+      render();
+
+      if (ok) ShowStatusAction::show("Download complete", 1400);
+      else if (err == "Cancelled") ShowStatusAction::show("Download cancelled", 1200);
+      else ShowStatusAction::show(err.length() ? err.c_str() : "Download failed", 1600);
+      render();
+      return;
+    }
+
+    if (Uni.Nav->wasPressed() &&
+        Uni.Nav->readDirection() == INavigation::DIR_BACK) {
+      _cancelTransfer = true;
+    }
+    return;
+  }
+
+  if (_state == STATE_REMOTE_BROWSER) {
+    if (Uni.Nav->isPressed() && !_holdHandled &&
+        Uni.Nav->heldDuration() >= HOLD_MS) {
+      _holdHandled = true;
+      Uni.Nav->suppressCurrentPress();
+      _holdRemote(_selectedIndex);
+      return;
+    }
+
+    if (!Uni.Nav->isPressed()) _holdHandled = false;
+    ListScreen::onUpdate();
+    return;
+  }
+
+  ListScreen::onUpdate();
+}
+
+void SftpClientScreen::onRender() {
+  if (_state == STATE_CONNECTING || _state == STATE_REMOTE_LOADING) {
+    _renderConnecting();
+    return;
+  }
+  if (_state == STATE_HOSTKEY_CONFIRM) {
+    _renderHostKeyConfirm();
+    return;
+  }
+  if (_state == STATE_TRANSFER) {
+    // ProgressView owns the body while a transfer is running.
+    return;
+  }
+  if (_state == STATE_REMOTE_BROWSER) {
+    _renderRemoteBrowser();
+    return;
+  }
+  ListScreen::onRender();
+}
+
+void SftpClientScreen::onItemSelected(uint8_t index) {
+  if (_state == STATE_ACTION) {
+    if (index == 0) {
+      if (_workerState == WORKER_READY) _requestList(".");
+      else                              _beginDownload();
+    } else if (index == 1) {
+      ShowStatusAction::show("Upload coming soon", 1300);
+      render();
+    }
+    return;
+  }
+
+  if (_state == STATE_SELECT_AUTH) {
+    _selectAuth(index);
+    return;
+  }
+
+  if (_state == STATE_SELECT_KEY) {
+    _selectKey(index);
+    return;
+  }
+
+  if (_state == STATE_REMOTE_BROWSER) {
+    _selectRemote(index);
+    return;
+  }
+
+  if (_state != STATE_CONFIG) return;
+
+  switch (index) {
+    case 0: _configHost();     break;
+    case 1: _configPort();     break;
+    case 2: _configUsername(); break;
+    case 3: _selectAuthMenu(); break;
+    case 4:
+      if (_authMode == AUTH_PASSWORD) _configPassword();
+      else if (_authMode == AUTH_PRIVATE_KEY) _openKeyPicker();
+      else _connect();
+      break;
+    case 5: _connect(); break;
+    default: break;
+  }
+}
+
+void SftpClientScreen::onBack() {
+  if (_state == STATE_ACTION) {
+    // Leaving the Download/Upload hub ends the SFTP session.
+    _closeConnection(false);
+    Screen.goBack();
+    return;
+  }
+
+  if (_state == STATE_HOSTKEY_CONFIRM) {
+    _acceptHostKey(false);
+    return;
+  }
+
+  if (_state == STATE_CONNECTING || _state == STATE_REMOTE_LOADING) {
+    _stopRequested = true;
+    _hostKeyDecision = -1;
+    return;
+  }
+
+  if (_state == STATE_TRANSFER) {
+    _cancelTransfer = true;
+    return;
+  }
+
+  if (_state == STATE_SELECT_AUTH || _state == STATE_SELECT_KEY) {
+    _state = STATE_CONFIG;
+    _updateLabels();
+    _rebuildConfig();
+    render();
+    return;
+  }
+
+  if (_state == STATE_REMOTE_BROWSER) {
+    // BACK from the remote browser returns to the action hub but deliberately
+    // keeps the SSH/SFTP worker and session alive for a subsequent transfer.
+    _showActions();
+    return;
+  }
+
+  // Before a connection exists, BACK from CONFIG returns to the parent menu.
+  Screen.goBack();
+}
+
+void SftpClientScreen::_showActions() {
+  _state = STATE_ACTION;
+  setItems(_actionItems, 2, 0);
+  render();
+}
+
+void SftpClientScreen::_beginDownload() {
+  // Used only when no live SFTP session exists yet.
+  _state = STATE_CONFIG;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void SftpClientScreen::_updateLabels() {
+  snprintf(_hostLabel, sizeof(_hostLabel), "%s",
+           _host.length() ? _host.c_str() : "-");
+  snprintf(_userLabel, sizeof(_userLabel), "%s",
+           _username.length() ? _username.c_str() : "-");
+  snprintf(_portLabel, sizeof(_portLabel), "%d", _port);
+
+  if (_authMode == AUTH_PASSWORD)
+    snprintf(_authLabel, sizeof(_authLabel), "Password");
+  else if (_authMode == AUTH_PRIVATE_KEY)
+    snprintf(_authLabel, sizeof(_authLabel), "Private Key");
+  else
+    snprintf(_authLabel, sizeof(_authLabel), "-");
+
+  snprintf(_passwordLabel, sizeof(_passwordLabel), "%s",
+           _password.length() ? "********" : "-");
+
+  if (_keyPath.length()) {
+    String name = _baseName(_keyPath);
+    name.toCharArray(_keyLabel, sizeof(_keyLabel));
+  } else {
+    snprintf(_keyLabel, sizeof(_keyLabel), "-");
+  }
+}
+
+void SftpClientScreen::_rebuildConfig() {
+  uint8_t sel = _selectedIndex;
+  _configItems[0] = {"Host", _hostLabel};
+  _configItems[1] = {"Port", _portLabel};
+  _configItems[2] = {"Username", _userLabel};
+  _configItems[3] = {"Auth Method", _authLabel};
+
+  if (_authMode == AUTH_PASSWORD) {
+    _configItems[4] = {"Password", _passwordLabel};
+    _configItems[5] = {"Connect", nullptr};
+    if (sel > 5) sel = 5;
+    setItems(_configItems, 6, sel);
+  } else if (_authMode == AUTH_PRIVATE_KEY) {
+    _configItems[4] = {"Key File", _keyLabel};
+    _configItems[5] = {"Connect", nullptr};
+    if (sel > 5) sel = 5;
+    setItems(_configItems, 6, sel);
+  } else {
+    _configItems[4] = {"Connect", nullptr};
+    if (sel > 4) sel = 4;
+    setItems(_configItems, 5, sel);
+  }
+}
+
+void SftpClientScreen::_configHost() {
+  String initial = _host;
+  if (!initial.length() && WiFi.status() == WL_CONNECTED) {
+    IPAddress ip = WiFi.localIP();
+    initial = String(ip[0]) + "." + String(ip[1]) + "." + String(ip[2]) + ".";
+  }
+
+  String value = InputTextAction::popup(
+    "Host", initial, InputTextAction::INPUT_IP_ADDRESS);
+  if (!InputTextAction::wasCancelled() && value.length()) _host = value;
+
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void SftpClientScreen::_configPort() {
+  int value = InputNumberAction::popup("Port", 1, 65535, _port);
+  if (!InputNumberAction::wasCancelled()) _port = value;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void SftpClientScreen::_configUsername() {
+  String value = InputTextAction::popup(
+    "Username", _username, InputTextAction::INPUT_TEXT);
+  if (!InputTextAction::wasCancelled() && value.length()) _username = value;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void SftpClientScreen::_configPassword() {
+  String value = InputTextAction::popup(
+    "Password", "", InputTextAction::INPUT_TEXT);
+  if (!InputTextAction::wasCancelled()) _password = value;
+  _selectedIndex = 4;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void SftpClientScreen::_selectAuthMenu() {
+  _state = STATE_SELECT_AUTH;
+  uint8_t selected = (_authMode == AUTH_PRIVATE_KEY) ? 1 : 0;
+  setItems(_authItems, 2, selected);
+  render();
+}
+
+void SftpClientScreen::_selectAuth(uint8_t index) {
+  if (index > 1) return;
+
+  _authMode = index == 0 ? AUTH_PASSWORD : AUTH_PRIVATE_KEY;
+  if (_authMode == AUTH_PASSWORD) _keyData = "";
+  else _password = "";
+
+  _selectedIndex = 3;
+  _state = STATE_CONFIG;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void SftpClientScreen::_openKeyPicker() {
+  if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+    ShowStatusAction::show("Storage not available", 1500);
+    render();
+    return;
+  }
+
+  Uni.Storage->makeDir("/unigeek");
+  Uni.Storage->makeDir("/unigeek/wifi");
+  Uni.Storage->makeDir("/unigeek/wifi/ssh");
+
+  _localBrowsePath = "/unigeek/wifi/ssh";
+  _localBrowser.root = "/";
+  _state = STATE_SELECT_KEY;
+  _loadKeyDir(_localBrowsePath);
+}
+
+void SftpClientScreen::_loadKeyDir(const String& path) {
+  _localBrowsePath = path;
+  uint8_t n = _localBrowser.load(this, path, {}, "KEY");
+  setItems(_localBrowser.items(), n);
+  render();
+}
+
+void SftpClientScreen::_selectKey(uint8_t index) {
+  if (index >= _localBrowser.count()) return;
+  const auto& e = _localBrowser.entry(index);
+
+  if (e.isDir) {
+    _loadKeyDir(e.path);
+    return;
+  }
+
+  _keyPath = e.path;
+  _selectedIndex = 4;
+  _state = STATE_CONFIG;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void SftpClientScreen::_connect() {
+  if (!_host.length()) {
+    ShowStatusAction::show("Host required", 1200); render(); return;
+  }
+  if (!_username.length()) {
+    ShowStatusAction::show("Username required", 1200); render(); return;
+  }
+  if (WiFi.status() != WL_CONNECTED) {
+    ShowStatusAction::show("WiFi not connected", 1500); render(); return;
+  }
+  if (_authMode == AUTH_NONE) {
+    ShowStatusAction::show("Auth method required", 1500); render(); return;
+  }
+
+  if (_authMode == AUTH_PASSWORD) {
+    if (!_password.length()) {
+      ShowStatusAction::show("Password required", 1200); render(); return;
+    }
+  } else {
+    if (!_keyPath.length()) {
+      ShowStatusAction::show("Key file required", 1200); render(); return;
+    }
+    if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+      ShowStatusAction::show("Storage not available", 1500); render(); return;
+    }
+    _keyData = Uni.Storage->readFile(_keyPath.c_str());
+    if (!_keyData.length()) {
+      ShowStatusAction::show("Key read failed", 1500); render(); return;
+    }
+  }
+
+  if (!_mutex) _mutex = xSemaphoreCreateMutex();
+  if (!_mutex || !_startWorker()) {
+    _keyData = "";
+    ShowStatusAction::show("SFTP task failed", 1500);
+    render();
+    return;
+  }
+
+  _state = STATE_CONNECTING;
+  render();
+}
+
+bool SftpClientScreen::_startWorker() {
+  if (_sftpTask) return false;
+
+  _stopRequested = false;
+  _cancelTransfer = false;
+  _hostKeyDecision = 0;
+  _workerState = WORKER_CONNECTING;
+  _command = CMD_NONE;
+  _commandDone = false;
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _commandError = "";
+    _hostFingerprint = "";
+    xSemaphoreGive(_mutex);
+  }
+
+  BaseType_t ok;
+#if defined(SOC_CPU_CORES_NUM) && SOC_CPU_CORES_NUM > 1
+  ok = xTaskCreatePinnedToCore(
+    _workerEntry, "UG SFTP", SFTP_TASK_STACK_SIZE, this, 1, &_sftpTask, 1);
+#else
+  ok = xTaskCreate(
+    _workerEntry, "UG SFTP", SFTP_TASK_STACK_SIZE, this, 1, &_sftpTask);
+#endif
+
+  if (ok != pdPASS) {
+    _sftpTask = nullptr;
+    _workerState = WORKER_IDLE;
+    return false;
+  }
+  return true;
+}
+
+void SftpClientScreen::_workerEntry(void* arg) {
+  static_cast<SftpClientScreen*>(arg)->_worker();
+}
+
+void SftpClientScreen::_setWorkerError(const char* message) {
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+    _commandError = message ? message : "SFTP failed";
+    xSemaphoreGive(_mutex);
+  }
+  _workerState = WORKER_FAILED;
+}
+
+void SftpClientScreen::_worker() {
+  ssh_session session = nullptr;
+  sftp_session sftp = nullptr;
+
+  String host = _host;
+  String user = _username;
+  String password = _password;
+  String keyData = _keyData;
+  AuthMode authMode = _authMode;
+  int port = _port;
+
+  session = ssh_new();
+  if (!session) {
+    _setWorkerError("SSH session failed");
+    goto cleanup;
+  }
+
+  if (ssh_options_set(session, SSH_OPTIONS_HOST, host.c_str()) != SSH_OK ||
+      ssh_options_set(session, SSH_OPTIONS_USER, user.c_str()) != SSH_OK ||
+      ssh_options_set(session, SSH_OPTIONS_PORT, &port) != SSH_OK) {
+    _setWorkerError("SSH options failed");
+    goto cleanup;
+  }
+
+  if (_stopRequested) goto cleanup;
+
+  if (ssh_connect(session) != SSH_OK) {
+    _setWorkerError("SSH connect failed");
+    goto cleanup;
+  }
+
+  // Fingerprint confirmation occurs before any user credential is sent.
+  {
+    ssh_key serverKey = nullptr;
+    unsigned char* hash = nullptr;
+    size_t hashLen = 0;
+
+    if (ssh_get_server_publickey(session, &serverKey) != SSH_OK || !serverKey) {
+      if (serverKey) ssh_key_free(serverKey);
+      _setWorkerError("SSH host key failed");
+      goto cleanup;
+    }
+
+    int rc = ssh_get_publickey_hash(
+      serverKey, SSH_PUBLICKEY_HASH_SHA256, &hash, &hashLen);
+    ssh_key_free(serverKey);
+
+    if (rc != SSH_OK || !hash || hashLen == 0) {
+      if (hash) ssh_clean_pubkey_hash(&hash);
+      _setWorkerError("SSH fingerprint failed");
+      goto cleanup;
+    }
+
+    char* hex = ssh_get_hexa(hash, hashLen);
+    ssh_clean_pubkey_hash(&hash);
+    if (!hex) {
+      _setWorkerError("SSH fingerprint failed");
+      goto cleanup;
+    }
+
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+      _hostFingerprint = "SHA256 ";
+      _hostFingerprint += hex;
+      xSemaphoreGive(_mutex);
+    }
+    ssh_string_free_char(hex);
+
+    _hostKeyDecision = 0;
+    _workerState = WORKER_WAIT_HOSTKEY;
+    while (!_stopRequested && _hostKeyDecision == 0)
+      vTaskDelay(pdMS_TO_TICKS(20));
+
+    if (_stopRequested || _hostKeyDecision < 0) {
+      _workerState = WORKER_CLOSED;
+      goto cleanup;
+    }
+    _workerState = WORKER_CONNECTING;
+  }
+
+  if (authMode == AUTH_PASSWORD) {
+    if (ssh_userauth_password(session, nullptr, password.c_str()) != SSH_AUTH_SUCCESS) {
+      _setWorkerError("SSH authentication failed");
+      goto cleanup;
+    }
+  } else {
+    ssh_key privateKey = nullptr;
+    ssh_key publicKey = nullptr;
+
+    int rc = ssh_pki_import_privkey_base64(
+      keyData.c_str(), nullptr, nullptr, nullptr, &privateKey);
+    if (rc != SSH_OK || !privateKey) {
+      if (privateKey) ssh_key_free(privateKey);
+      _setWorkerError("SSH key import failed");
+      goto cleanup;
+    }
+
+    rc = ssh_pki_export_privkey_to_pubkey(privateKey, &publicKey);
+    if (rc != SSH_OK || !publicKey) {
+      if (publicKey) ssh_key_free(publicKey);
+      ssh_key_free(privateKey);
+      _setWorkerError("SSH public key failed");
+      goto cleanup;
+    }
+
+    rc = ssh_userauth_try_publickey(session, nullptr, publicKey);
+    if (rc == SSH_AUTH_SUCCESS)
+      rc = ssh_userauth_publickey(session, nullptr, privateKey);
+
+    ssh_key_free(publicKey);
+    ssh_key_free(privateKey);
+
+    if (rc != SSH_AUTH_SUCCESS) {
+      _setWorkerError("SSH key auth failed");
+      goto cleanup;
+    }
+  }
+
+  password = "";
+  keyData = "";
+
+  sftp = sftp_new(session);
+  if (!sftp || sftp_init(sftp) != SSH_OK) {
+    _setWorkerError("SFTP init failed");
+    goto cleanup;
+  }
+
+  _workerState = WORKER_READY;
+
+  while (!_stopRequested) {
+    WorkerCommand cmd = _command;
+    if (cmd == CMD_NONE) {
+      vTaskDelay(pdMS_TO_TICKS(10));
+      continue;
+    }
+
+    String path;
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      path = _commandPath;
+      _commandError = "";
+      xSemaphoreGive(_mutex);
+    }
+
+    _command = CMD_NONE;
+    _commandDone = false;
+    _commandOk = false;
+    _cancelTransfer = false;
+
+    bool ok = false;
+    if (cmd == CMD_LIST) {
+      ok = _workerList((void*)sftp, path);
+    } else if (cmd == CMD_DOWNLOAD_FILE) {
+      String local = String(DOWNLOAD_DIR) + "/" + _baseName(path);
+      sftp_attributes a = sftp_stat(sftp, path.c_str());
+      uint64_t size = a ? a->size : 0;
+      if (a) sftp_attributes_free(a);
+      ok = _workerDownloadFile((void*)sftp, path, local, size);
+    } else if (cmd == CMD_DOWNLOAD_DIR) {
+      String local = String(DOWNLOAD_DIR) + "/" + _baseName(path);
+      ok = _workerDownloadDir((void*)sftp, path, local);
+    }
+
+    if (_cancelTransfer && cmd != CMD_LIST) {
+      ok = false;
+      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+        _commandError = "Cancelled";
+        xSemaphoreGive(_mutex);
+      }
+    }
+
+    _commandOk = ok;
+    _commandDone = true;
+    _workerState = WORKER_READY;
+  }
+
+  _workerState = WORKER_CLOSED;
+
+cleanup:
+  if (sftp) {
+    sftp_free(sftp);
+    sftp = nullptr;
+  }
+
+  if (session) {
+    ssh_disconnect(session);
+    ssh_free(session);
+    session = nullptr;
+  }
+
+  password = "";
+  keyData = "";
+  _sftpTask = nullptr;
+  vTaskDelete(nullptr);
+}
+
+void SftpClientScreen::_closeConnection(bool returnToActions) {
+  _stopRequested = true;
+  _cancelTransfer = true;
+  _hostKeyDecision = -1;
+
+  uint32_t start = millis();
+  while (_sftpTask && millis() - start < 800) delay(5);
+
+  _password = "";
+  _keyData = "";
+
+  if (returnToActions) _showActions();
+}
+
+void SftpClientScreen::_requestList(const String& path) {
+  if (_workerState != WORKER_READY || !_mutex) return;
+
+  if (xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _commandPath = path;
+    _commandError = "";
+    xSemaphoreGive(_mutex);
+  }
+
+  _remotePath = path;
+  _commandDone = false;
+  _commandOk = false;
+  _command = CMD_LIST;
+  _state = STATE_REMOTE_LOADING;
+  render();
+}
+
+bool SftpClientScreen::_workerList(void* sftpOpaque, const String& path) {
+  sftp_session sftp = (sftp_session)sftpOpaque;
+  sftp_dir dir = sftp_opendir(sftp, path.c_str());
+  if (!dir) {
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      _commandError = "Cannot open remote dir";
+      xSemaphoreGive(_mutex);
+    }
+    return false;
+  }
+
+  SharedRemoteEntry temp[MAX_REMOTE_ENTRIES];
+  uint8_t count = 0;
+
+  while (!_stopRequested && count < MAX_REMOTE_ENTRIES) {
+    sftp_attributes a = sftp_readdir(sftp, dir);
+    if (!a) break;
+
+    String name = a->name ? a->name : "";
+    if (name != "." && name != ".." && name.length()) {
+      String child;
+      if (path == "/") child = "/" + name;
+      else if (path == ".") child = "./" + name;
+      else child = path + "/" + name;
+
+      temp[count].name = name;
+      temp[count].path = child;
+      temp[count].isDir = (a->type == SSH_FILEXFER_TYPE_DIRECTORY);
+      temp[count].size = a->size;
+      count++;
+    }
+    sftp_attributes_free(a);
+  }
+
+  sftp_closedir(dir);
+
+  // Directories first, then case-insensitive alphabetical order.
+  for (uint8_t i = 1; i < count; ++i) {
+    SharedRemoteEntry key = temp[i];
+    int j = i - 1;
+    while (j >= 0) {
+      bool move = false;
+      if (temp[j].isDir != key.isDir)
+        move = !temp[j].isDir && key.isDir;
+      else
+        move = strcasecmp(temp[j].name.c_str(), key.name.c_str()) > 0;
+      if (!move) break;
+      temp[j + 1] = temp[j];
+      --j;
+    }
+    temp[j + 1] = key;
+  }
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+    _sharedEntryCount = count;
+    for (uint8_t i = 0; i < count; ++i) _sharedEntries[i] = temp[i];
+    xSemaphoreGive(_mutex);
+  }
+  return true;
+}
+
+void SftpClientScreen::_copyRemoteListing() {
+  if (!_mutex) return;
+
+  SharedRemoteEntry temp[MAX_REMOTE_ENTRIES];
+  uint8_t count = 0;
+
+  if (xSemaphoreTake(_mutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+    count = _sharedEntryCount;
+    for (uint8_t i = 0; i < count; ++i) temp[i] = _sharedEntries[i];
+    xSemaphoreGive(_mutex);
+  }
+
+  uint8_t out = 0;
+  if (_remotePath != ".") {
+    _remoteNames[out] = "..";
+    _remoteSubs[out] = "DIR";
+    _remotePaths[out] = _parentRemotePath(_remotePath);
+    _remoteIsDir[out] = true;
+    _remoteSizes[out] = 0;
+    _remoteItems[out] = {_remoteNames[out].c_str(), _remoteSubs[out].c_str()};
+    out++;
+  }
+
+  for (uint8_t i = 0; i < count && out < MAX_REMOTE_ENTRIES + 1; ++i, ++out) {
+    _remoteNames[out] = temp[i].name;
+    _remotePaths[out] = temp[i].path;
+    _remoteIsDir[out] = temp[i].isDir;
+    _remoteSizes[out] = temp[i].size;
+
+    if (temp[i].isDir) {
+      _remoteSubs[out] = "DIR";
+    } else {
+      uint64_t size = temp[i].size;
+      if (size >= 1024 * 1024)
+        _remoteSubs[out] = String((double)size / (1024.0 * 1024.0), 1) + " MB";
+      else if (size >= 1024)
+        _remoteSubs[out] = String((double)size / 1024.0, 1) + " KB";
+      else
+        _remoteSubs[out] = String((unsigned long)size) + " B";
+    }
+
+    _remoteItems[out] = {
+      _remoteNames[out].c_str(),
+      _remoteSubs[out].c_str()
+    };
+  }
+
+  _remoteCount = out;
+  setItems(_remoteItems, _remoteCount, 0);
+}
+
+void SftpClientScreen::_selectRemote(uint8_t index) {
+  if (index >= _remoteCount) return;
+
+  if (_remoteIsDir[index]) {
+    _requestList(_remotePaths[index]);
+    return;
+  }
+
+  if (!_confirmTransfer("Download file?", _remoteNames[index])) {
+    render();
+    return;
+  }
+
+  _requestDownload(_remotePaths[index], false);
+}
+
+void SftpClientScreen::_holdRemote(uint8_t index) {
+  if (index >= _remoteCount || !_remoteIsDir[index]) return;
+  if (_remoteNames[index] == "..") return;
+
+  if (!_confirmTransfer("Download directory?", _remoteNames[index])) {
+    render();
+    return;
+  }
+
+  _requestDownload(_remotePaths[index], true);
+}
+
+bool SftpClientScreen::_confirmTransfer(const char* title, const String& name) {
+  (void)name;
+
+  InputSelectAction::Option opts[] = {
+    {"Yes", "yes"},
+    {"No", "no"},
+  };
+
+  // InputSelectAction renders its title as a single-line overlay heading.
+  // Do not embed the selected filename/directory with a newline here; doing so
+  // produces visual artifacts on the UG display.
+  const char* result = InputSelectAction::popup(
+    title, opts, 2, "no");
+  return result && strcmp(result, "yes") == 0;
+}
+
+void SftpClientScreen::_requestDownload(const String& remotePath, bool directory) {
+  if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+    ShowStatusAction::show("Storage not available", 1500);
+    render();
+    return;
+  }
+
+  Uni.Storage->makeDir("/unigeek");
+  Uni.Storage->makeDir("/unigeek/wifi");
+  Uni.Storage->makeDir("/unigeek/wifi/sftp");
+  Uni.Storage->makeDir(DOWNLOAD_DIR);
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _commandPath = remotePath;
+    _commandError = "";
+    _progressDone = 0;
+    _progressTotal = 0;
+    _progressFilesDone = 0;
+    _progressFilesTotal = 0;
+    _progressName = _baseName(remotePath);
+    xSemaphoreGive(_mutex);
+  }
+
+  _cancelTransfer = false;
+  _commandDone = false;
+  _commandOk = false;
+  _command = directory ? CMD_DOWNLOAD_DIR : CMD_DOWNLOAD_FILE;
+  _state = STATE_TRANSFER;
+
+  ProgressView::init();
+  ProgressView::progress(
+    directory ? "Preparing directory..." : _progressName.c_str(), 0);
+}
+
+void SftpClientScreen::_updateTransferProgress() {
+  if (!_mutex) return;
+
+  uint64_t done = 0, total = 0;
+  uint32_t filesDone = 0, filesTotal = 0;
+  String name;
+
+  if (xSemaphoreTake(_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+    done = _progressDone;
+    total = _progressTotal;
+    filesDone = _progressFilesDone;
+    filesTotal = _progressFilesTotal;
+    name = _progressName;
+    xSemaphoreGive(_mutex);
+  }
+
+  uint8_t pct = total ? (uint8_t)min<uint64_t>(100, (done * 100) / total) : 0;
+  String msg;
+  if (filesTotal > 1)
+    msg = name + "\n" + String(filesDone) + "/" + String(filesTotal) + " files";
+  else
+    msg = name.length() ? name : "Downloading...";
+
+  ProgressView::progress(msg.c_str(), pct);
+}
+
+bool SftpClientScreen::_workerDownloadFile(void* sftpOpaque,
+                                           const String& remotePath,
+                                           const String& localPath,
+                                           uint64_t knownSize) {
+  sftp_session sftp = (sftp_session)sftpOpaque;
+  sftp_file remote = sftp_open(sftp, remotePath.c_str(), O_RDONLY, 0);
+  if (!remote) {
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      _commandError = "Remote file open failed";
+      xSemaphoreGive(_mutex);
+    }
+    return false;
+  }
+
+  fs::File local = Uni.Storage->open(localPath.c_str(), "w");
+  if (!local) {
+    sftp_close(remote);
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      _commandError = "Local file open failed";
+      xSemaphoreGive(_mutex);
+    }
+    return false;
+  }
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+    if (_progressTotal == 0) _progressTotal = knownSize;
+    _progressName = _baseName(remotePath);
+    xSemaphoreGive(_mutex);
+  }
+
+  uint8_t buf[4096];
+  bool ok = true;
+
+  while (!_stopRequested && !_cancelTransfer) {
+    ssize_t n = sftp_read(remote, buf, sizeof(buf));
+    if (n < 0) {
+      ok = false;
+      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+        _commandError = "SFTP read failed";
+        xSemaphoreGive(_mutex);
+      }
+      break;
+    }
+    if (n == 0) break;
+
+    size_t written = local.write(buf, (size_t)n);
+    if (written != (size_t)n) {
+      ok = false;
+      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+        _commandError = "Storage write failed";
+        xSemaphoreGive(_mutex);
+      }
+      break;
+    }
+
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+      _progressDone += written;
+      xSemaphoreGive(_mutex);
+    }
+  }
+
+  local.close();
+  sftp_close(remote);
+
+  if (_cancelTransfer || _stopRequested) return false;
+
+  if (ok && _mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+    _progressFilesDone++;
+    xSemaphoreGive(_mutex);
+  }
+  return ok;
+}
+
+bool SftpClientScreen::_workerCalcDir(void* sftpOpaque,
+                                      const String& remotePath,
+                                      uint64_t& bytes,
+                                      uint32_t& files,
+                                      int depth) {
+  if (depth > 12 || _cancelTransfer || _stopRequested) return false;
+
+  sftp_session sftp = (sftp_session)sftpOpaque;
+  sftp_dir dir = sftp_opendir(sftp, remotePath.c_str());
+  if (!dir) return false;
+
+  bool ok = true;
+  while (!_cancelTransfer && !_stopRequested) {
+    sftp_attributes a = sftp_readdir(sftp, dir);
+    if (!a) break;
+
+    String name = a->name ? a->name : "";
+    if (name != "." && name != "..") {
+      String child = remotePath == "/" ? "/" + name : remotePath + "/" + name;
+      if (a->type == SSH_FILEXFER_TYPE_DIRECTORY) {
+        if (!_workerCalcDir(sftpOpaque, child, bytes, files, depth + 1)) {
+          ok = false;
+          sftp_attributes_free(a);
+          break;
+        }
+      } else if (a->type == SSH_FILEXFER_TYPE_REGULAR) {
+        bytes += a->size;
+        files++;
+      }
+    }
+    sftp_attributes_free(a);
+  }
+
+  sftp_closedir(dir);
+  return ok && !_cancelTransfer && !_stopRequested;
+}
+
+bool SftpClientScreen::_workerDownloadTree(void* sftpOpaque,
+                                           const String& remotePath,
+                                           const String& localPath,
+                                           int depth) {
+  if (depth > 12 || _cancelTransfer || _stopRequested) return false;
+
+  Uni.Storage->makeDir(localPath.c_str());
+
+  sftp_session sftp = (sftp_session)sftpOpaque;
+  sftp_dir dir = sftp_opendir(sftp, remotePath.c_str());
+  if (!dir) return false;
+
+  bool ok = true;
+  while (!_cancelTransfer && !_stopRequested) {
+    sftp_attributes a = sftp_readdir(sftp, dir);
+    if (!a) break;
+
+    String name = a->name ? a->name : "";
+    if (name != "." && name != "..") {
+      String remoteChild =
+        remotePath == "/" ? "/" + name : remotePath + "/" + name;
+      String localChild = localPath + "/" + name;
+
+      if (a->type == SSH_FILEXFER_TYPE_DIRECTORY) {
+        if (!_workerDownloadTree(
+              sftpOpaque, remoteChild, localChild, depth + 1)) {
+          ok = false;
+          sftp_attributes_free(a);
+          break;
+        }
+      } else if (a->type == SSH_FILEXFER_TYPE_REGULAR) {
+        if (!_workerDownloadFile(
+              sftpOpaque, remoteChild, localChild, a->size)) {
+          ok = false;
+          sftp_attributes_free(a);
+          break;
+        }
+      }
+    }
+    sftp_attributes_free(a);
+  }
+
+  sftp_closedir(dir);
+  return ok && !_cancelTransfer && !_stopRequested;
+}
+
+bool SftpClientScreen::_workerDownloadDir(void* sftpOpaque,
+                                          const String& remotePath,
+                                          const String& localPath) {
+  uint64_t totalBytes = 0;
+  uint32_t totalFiles = 0;
+
+  if (!_workerCalcDir(
+        sftpOpaque, remotePath, totalBytes, totalFiles, 0)) {
+    if (!_cancelTransfer && _mutex &&
+        xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      _commandError = "Directory scan failed";
+      xSemaphoreGive(_mutex);
+    }
+    return false;
+  }
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _progressTotal = totalBytes;
+    _progressFilesTotal = totalFiles;
+    _progressDone = 0;
+    _progressFilesDone = 0;
+    _progressName = _baseName(remotePath);
+    xSemaphoreGive(_mutex);
+  }
+
+  return _workerDownloadTree(sftpOpaque, remotePath, localPath, 0);
+}
+
+String SftpClientScreen::_parentRemotePath(const String& path) const {
+  if (path == "." || path.length() == 0) return ".";
+  int slash = path.lastIndexOf('/');
+  if (slash < 0) return ".";
+  if (slash == 0) return "/";
+  String parent = path.substring(0, slash);
+  return parent.length() ? parent : ".";
+}
+
+String SftpClientScreen::_baseName(const String& path) const {
+  String clean = path;
+  while (clean.length() > 1 && clean.endsWith("/"))
+    clean.remove(clean.length() - 1);
+  int slash = clean.lastIndexOf('/');
+  return slash >= 0 ? clean.substring(slash + 1) : clean;
+}
+
+void SftpClientScreen::_acceptHostKey(bool trust) {
+  _hostKeyDecision = trust ? 1 : -1;
+  if (trust) {
+    _state = STATE_CONNECTING;
+  } else {
+    _stopRequested = true;
+    _state = STATE_CONNECTING;
+  }
+  render();
+}
+
+void SftpClientScreen::_renderConnecting() {
+  auto& lcd = Uni.Lcd;
+  int x = bodyX(), y = bodyY(), w = bodyW(), h = bodyH();
+  lcd.fillRect(x, y, w, h, TFT_BLACK);
+  lcd.setTextFont(1);
+  lcd.setTextSize(1);
+  lcd.setTextDatum(MC_DATUM);
+  lcd.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+
+  String msg = (_state == STATE_REMOTE_LOADING)
+             ? "Loading remote files..."
+             : "Connecting to " + _host + ":" + String(_port) + "...";
+  lcd.drawString(msg.c_str(), x + w / 2, y + h / 2);
+  lcd.setTextDatum(TL_DATUM);
+}
+
+void SftpClientScreen::_renderHostKeyConfirm() {
+  auto& lcd = Uni.Lcd;
+  int x = bodyX(), y = bodyY(), w = bodyW(), h = bodyH();
+  lcd.fillRect(x, y, w, h, TFT_BLACK);
+  lcd.setTextFont(1);
+  lcd.setTextSize(1);
+  lcd.setTextDatum(TL_DATUM);
+
+  int cy = y + 4;
+  lcd.setTextColor(TFT_YELLOW, TFT_BLACK);
+  lcd.drawString("SSH Host Key", x + 4, cy);
+  cy += 12;
+
+  lcd.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+  String hostLine = _host + ":" + String(_port);
+  lcd.drawString(hostLine.c_str(), x + 4, cy);
+  cy += 14;
+
+  String fp;
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+    fp = _hostFingerprint;
+    xSemaphoreGive(_mutex);
+  }
+
+  int charsPerLine = max(8, (w - 8) / 6);
+  for (int pos = 0; pos < (int)fp.length() && cy < y + h - 32;
+       pos += charsPerLine) {
+    String line = fp.substring(pos, min(pos + charsPerLine, (int)fp.length()));
+    lcd.drawString(line.c_str(), x + 4, cy);
+    cy += 10;
+  }
+
+  int buttonY = y + h - 25;
+  int buttonW = (w - 12) / 2;
+
+  auto drawButton = [&](int bx, const char* label, bool selected) {
+    lcd.drawRoundRect(
+      bx, buttonY, buttonW, 19, 3,
+      selected ? TFT_YELLOW : TFT_DARKGREY);
+    lcd.setTextDatum(MC_DATUM);
+    lcd.setTextColor(
+      selected ? TFT_WHITE : TFT_LIGHTGREY, TFT_BLACK);
+    lcd.drawString(label, bx + buttonW / 2, buttonY + 9);
+    lcd.setTextDatum(TL_DATUM);
+  };
+
+  drawButton(x + 4, "Trust", _hostKeySelection == 0);
+  drawButton(x + 8 + buttonW, "Cancel", _hostKeySelection == 1);
+}
+
+void SftpClientScreen::_renderRemoteBrowser() {
+  ListScreen::onRender();
+
+  auto& lcd = Uni.Lcd;
+  const int x = bodyX();
+  const int y = bodyY();
+  const int w = bodyW();
+  const int h = bodyH();
+  const int footerH = 23;
+  const int fy = y + h - footerH;
+
+  lcd.fillRect(x, fy, w, footerH, TFT_BLACK);
+  lcd.drawFastHLine(x + 3, fy, w - 6, TFT_DARKGREY);
+  lcd.setTextFont(1);
+  lcd.setTextSize(1);
+  lcd.setTextDatum(TL_DATUM);
+  lcd.setTextColor(TFT_DARKGREY, TFT_BLACK);
+  lcd.drawString("Press Open dir / Download file", x + 4, fy + 3);
+  lcd.drawString("Hold  Download directory", x + 4, fy + 13);
+}

--- a/firmware/src/screens/wifi/network/remote/SftpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SftpClientScreen.cpp
@@ -25,8 +25,11 @@ const char* SftpClientScreen::title() {
       return "SFTP Client";
     case STATE_REMOTE_LOADING:
     case STATE_REMOTE_BROWSER:
+      return _remoteMode == REMOTE_UPLOAD_DEST ? "SFTP Upload" : "SFTP Download";
+    case STATE_LOCAL_BROWSER:
+      return "SFTP Upload";
     case STATE_TRANSFER:
-      return "SFTP Download";
+      return _transferIsUpload ? "SFTP Upload" : "SFTP Download";
     case STATE_ACTION:
     default:
       return "SFTP Client";
@@ -140,7 +143,8 @@ void SftpClientScreen::onUpdate() {
           xSemaphoreGive(_mutex);
         }
         ShowStatusAction::show(err.c_str(), 1500);
-        _state = STATE_REMOTE_BROWSER;
+        _state = (_remoteMode == REMOTE_UPLOAD_DEST)
+               ? STATE_LOCAL_BROWSER : STATE_REMOTE_BROWSER;
         render();
         return;
       }
@@ -152,7 +156,12 @@ void SftpClientScreen::onUpdate() {
 
     if (Uni.Nav->wasPressed() &&
         Uni.Nav->readDirection() == INavigation::DIR_BACK) {
-      _closeConnection(true);
+      if (_remoteMode == REMOTE_UPLOAD_DEST) {
+        _state = STATE_LOCAL_BROWSER;
+        render();
+      } else {
+        _showActions();
+      }
     }
     return;
   }
@@ -169,12 +178,20 @@ void SftpClientScreen::onUpdate() {
       }
       _commandDone = false;
       ProgressView::finish();
-      _state = STATE_REMOTE_BROWSER;
+
+      const bool upload = _transferIsUpload;
+      _state = upload ? STATE_LOCAL_BROWSER : STATE_REMOTE_BROWSER;
       render();
 
-      if (ok) ShowStatusAction::show("Download complete", 1400);
-      else if (err == "Cancelled") ShowStatusAction::show("Download cancelled", 1200);
-      else ShowStatusAction::show(err.length() ? err.c_str() : "Download failed", 1600);
+      if (ok) {
+        ShowStatusAction::show(upload ? "Upload complete" : "Download complete", 1400);
+      } else if (err == "Cancelled") {
+        ShowStatusAction::show(upload ? "Upload cancelled" : "Download cancelled", 1200);
+      } else {
+        ShowStatusAction::show(
+          err.length() ? err.c_str() : (upload ? "Upload failed" : "Download failed"),
+          1600);
+      }
       render();
       return;
     }
@@ -183,6 +200,20 @@ void SftpClientScreen::onUpdate() {
         Uni.Nav->readDirection() == INavigation::DIR_BACK) {
       _cancelTransfer = true;
     }
+    return;
+  }
+
+  if (_state == STATE_LOCAL_BROWSER) {
+    if (Uni.Nav->isPressed() && !_holdHandled &&
+        Uni.Nav->heldDuration() >= HOLD_MS) {
+      _holdHandled = true;
+      Uni.Nav->suppressCurrentPress();
+      _holdLocalUpload(_selectedIndex);
+      return;
+    }
+
+    if (!Uni.Nav->isPressed()) _holdHandled = false;
+    ListScreen::onUpdate();
     return;
   }
 
@@ -220,17 +251,21 @@ void SftpClientScreen::onRender() {
     _renderRemoteBrowser();
     return;
   }
+  if (_state == STATE_LOCAL_BROWSER) {
+    _renderLocalBrowser();
+    return;
+  }
   ListScreen::onRender();
 }
 
 void SftpClientScreen::onItemSelected(uint8_t index) {
   if (_state == STATE_ACTION) {
     if (index == 0) {
+      _remoteMode = REMOTE_DOWNLOAD;
       if (_workerState == WORKER_READY) _requestList(".");
       else                              _beginDownload();
     } else if (index == 1) {
-      ShowStatusAction::show("Upload coming soon", 1300);
-      render();
+      _beginUpload();
     }
     return;
   }
@@ -247,6 +282,11 @@ void SftpClientScreen::onItemSelected(uint8_t index) {
 
   if (_state == STATE_REMOTE_BROWSER) {
     _selectRemote(index);
+    return;
+  }
+
+  if (_state == STATE_LOCAL_BROWSER) {
+    _selectLocalUpload(index);
     return;
   }
 
@@ -300,8 +340,18 @@ void SftpClientScreen::onBack() {
   }
 
   if (_state == STATE_REMOTE_BROWSER) {
-    // BACK from the remote browser returns to the action hub but deliberately
-    // keeps the SSH/SFTP worker and session alive for a subsequent transfer.
+    if (_remoteMode == REMOTE_UPLOAD_DEST) {
+      // Cancel destination selection and return to the local upload browser.
+      _state = STATE_LOCAL_BROWSER;
+      render();
+    } else {
+      // BACK from Download returns to the action hub while keeping the session.
+      _showActions();
+    }
+    return;
+  }
+
+  if (_state == STATE_LOCAL_BROWSER) {
     _showActions();
     return;
   }
@@ -317,11 +367,35 @@ void SftpClientScreen::_showActions() {
 }
 
 void SftpClientScreen::_beginDownload() {
+  _remoteMode = REMOTE_DOWNLOAD;
+
   // Used only when no live SFTP session exists yet.
   _state = STATE_CONFIG;
   _updateLabels();
   _rebuildConfig();
   render();
+}
+
+void SftpClientScreen::_beginUpload() {
+  if (_workerState != WORKER_READY) {
+    _state = STATE_CONFIG;
+    _updateLabels();
+    _rebuildConfig();
+    render();
+    return;
+  }
+
+  if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+    ShowStatusAction::show("Storage not available", 1500);
+    render();
+    return;
+  }
+
+  _uploadLocalPath = "";
+  _uploadName = "";
+  _uploadIsDir = false;
+  _localBrowser.root = "/";
+  _loadLocalUploadDir("/");
 }
 
 void SftpClientScreen::_updateLabels() {
@@ -476,6 +550,69 @@ void SftpClientScreen::_selectKey(uint8_t index) {
   _updateLabels();
   _rebuildConfig();
   render();
+}
+
+
+void SftpClientScreen::_loadLocalUploadDir(const String& path) {
+  _localBrowsePath = path;
+  uint8_t n = _localBrowser.load(this, path, {}, "SD");
+  _state = STATE_LOCAL_BROWSER;
+  setItems(_localBrowser.items(), n);
+  render();
+}
+
+void SftpClientScreen::_selectLocalUpload(uint8_t index) {
+  if (index >= _localBrowser.count()) return;
+  const auto& e = _localBrowser.entry(index);
+
+  if (e.isDir) {
+    _loadLocalUploadDir(e.path);
+    return;
+  }
+
+  _chooseUploadSource(e.path, e.name, false);
+}
+
+void SftpClientScreen::_holdLocalUpload(uint8_t index) {
+  if (index >= _localBrowser.count()) return;
+  const auto& e = _localBrowser.entry(index);
+  if (!e.isDir || e.name == "..") return;
+
+  _chooseUploadSource(e.path, e.name, true);
+}
+
+void SftpClientScreen::_chooseUploadSource(const String& path,
+                                           const String& name,
+                                           bool isDir) {
+  _uploadLocalPath = path;
+  _uploadName = name;
+  _uploadIsDir = isDir;
+  _chooseUploadDestinationMode();
+}
+
+void SftpClientScreen::_chooseUploadDestinationMode() {
+  static const InputSelectAction::Option opts[] = {
+    {"Downloads", "downloads"},
+    {"Browse", "browse"},
+  };
+
+  const char* result = InputSelectAction::popup(
+    "Upload Destination", opts, 2, "downloads");
+
+  if (!result) {
+    _state = STATE_LOCAL_BROWSER;
+    render();
+    return;
+  }
+
+  if (strcmp(result, "downloads") == 0) {
+    // Relative SFTP paths resolve from the connected user's home directory.
+    _chooseUploadDestination("Downloads");
+    return;
+  }
+
+  _remoteMode = REMOTE_UPLOAD_DEST;
+  _requestList(".");
 }
 
 void SftpClientScreen::_connect() {
@@ -702,8 +839,10 @@ void SftpClientScreen::_worker() {
     }
 
     String path;
+    String path2;
     if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
       path = _commandPath;
+      path2 = _commandPath2;
       _commandError = "";
       xSemaphoreGive(_mutex);
     }
@@ -725,6 +864,35 @@ void SftpClientScreen::_worker() {
     } else if (cmd == CMD_DOWNLOAD_DIR) {
       String local = String(DOWNLOAD_DIR) + "/" + _baseName(path);
       ok = _workerDownloadDir((void*)sftp, path, local);
+    } else if (cmd == CMD_UPLOAD_FILE) {
+      if (!_workerEnsureRemoteDir((void*)sftp, path2)) {
+        if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+          _commandError = "Remote directory not found";
+          xSemaphoreGive(_mutex);
+        }
+        ok = false;
+      } else {
+        String remote = path2;
+        if (!remote.endsWith("/")) remote += "/";
+        remote += _baseName(path);
+        fs::File f = Uni.Storage->open(path.c_str(), "r");
+        uint64_t size = f ? (uint64_t)f.size() : 0;
+        if (f) f.close();
+        ok = _workerUploadFile((void*)sftp, path, remote, size);
+      }
+    } else if (cmd == CMD_UPLOAD_DIR) {
+      if (!_workerEnsureRemoteDir((void*)sftp, path2)) {
+        if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+          _commandError = "Remote directory not found";
+          xSemaphoreGive(_mutex);
+        }
+        ok = false;
+      } else {
+        String remote = path2;
+        if (!remote.endsWith("/")) remote += "/";
+        remote += _baseName(path);
+        ok = _workerUploadDir((void*)sftp, path, remote);
+      }
     }
 
     if (_cancelTransfer && cmd != CMD_LIST) {
@@ -865,6 +1033,17 @@ void SftpClientScreen::_copyRemoteListing() {
   }
 
   uint8_t out = 0;
+
+  if (_remoteMode == REMOTE_UPLOAD_DEST) {
+    _remoteNames[out] = ".";
+    _remoteSubs[out] = "UPLOAD HERE";
+    _remotePaths[out] = _remotePath;
+    _remoteIsDir[out] = true;
+    _remoteSizes[out] = 0;
+    _remoteItems[out] = {_remoteNames[out].c_str(), _remoteSubs[out].c_str()};
+    out++;
+  }
+
   if (_remotePath != ".") {
     _remoteNames[out] = "..";
     _remoteSubs[out] = "DIR";
@@ -875,7 +1054,7 @@ void SftpClientScreen::_copyRemoteListing() {
     out++;
   }
 
-  for (uint8_t i = 0; i < count && out < MAX_REMOTE_ENTRIES + 1; ++i, ++out) {
+  for (uint8_t i = 0; i < count && out < MAX_REMOTE_ENTRIES + 2; ++i, ++out) {
     _remoteNames[out] = temp[i].name;
     _remotePaths[out] = temp[i].path;
     _remoteIsDir[out] = temp[i].isDir;
@@ -906,6 +1085,17 @@ void SftpClientScreen::_copyRemoteListing() {
 void SftpClientScreen::_selectRemote(uint8_t index) {
   if (index >= _remoteCount) return;
 
+  if (_remoteMode == REMOTE_UPLOAD_DEST) {
+    // "." is the synthetic UPLOAD HERE action for the current directory.
+    // PRESS executes it directly; PRESS on a real directory still navigates.
+    if (_remoteNames[index] == ".") {
+      _chooseUploadDestination(_remotePaths[index]);
+    } else if (_remoteIsDir[index]) {
+      _requestList(_remotePaths[index]);
+    }
+    return;
+  }
+
   if (_remoteIsDir[index]) {
     _requestList(_remotePaths[index]);
     return;
@@ -921,6 +1111,13 @@ void SftpClientScreen::_selectRemote(uint8_t index) {
 
 void SftpClientScreen::_holdRemote(uint8_t index) {
   if (index >= _remoteCount || !_remoteIsDir[index]) return;
+
+  if (_remoteMode == REMOTE_UPLOAD_DEST) {
+    if (_remoteNames[index] == "..") return;
+    _chooseUploadDestination(_remotePaths[index]);
+    return;
+  }
+
   if (_remoteNames[index] == "..") return;
 
   if (!_confirmTransfer("Download directory?", _remoteNames[index])) {
@@ -929,6 +1126,16 @@ void SftpClientScreen::_holdRemote(uint8_t index) {
   }
 
   _requestDownload(_remotePaths[index], true);
+}
+
+void SftpClientScreen::_chooseUploadDestination(const String& remoteDir) {
+  if (!_confirmTransfer(_uploadIsDir ? "Upload directory?" : "Upload file?",
+                        _uploadName)) {
+    render();
+    return;
+  }
+
+  _requestUpload(remoteDir);
 }
 
 bool SftpClientScreen::_confirmTransfer(const char* title, const String& name) {
@@ -942,12 +1149,19 @@ bool SftpClientScreen::_confirmTransfer(const char* title, const String& name) {
   // InputSelectAction renders its title as a single-line overlay heading.
   // Do not embed the selected filename/directory with a newline here; doing so
   // produces visual artifacts on the UG display.
+  // File-browser screens may leave a different LCD font selected. Normalize it
+  // before opening the popup so its title/options render consistently.
+  Uni.Lcd.setTextFont(1);
+  Uni.Lcd.setTextSize(1);
+  Uni.Lcd.setTextDatum(TL_DATUM);
+
   const char* result = InputSelectAction::popup(
-    title, opts, 2, "no");
+    title, opts, 2, "yes");
   return result && strcmp(result, "yes") == 0;
 }
 
 void SftpClientScreen::_requestDownload(const String& remotePath, bool directory) {
+  _transferIsUpload = false;
   if (!Uni.Storage || !Uni.Storage->isAvailable()) {
     ShowStatusAction::show("Storage not available", 1500);
     render();
@@ -979,6 +1193,38 @@ void SftpClientScreen::_requestDownload(const String& remotePath, bool directory
   ProgressView::init();
   ProgressView::progress(
     directory ? "Preparing directory..." : _progressName.c_str(), 0);
+}
+
+
+void SftpClientScreen::_requestUpload(const String& remoteDir) {
+  if (!_uploadLocalPath.length()) {
+    ShowStatusAction::show("Upload source missing", 1200);
+    render();
+    return;
+  }
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _commandPath = _uploadLocalPath;
+    _commandPath2 = remoteDir;
+    _commandError = "";
+    _progressDone = 0;
+    _progressTotal = 0;
+    _progressFilesDone = 0;
+    _progressFilesTotal = 0;
+    _progressName = _uploadName;
+    xSemaphoreGive(_mutex);
+  }
+
+  _transferIsUpload = true;
+  _cancelTransfer = false;
+  _commandDone = false;
+  _commandOk = false;
+  _command = _uploadIsDir ? CMD_UPLOAD_DIR : CMD_UPLOAD_FILE;
+  _state = STATE_TRANSFER;
+
+  ProgressView::init();
+  ProgressView::progress(
+    _uploadIsDir ? "Preparing directory..." : _uploadName.c_str(), 0);
 }
 
 void SftpClientScreen::_updateTransferProgress() {
@@ -1191,6 +1437,221 @@ bool SftpClientScreen::_workerDownloadDir(void* sftpOpaque,
   return _workerDownloadTree(sftpOpaque, remotePath, localPath, 0);
 }
 
+
+bool SftpClientScreen::_workerEnsureRemoteDir(void* sftpOpaque,
+                                               const String& remotePath) {
+  sftp_session sftp = (sftp_session)sftpOpaque;
+  sftp_attributes a = sftp_stat(sftp, remotePath.c_str());
+  if (a) {
+    bool isDir = (a->type == SSH_FILEXFER_TYPE_DIRECTORY);
+    sftp_attributes_free(a);
+    return isDir;
+  }
+
+  if (sftp_mkdir(sftp, remotePath.c_str(), 0755) == SSH_OK) return true;
+
+  // Some servers return failure when the path appeared concurrently. Recheck.
+  a = sftp_stat(sftp, remotePath.c_str());
+  if (!a) return false;
+  bool isDir = (a->type == SSH_FILEXFER_TYPE_DIRECTORY);
+  sftp_attributes_free(a);
+  return isDir;
+}
+
+bool SftpClientScreen::_workerUploadFile(void* sftpOpaque,
+                                         const String& localPath,
+                                         const String& remotePath,
+                                         uint64_t knownSize) {
+  sftp_session sftp = (sftp_session)sftpOpaque;
+
+  fs::File local = Uni.Storage->open(localPath.c_str(), "r");
+  if (!local) {
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      _commandError = "Local file open failed";
+      xSemaphoreGive(_mutex);
+    }
+    return false;
+  }
+
+  sftp_file remote = sftp_open(
+    sftp, remotePath.c_str(), O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  if (!remote) {
+    local.close();
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      _commandError = "Remote file open failed";
+      xSemaphoreGive(_mutex);
+    }
+    return false;
+  }
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+    if (_progressTotal == 0) _progressTotal = knownSize;
+    _progressName = _baseName(localPath);
+    xSemaphoreGive(_mutex);
+  }
+
+  uint8_t buf[4096];
+  bool ok = true;
+
+  while (!_stopRequested && !_cancelTransfer) {
+    size_t n = local.read(buf, sizeof(buf));
+    if (n == 0) break;
+
+    size_t sent = 0;
+    while (sent < n && !_stopRequested && !_cancelTransfer) {
+      ssize_t w = sftp_write(remote, buf + sent, n - sent);
+      if (w <= 0) {
+        ok = false;
+        if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+          _commandError = "SFTP write failed";
+          xSemaphoreGive(_mutex);
+        }
+        break;
+      }
+      sent += (size_t)w;
+
+      if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+        _progressDone += (uint64_t)w;
+        xSemaphoreGive(_mutex);
+      }
+    }
+
+    if (!ok) break;
+  }
+
+  sftp_close(remote);
+  local.close();
+
+  if (_cancelTransfer || _stopRequested) return false;
+
+  if (ok && _mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+    _progressFilesDone++;
+    xSemaphoreGive(_mutex);
+  }
+  return ok;
+}
+
+bool SftpClientScreen::_workerCalcLocalDir(const String& localPath,
+                                            uint64_t& bytes,
+                                            uint32_t& files,
+                                            int depth) {
+  if (depth > 12 || _cancelTransfer || _stopRequested) return false;
+
+  fs::File dir = Uni.Storage->open(localPath.c_str(), "r");
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    return false;
+  }
+
+  bool ok = true;
+  fs::File child = dir.openNextFile();
+  while (child && !_cancelTransfer && !_stopRequested) {
+    String name = _baseName(String(child.name()));
+    String childPath = localPath;
+    if (!childPath.endsWith("/")) childPath += "/";
+    childPath += name;
+
+    if (child.isDirectory()) {
+      child.close();
+      if (!_workerCalcLocalDir(childPath, bytes, files, depth + 1)) {
+        ok = false;
+        break;
+      }
+    } else {
+      bytes += (uint64_t)child.size();
+      files++;
+      child.close();
+    }
+    child = dir.openNextFile();
+  }
+  if (child) child.close();
+  dir.close();
+
+  return ok && !_cancelTransfer && !_stopRequested;
+}
+
+bool SftpClientScreen::_workerUploadTree(void* sftpOpaque,
+                                         const String& localPath,
+                                         const String& remotePath,
+                                         int depth) {
+  if (depth > 12 || _cancelTransfer || _stopRequested) return false;
+  if (!_workerEnsureRemoteDir(sftpOpaque, remotePath)) {
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      _commandError = "Remote mkdir failed";
+      xSemaphoreGive(_mutex);
+    }
+    return false;
+  }
+
+  fs::File dir = Uni.Storage->open(localPath.c_str(), "r");
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    return false;
+  }
+
+  bool ok = true;
+  fs::File child = dir.openNextFile();
+  while (child && !_cancelTransfer && !_stopRequested) {
+    String name = _baseName(String(child.name()));
+    String localChild = localPath;
+    if (!localChild.endsWith("/")) localChild += "/";
+    localChild += name;
+
+    String remoteChild = remotePath;
+    if (!remoteChild.endsWith("/")) remoteChild += "/";
+    remoteChild += name;
+
+    if (child.isDirectory()) {
+      child.close();
+      if (!_workerUploadTree(
+            sftpOpaque, localChild, remoteChild, depth + 1)) {
+        ok = false;
+        break;
+      }
+    } else {
+      uint64_t size = (uint64_t)child.size();
+      child.close();
+      if (!_workerUploadFile(
+            sftpOpaque, localChild, remoteChild, size)) {
+        ok = false;
+        break;
+      }
+    }
+    child = dir.openNextFile();
+  }
+  if (child) child.close();
+  dir.close();
+
+  return ok && !_cancelTransfer && !_stopRequested;
+}
+
+bool SftpClientScreen::_workerUploadDir(void* sftpOpaque,
+                                        const String& localPath,
+                                        const String& remotePath) {
+  uint64_t totalBytes = 0;
+  uint32_t totalFiles = 0;
+
+  if (!_workerCalcLocalDir(localPath, totalBytes, totalFiles, 0)) {
+    if (!_cancelTransfer && _mutex &&
+        xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      _commandError = "Directory scan failed";
+      xSemaphoreGive(_mutex);
+    }
+    return false;
+  }
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _progressTotal = totalBytes;
+    _progressFilesTotal = totalFiles;
+    _progressDone = 0;
+    _progressFilesDone = 0;
+    _progressName = _baseName(localPath);
+    xSemaphoreGive(_mutex);
+  }
+
+  return _workerUploadTree(sftpOpaque, localPath, remotePath, 0);
+}
+
 String SftpClientScreen::_parentRemotePath(const String& path) const {
   if (path == "." || path.length() == 0) return ".";
   int slash = path.lastIndexOf('/');
@@ -1210,6 +1671,9 @@ String SftpClientScreen::_baseName(const String& path) const {
 
 void SftpClientScreen::_acceptHostKey(bool trust) {
   _hostKeyDecision = trust ? 1 : -1;
+  // Leave WAIT_HOSTKEY immediately on the UI side. Otherwise onUpdate() can
+  // re-open the Trust prompt before the worker observes the decision.
+  _workerState = WORKER_CONNECTING;
   if (trust) {
     _state = STATE_CONNECTING;
   } else {
@@ -1286,22 +1750,11 @@ void SftpClientScreen::_renderHostKeyConfirm() {
 }
 
 void SftpClientScreen::_renderRemoteBrowser() {
+  // Let ListScreen use the full browser body. A manually painted footer here
+  // obscures the last visible rows.
   ListScreen::onRender();
+}
 
-  auto& lcd = Uni.Lcd;
-  const int x = bodyX();
-  const int y = bodyY();
-  const int w = bodyW();
-  const int h = bodyH();
-  const int footerH = 23;
-  const int fy = y + h - footerH;
-
-  lcd.fillRect(x, fy, w, footerH, TFT_BLACK);
-  lcd.drawFastHLine(x + 3, fy, w - 6, TFT_DARKGREY);
-  lcd.setTextFont(1);
-  lcd.setTextSize(1);
-  lcd.setTextDatum(TL_DATUM);
-  lcd.setTextColor(TFT_DARKGREY, TFT_BLACK);
-  lcd.drawString("Press Open dir / Download file", x + 4, fy + 3);
-  lcd.drawString("Hold  Download directory", x + 4, fy + 13);
+void SftpClientScreen::_renderLocalBrowser() {
+  ListScreen::onRender();
 }

--- a/firmware/src/screens/wifi/network/remote/SftpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SftpClientScreen.cpp
@@ -454,8 +454,14 @@ void SftpClientScreen::_configHost() {
     initial = String(ip[0]) + "." + String(ip[1]) + "." + String(ip[2]) + ".";
   }
 
+#ifdef DEVICE_HAS_KEYBOARD
+  const auto hostInputMode = InputTextAction::INPUT_TEXT;
+#else
+  const auto hostInputMode = InputTextAction::INPUT_IP_ADDRESS;
+#endif
+
   String value = InputTextAction::popup(
-    "Host", initial, InputTextAction::INPUT_IP_ADDRESS);
+    "Host", initial, hostInputMode);
   if (!InputTextAction::wasCancelled() && value.length()) _host = value;
 
   _updateLabels();

--- a/firmware/src/screens/wifi/network/remote/SftpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SftpClientScreen.cpp
@@ -520,9 +520,10 @@ void SftpClientScreen::_openKeyPicker() {
 
   Uni.Storage->makeDir("/unigeek");
   Uni.Storage->makeDir("/unigeek/wifi");
-  Uni.Storage->makeDir("/unigeek/wifi/ssh");
+  Uni.Storage->makeDir("/unigeek/wifi/remote");
+  Uni.Storage->makeDir("/unigeek/wifi/remote/ssh");
 
-  _localBrowsePath = "/unigeek/wifi/ssh";
+  _localBrowsePath = "/unigeek/wifi/remote/ssh";
   _localBrowser.root = "/";
   _state = STATE_SELECT_KEY;
   _loadKeyDir(_localBrowsePath);
@@ -1170,7 +1171,8 @@ void SftpClientScreen::_requestDownload(const String& remotePath, bool directory
 
   Uni.Storage->makeDir("/unigeek");
   Uni.Storage->makeDir("/unigeek/wifi");
-  Uni.Storage->makeDir("/unigeek/wifi/sftp");
+  Uni.Storage->makeDir("/unigeek/wifi/remote");
+  Uni.Storage->makeDir("/unigeek/wifi/remote/sftp");
   Uni.Storage->makeDir(DOWNLOAD_DIR);
 
   if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {

--- a/firmware/src/screens/wifi/network/remote/SftpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SftpClientScreen.cpp
@@ -1287,6 +1287,7 @@ bool SftpClientScreen::_workerDownloadFile(void* sftpOpaque,
 
   uint8_t buf[4096];
   bool ok = true;
+  uint64_t received = 0;
 
   while (!_stopRequested && !_cancelTransfer) {
     ssize_t n = sftp_read(remote, buf, sizeof(buf));
@@ -1310,6 +1311,8 @@ bool SftpClientScreen::_workerDownloadFile(void* sftpOpaque,
       break;
     }
 
+    received += written;
+
     if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
       _progressDone += written;
       xSemaphoreGive(_mutex);
@@ -1319,13 +1322,26 @@ bool SftpClientScreen::_workerDownloadFile(void* sftpOpaque,
   local.close();
   sftp_close(remote);
 
-  if (_cancelTransfer || _stopRequested) return false;
+  if (_cancelTransfer || _stopRequested) ok = false;
 
-  if (ok && _mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+  if (ok && knownSize && received != knownSize) {
+    ok = false;
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      _commandError = "Incomplete download";
+      xSemaphoreGive(_mutex);
+    }
+  }
+
+  if (!ok) {
+    Uni.Storage->deleteFile(localPath.c_str());
+    return false;
+  }
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
     _progressFilesDone++;
     xSemaphoreGive(_mutex);
   }
-  return ok;
+  return true;
 }
 
 bool SftpClientScreen::_workerCalcDir(void* sftpOpaque,
@@ -1494,6 +1510,8 @@ bool SftpClientScreen::_workerUploadFile(void* sftpOpaque,
 
   uint8_t buf[4096];
   bool ok = true;
+  uint64_t sentTotal = 0;
+  uint32_t lastProgress = millis();
 
   while (!_stopRequested && !_cancelTransfer) {
     size_t n = local.read(buf, sizeof(buf));
@@ -1502,7 +1520,8 @@ bool SftpClientScreen::_workerUploadFile(void* sftpOpaque,
     size_t sent = 0;
     while (sent < n && !_stopRequested && !_cancelTransfer) {
       ssize_t w = sftp_write(remote, buf + sent, n - sent);
-      if (w <= 0) {
+
+      if (w < 0) {
         ok = false;
         if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
           _commandError = "SFTP write failed";
@@ -1510,7 +1529,23 @@ bool SftpClientScreen::_workerUploadFile(void* sftpOpaque,
         }
         break;
       }
+
+      if (w == 0) {
+        if (millis() - lastProgress >= WRITE_STALL_TIMEOUT_MS) {
+          ok = false;
+          if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+            _commandError = "SFTP write timed out";
+            xSemaphoreGive(_mutex);
+          }
+          break;
+        }
+        vTaskDelay(pdMS_TO_TICKS(2));
+        continue;
+      }
+
       sent += (size_t)w;
+      sentTotal += (uint64_t)w;
+      lastProgress = millis();
 
       if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(10)) == pdTRUE) {
         _progressDone += (uint64_t)w;
@@ -1526,11 +1561,21 @@ bool SftpClientScreen::_workerUploadFile(void* sftpOpaque,
 
   if (_cancelTransfer || _stopRequested) return false;
 
-  if (ok && _mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+  if (ok && knownSize && sentTotal != knownSize) {
+    ok = false;
+    if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+      _commandError = "Incomplete upload";
+      xSemaphoreGive(_mutex);
+    }
+  }
+
+  if (!ok) return false;
+
+  if (_mutex && xSemaphoreTake(_mutex, pdMS_TO_TICKS(20)) == pdTRUE) {
     _progressFilesDone++;
     xSemaphoreGive(_mutex);
   }
-  return ok;
+  return true;
 }
 
 bool SftpClientScreen::_workerCalcLocalDir(const String& localPath,

--- a/firmware/src/screens/wifi/network/remote/SftpClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/SftpClientScreen.h
@@ -1,0 +1,179 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+#include "ui/views/BrowseFileView.h"
+
+class SftpClientScreen : public ListScreen
+{
+public:
+  const char* title() override;
+  bool inhibitPowerOff() override { return _state == STATE_TRANSFER; }
+  ~SftpClientScreen();
+
+  void onInit() override;
+  void onUpdate() override;
+  void onRender() override;
+  void onItemSelected(uint8_t index) override;
+  void onBack() override;
+
+private:
+  enum State : uint8_t {
+    STATE_ACTION,
+    STATE_CONFIG,
+    STATE_SELECT_AUTH,
+    STATE_SELECT_KEY,
+    STATE_CONNECTING,
+    STATE_HOSTKEY_CONFIRM,
+    STATE_REMOTE_LOADING,
+    STATE_REMOTE_BROWSER,
+    STATE_TRANSFER
+  };
+
+  enum AuthMode : uint8_t {
+    AUTH_NONE,
+    AUTH_PASSWORD,
+    AUTH_PRIVATE_KEY
+  };
+
+  enum WorkerState : uint8_t {
+    WORKER_IDLE,
+    WORKER_CONNECTING,
+    WORKER_WAIT_HOSTKEY,
+    WORKER_READY,
+    WORKER_FAILED,
+    WORKER_CLOSED
+  };
+
+  enum WorkerCommand : uint8_t {
+    CMD_NONE,
+    CMD_LIST,
+    CMD_DOWNLOAD_FILE,
+    CMD_DOWNLOAD_DIR
+  };
+
+  struct SharedRemoteEntry {
+    String name;
+    String path;
+    bool isDir = false;
+    uint64_t size = 0;
+  };
+
+  static constexpr uint8_t MAX_REMOTE_ENTRIES = 96;
+  static constexpr uint32_t SFTP_TASK_STACK_SIZE = 28672;
+  static constexpr uint32_t HOLD_MS = 900;
+  static constexpr const char* DOWNLOAD_DIR = "/unigeek/wifi/sftp/downloads";
+
+  State _state = STATE_ACTION;
+  AuthMode _authMode = AUTH_NONE;
+
+  String _host;
+  String _username;
+  String _password;
+  String _keyPath;
+  String _keyData;
+  int _port = 22;
+
+  char _hostLabel[40] = {};
+  char _portLabel[16] = {};
+  char _userLabel[32] = {};
+  char _authLabel[20] = "-";
+  char _passwordLabel[16] = "-";
+  char _keyLabel[32] = {};
+
+  ListItem _actionItems[2] = {
+    {"Download", nullptr},
+    {"Upload", nullptr},
+  };
+  ListItem _configItems[6];
+  ListItem _authItems[2] = {
+    {"Password", nullptr},
+    {"Private Key", nullptr},
+  };
+
+  BrowseFileView _localBrowser;
+  String _localBrowsePath = "/unigeek/wifi/ssh";
+
+  // Remote-browser UI snapshot. The worker writes _sharedEntries; the UI copies
+  // them into these arrays after a LIST command completes.
+  SharedRemoteEntry _sharedEntries[MAX_REMOTE_ENTRIES];
+  uint8_t _sharedEntryCount = 0;
+
+  String _remoteNames[MAX_REMOTE_ENTRIES + 1];
+  String _remoteSubs[MAX_REMOTE_ENTRIES + 1];
+  String _remotePaths[MAX_REMOTE_ENTRIES + 1];
+  bool _remoteIsDir[MAX_REMOTE_ENTRIES + 1] = {};
+  uint64_t _remoteSizes[MAX_REMOTE_ENTRIES + 1] = {};
+  ListItem _remoteItems[MAX_REMOTE_ENTRIES + 1];
+  uint8_t _remoteCount = 0;
+  String _remotePath = ".";
+  bool _holdHandled = false;
+
+  TaskHandle_t _sftpTask = nullptr;
+  SemaphoreHandle_t _mutex = nullptr;
+  volatile WorkerState _workerState = WORKER_IDLE;
+  volatile WorkerCommand _command = CMD_NONE;
+  volatile bool _stopRequested = false;
+  volatile bool _cancelTransfer = false;
+  volatile bool _commandDone = false;
+  volatile bool _commandOk = false;
+
+  String _commandPath;
+  String _commandError;
+  String _hostFingerprint;
+  volatile int8_t _hostKeyDecision = 0; // 0 pending, 1 trust, -1 cancel
+  uint8_t _hostKeySelection = 0;
+
+  uint64_t _progressDone = 0;
+  uint64_t _progressTotal = 0;
+  uint32_t _progressFilesDone = 0;
+  uint32_t _progressFilesTotal = 0;
+  String _progressName;
+
+  void _updateLabels();
+  void _rebuildConfig();
+  void _showActions();
+  void _beginDownload();
+  void _configHost();
+  void _configPort();
+  void _configUsername();
+  void _configPassword();
+  void _selectAuthMenu();
+  void _selectAuth(uint8_t index);
+  void _openKeyPicker();
+  void _loadKeyDir(const String& path);
+  void _selectKey(uint8_t index);
+
+  void _connect();
+  bool _startWorker();
+  static void _workerEntry(void* arg);
+  void _worker();
+  void _setWorkerError(const char* message);
+  void _closeConnection(bool returnToActions = true);
+
+  void _requestList(const String& path);
+  void _copyRemoteListing();
+  void _selectRemote(uint8_t index);
+  void _holdRemote(uint8_t index);
+  String _parentRemotePath(const String& path) const;
+  String _baseName(const String& path) const;
+
+  bool _confirmTransfer(const char* title, const String& name);
+  void _requestDownload(const String& remotePath, bool directory);
+  void _updateTransferProgress();
+
+  void _acceptHostKey(bool trust);
+  void _renderConnecting();
+  void _renderHostKeyConfirm();
+  void _renderRemoteBrowser();
+
+  // Worker-only helpers. libssh/SFTP objects never leave the worker task.
+  bool _workerList(void* sftpOpaque, const String& path);
+  bool _workerDownloadFile(void* sftpOpaque, const String& remotePath,
+                           const String& localPath, uint64_t knownSize);
+  bool _workerDownloadDir(void* sftpOpaque, const String& remotePath,
+                          const String& localPath);
+  bool _workerCalcDir(void* sftpOpaque, const String& remotePath,
+                      uint64_t& bytes, uint32_t& files, int depth);
+  bool _workerDownloadTree(void* sftpOpaque, const String& remotePath,
+                           const String& localPath, int depth);
+};

--- a/firmware/src/screens/wifi/network/remote/SftpClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/SftpClientScreen.h
@@ -26,6 +26,7 @@ private:
     STATE_HOSTKEY_CONFIRM,
     STATE_REMOTE_LOADING,
     STATE_REMOTE_BROWSER,
+    STATE_LOCAL_BROWSER,
     STATE_TRANSFER
   };
 
@@ -48,7 +49,9 @@ private:
     CMD_NONE,
     CMD_LIST,
     CMD_DOWNLOAD_FILE,
-    CMD_DOWNLOAD_DIR
+    CMD_DOWNLOAD_DIR,
+    CMD_UPLOAD_FILE,
+    CMD_UPLOAD_DIR
   };
 
   struct SharedRemoteEntry {
@@ -56,6 +59,11 @@ private:
     String path;
     bool isDir = false;
     uint64_t size = 0;
+  };
+
+  enum RemoteMode : uint8_t {
+    REMOTE_DOWNLOAD,
+    REMOTE_UPLOAD_DEST
   };
 
   static constexpr uint8_t MAX_REMOTE_ENTRIES = 96;
@@ -92,21 +100,26 @@ private:
 
   BrowseFileView _localBrowser;
   String _localBrowsePath = "/unigeek/wifi/ssh";
+  String _uploadLocalPath;
+  String _uploadName;
+  bool _uploadIsDir = false;
 
   // Remote-browser UI snapshot. The worker writes _sharedEntries; the UI copies
   // them into these arrays after a LIST command completes.
   SharedRemoteEntry _sharedEntries[MAX_REMOTE_ENTRIES];
   uint8_t _sharedEntryCount = 0;
 
-  String _remoteNames[MAX_REMOTE_ENTRIES + 1];
-  String _remoteSubs[MAX_REMOTE_ENTRIES + 1];
-  String _remotePaths[MAX_REMOTE_ENTRIES + 1];
-  bool _remoteIsDir[MAX_REMOTE_ENTRIES + 1] = {};
-  uint64_t _remoteSizes[MAX_REMOTE_ENTRIES + 1] = {};
-  ListItem _remoteItems[MAX_REMOTE_ENTRIES + 1];
+  String _remoteNames[MAX_REMOTE_ENTRIES + 2];
+  String _remoteSubs[MAX_REMOTE_ENTRIES + 2];
+  String _remotePaths[MAX_REMOTE_ENTRIES + 2];
+  bool _remoteIsDir[MAX_REMOTE_ENTRIES + 2] = {};
+  uint64_t _remoteSizes[MAX_REMOTE_ENTRIES + 2] = {};
+  ListItem _remoteItems[MAX_REMOTE_ENTRIES + 2];
   uint8_t _remoteCount = 0;
   String _remotePath = ".";
+  RemoteMode _remoteMode = REMOTE_DOWNLOAD;
   bool _holdHandled = false;
+  bool _transferIsUpload = false;
 
   TaskHandle_t _sftpTask = nullptr;
   SemaphoreHandle_t _mutex = nullptr;
@@ -118,6 +131,7 @@ private:
   volatile bool _commandOk = false;
 
   String _commandPath;
+  String _commandPath2;
   String _commandError;
   String _hostFingerprint;
   volatile int8_t _hostKeyDecision = 0; // 0 pending, 1 trust, -1 cancel
@@ -133,6 +147,7 @@ private:
   void _rebuildConfig();
   void _showActions();
   void _beginDownload();
+  void _beginUpload();
   void _configHost();
   void _configPort();
   void _configUsername();
@@ -142,6 +157,12 @@ private:
   void _openKeyPicker();
   void _loadKeyDir(const String& path);
   void _selectKey(uint8_t index);
+
+  void _loadLocalUploadDir(const String& path);
+  void _selectLocalUpload(uint8_t index);
+  void _holdLocalUpload(uint8_t index);
+  void _chooseUploadSource(const String& path, const String& name, bool isDir);
+  void _chooseUploadDestinationMode();
 
   void _connect();
   bool _startWorker();
@@ -154,17 +175,20 @@ private:
   void _copyRemoteListing();
   void _selectRemote(uint8_t index);
   void _holdRemote(uint8_t index);
+  void _chooseUploadDestination(const String& remoteDir);
   String _parentRemotePath(const String& path) const;
   String _baseName(const String& path) const;
 
   bool _confirmTransfer(const char* title, const String& name);
   void _requestDownload(const String& remotePath, bool directory);
+  void _requestUpload(const String& remoteDir);
   void _updateTransferProgress();
 
   void _acceptHostKey(bool trust);
   void _renderConnecting();
   void _renderHostKeyConfirm();
   void _renderRemoteBrowser();
+  void _renderLocalBrowser();
 
   // Worker-only helpers. libssh/SFTP objects never leave the worker task.
   bool _workerList(void* sftpOpaque, const String& path);
@@ -176,4 +200,13 @@ private:
                       uint64_t& bytes, uint32_t& files, int depth);
   bool _workerDownloadTree(void* sftpOpaque, const String& remotePath,
                            const String& localPath, int depth);
+  bool _workerUploadFile(void* sftpOpaque, const String& localPath,
+                         const String& remotePath, uint64_t knownSize);
+  bool _workerUploadDir(void* sftpOpaque, const String& localPath,
+                        const String& remotePath);
+  bool _workerCalcLocalDir(const String& localPath,
+                           uint64_t& bytes, uint32_t& files, int depth);
+  bool _workerUploadTree(void* sftpOpaque, const String& localPath,
+                         const String& remotePath, int depth);
+  bool _workerEnsureRemoteDir(void* sftpOpaque, const String& remotePath);
 };

--- a/firmware/src/screens/wifi/network/remote/SftpClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/SftpClientScreen.h
@@ -69,6 +69,7 @@ private:
   static constexpr uint8_t MAX_REMOTE_ENTRIES = 96;
   static constexpr uint32_t SFTP_TASK_STACK_SIZE = 28672;
   static constexpr uint32_t HOLD_MS = 900;
+  static constexpr uint32_t WRITE_STALL_TIMEOUT_MS = 12000;
   static constexpr const char* DOWNLOAD_DIR = "/unigeek/wifi/remote/sftp/downloads";
 
   State _state = STATE_ACTION;

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
@@ -1006,6 +1006,9 @@ void SshClientScreen::_renderConnecting() {
 
 void SshClientScreen::_acceptHostKey(bool trust) {
   _hostKeyDecision = trust ? 1 : -1;
+  // Leave WAIT_HOSTKEY immediately on the UI side. Otherwise onUpdate() can
+  // re-open the Trust prompt before the worker observes the decision.
+  _workerState = WORKER_CONNECTING;
 
   if (trust) {
     _state = STATE_CONNECTING;

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
@@ -364,9 +364,10 @@ void SshClientScreen::_openKeyPicker() {
   // explicitly because not every storage backend creates parent directories.
   Uni.Storage->makeDir("/unigeek");
   Uni.Storage->makeDir("/unigeek/wifi");
-  Uni.Storage->makeDir("/unigeek/wifi/ssh");
+  Uni.Storage->makeDir("/unigeek/wifi/remote");
+  Uni.Storage->makeDir("/unigeek/wifi/remote/ssh");
 
-  _browsePath = "/unigeek/wifi/ssh";
+  _browsePath = "/unigeek/wifi/remote/ssh";
   _browser.root = "/";
   _state = STATE_SELECT_KEY;
   _loadKeyDir(_browsePath);

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
@@ -34,12 +34,42 @@ void SshClientScreen::onInit() {
 }
 
 void SshClientScreen::onUpdate() {
+  if (_state == STATE_HOSTKEY_CONFIRM) {
+    if (!Uni.Nav->wasPressed()) return;
+
+    auto dir = Uni.Nav->readDirection();
+    if (dir == INavigation::DIR_BACK) {
+      _acceptHostKey(false);
+      return;
+    }
+
+    if (dir == INavigation::DIR_UP || dir == INavigation::DIR_DOWN ||
+        dir == INavigation::DIR_LEFT || dir == INavigation::DIR_RIGHT) {
+      _hostKeySelection = (_hostKeySelection == 0) ? 1 : 0;
+      render();
+      return;
+    }
+
+    if (dir == INavigation::DIR_PRESS) {
+      _acceptHostKey(_hostKeySelection == 0);
+      return;
+    }
+    return;
+  }
+
   if (_state == STATE_SELECT_AUTH || _state == STATE_SELECT_KEY) {
     ListScreen::onUpdate();
     return;
   }
 
   if (_state == STATE_CONNECTING) {
+    if (_workerState == WORKER_WAIT_HOSTKEY) {
+      _hostKeySelection = 0;
+      _state = STATE_HOSTKEY_CONFIRM;
+      render();
+      return;
+    }
+
     if (_workerState == WORKER_RUNNING) {
       _password = "";
       _keyData = "";
@@ -137,6 +167,10 @@ void SshClientScreen::onRender() {
     _renderConnecting();
     return;
   }
+  if (_state == STATE_HOSTKEY_CONFIRM) {
+    _renderHostKeyConfirm();
+    return;
+  }
   _renderOutput();
 }
 
@@ -157,8 +191,9 @@ void SshClientScreen::onItemSelected(uint8_t index) {
     case 2: _configUsername(); break;
     case 3: _auth();           break;
     case 4:
-      if (_authMode == AUTH_PRIVATE_KEY) _openKeyPicker();
-      else                               _connect();
+      if (_authMode == AUTH_PASSWORD)          _configPassword();
+      else if (_authMode == AUTH_PRIVATE_KEY)  _openKeyPicker();
+      else                                     _connect();
       break;
     case 5: _connect();        break;
     default: break;
@@ -166,6 +201,11 @@ void SshClientScreen::onItemSelected(uint8_t index) {
 }
 
 void SshClientScreen::onBack() {
+  if (_state == STATE_HOSTKEY_CONFIRM) {
+    _acceptHostKey(false);
+    return;
+  }
+
   if (_state == STATE_CONNECTING) {
     _stopRequested = true;
     return;
@@ -191,11 +231,15 @@ void SshClientScreen::_updateLabels() {
   else                         _username.toCharArray(_userLabel, sizeof(_userLabel));
 
   if (_authMode == AUTH_PASSWORD) {
-    snprintf(_authLabel, sizeof(_authLabel), "%s",
-             _password.length() > 0 ? "Password *" : "Password");
-  } else {
+    snprintf(_authLabel, sizeof(_authLabel), "Password");
+  } else if (_authMode == AUTH_PRIVATE_KEY) {
     snprintf(_authLabel, sizeof(_authLabel), "Private Key");
+  } else {
+    snprintf(_authLabel, sizeof(_authLabel), "-");
   }
+
+  snprintf(_passwordLabel, sizeof(_passwordLabel), "%s",
+           _password.length() > 0 ? "********" : "-");
 
   if (_keyPath.length() == 0) {
     snprintf(_keyLabel, sizeof(_keyLabel), "-");
@@ -213,9 +257,13 @@ void SshClientScreen::_rebuildItems() {
   _items[0] = {"Host", _hostLabel};
   _items[1] = {"Port", _portLabel};
   _items[2] = {"Username", _userLabel};
-  _items[3] = {"Auth", _authLabel};
+  _items[3] = {"Auth Method", _authLabel};
 
-  if (_authMode == AUTH_PRIVATE_KEY) {
+  if (_authMode == AUTH_PASSWORD) {
+    _items[4] = {"Password", _passwordLabel};
+    _items[5] = {"Connect", nullptr};
+    setItems(_items, 6, min<uint8_t>(sel, 5));
+  } else if (_authMode == AUTH_PRIVATE_KEY) {
     _items[4] = {"Key File", _keyLabel};
     _items[5] = {"Connect", nullptr};
     setItems(_items, 6, min<uint8_t>(sel, 5));
@@ -261,9 +309,27 @@ void SshClientScreen::_configUsername() {
   render();
 }
 
+void SshClientScreen::_configPassword() {
+  String value = InputTextAction::popup(
+    "Password", "", InputTextAction::INPUT_TEXT);
+
+  if (!InputTextAction::wasCancelled()) {
+    _password = value;
+  }
+
+  _selectedIndex = 4;
+  _updateLabels();
+  _rebuildItems();
+  render();
+}
+
 void SshClientScreen::_auth() {
   _state = STATE_SELECT_AUTH;
-  setItems(_authItems, 2, _authMode == AUTH_PRIVATE_KEY ? 1 : 0);
+
+  // If no method has been chosen yet, start on Password without making it the
+  // active method until the user actually confirms the selection.
+  uint8_t selected = (_authMode == AUTH_PRIVATE_KEY) ? 1 : 0;
+  setItems(_authItems, 2, selected);
   render();
 }
 
@@ -278,6 +344,9 @@ void SshClientScreen::_selectAuth(uint8_t index) {
     _password = "";
   }
 
+  // Return to CONFIG with Auth still selected. The submenu index (0/1) must not
+  // leak into the main menu selection, otherwise CONFIG jumps to Host/Port.
+  _selectedIndex = 3;
   _state = STATE_CONFIG;
   _updateLabels();
   _rebuildItems();
@@ -348,6 +417,12 @@ void SshClientScreen::_connect() {
     return;
   }
 
+  if (_authMode == AUTH_NONE) {
+    ShowStatusAction::show("Auth method required", 1500);
+    render();
+    return;
+  }
+
   if (_authMode == AUTH_PASSWORD) {
     if (_password.length() == 0) {
       String value = InputTextAction::popup("Password", "", InputTextAction::INPUT_TEXT);
@@ -399,11 +474,13 @@ bool SshClientScreen::_startSshWorker() {
 
   _stopRequested = false;
   _workerState = WORKER_CONNECTING;
+  _hostKeyDecision = 0;
 
   if (xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
     _workerRx = "";
     _workerTx = "";
     _workerError = "";
+    _hostFingerprint = "";
     xSemaphoreGive(_ioMutex);
   }
 
@@ -469,6 +546,60 @@ void SshClientScreen::_sshWorker() {
   if (ssh_connect(session) != SSH_OK) {
     _setWorkerError("SSH connect failed");
     goto cleanup;
+  }
+
+  if (_stopRequested) goto cleanup;
+
+  // Present the server identity before sending any user credential.
+  {
+    ssh_key serverKey = nullptr;
+    unsigned char* hash = nullptr;
+    size_t hashLen = 0;
+
+    if (ssh_get_server_publickey(session, &serverKey) != SSH_OK || !serverKey) {
+      if (serverKey) ssh_key_free(serverKey);
+      _setWorkerError("SSH host key failed");
+      goto cleanup;
+    }
+
+    int rc = ssh_get_publickey_hash(
+      serverKey, SSH_PUBLICKEY_HASH_SHA256, &hash, &hashLen);
+    ssh_key_free(serverKey);
+
+    if (rc != SSH_OK || !hash || hashLen == 0) {
+      if (hash) ssh_clean_pubkey_hash(&hash);
+      _setWorkerError("SSH fingerprint failed");
+      goto cleanup;
+    }
+
+    char* hex = ssh_get_hexa(hash, hashLen);
+    ssh_clean_pubkey_hash(&hash);
+
+    if (!hex) {
+      _setWorkerError("SSH fingerprint failed");
+      goto cleanup;
+    }
+
+    if (_ioMutex && xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+      _hostFingerprint = "SHA256 ";
+      _hostFingerprint += hex;
+      xSemaphoreGive(_ioMutex);
+    }
+    ssh_string_free_char(hex);
+
+    _hostKeyDecision = 0;
+    _workerState = WORKER_WAIT_HOSTKEY;
+
+    while (!_stopRequested && _hostKeyDecision == 0) {
+      vTaskDelay(pdMS_TO_TICKS(20));
+    }
+
+    if (_stopRequested || _hostKeyDecision < 0) {
+      _workerState = WORKER_CLOSED;
+      goto cleanup;
+    }
+
+    _workerState = WORKER_CONNECTING;
   }
 
   if (_stopRequested) goto cleanup;
@@ -620,6 +751,7 @@ cleanup:
 
 void SshClientScreen::_closeConnection(bool returnToConfig) {
   _stopRequested = true;
+  _hostKeyDecision = -1;
 
   // When the session is already running, the worker is non-blocking and should
   // exit promptly. Avoid deleting it from the UI task because libssh objects
@@ -870,6 +1002,80 @@ void SshClientScreen::_renderConnecting() {
   String msg = "Connecting to " + _host + ":" + String(_port) + "...";
   lcd.drawString(msg.c_str(), x + w / 2, y + h / 2);
   lcd.setTextDatum(TL_DATUM);
+}
+
+void SshClientScreen::_acceptHostKey(bool trust) {
+  _hostKeyDecision = trust ? 1 : -1;
+
+  if (trust) {
+    _state = STATE_CONNECTING;
+    render();
+  } else {
+    _stopRequested = true;
+    _state = STATE_CONNECTING;
+    render();
+  }
+}
+
+void SshClientScreen::_renderHostKeyConfirm() {
+  auto& lcd = Uni.Lcd;
+  const int x = bodyX();
+  const int y = bodyY();
+  const int w = bodyW();
+  const int h = bodyH();
+
+  lcd.fillRect(x, y, w, h, TFT_BLACK);
+  lcd.setTextFont(1);
+  lcd.setTextSize(1);
+  lcd.setTextDatum(TL_DATUM);
+
+  int cy = y + PAD;
+
+  lcd.setTextColor(TFT_YELLOW, TFT_BLACK);
+  lcd.drawString("SSH Host Key", x + PAD, cy);
+  cy += 12;
+
+  lcd.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+  String hostLine = _host + ":" + String(_port);
+  lcd.drawString(hostLine.c_str(), x + PAD, cy);
+  cy += 12;
+
+  lcd.drawFastHLine(x + PAD, cy, w - PAD * 2, TFT_DARKGREY);
+  cy += 5;
+
+  String fingerprint;
+  if (_ioMutex && xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+    fingerprint = _hostFingerprint;
+    xSemaphoreGive(_ioMutex);
+  }
+
+  // 6 px per character with font 1. Wrap the SHA-256 fingerprint so the entire
+  // server identity remains visible even on narrow screens.
+  const int charsPerLine = max(8, (w - PAD * 2) / 6);
+  int pos = 0;
+  while (pos < (int)fingerprint.length() && cy < y + h - 34) {
+    String line = fingerprint.substring(pos, min(pos + charsPerLine,
+                                                 (int)fingerprint.length()));
+    lcd.drawString(line.c_str(), x + PAD, cy);
+    pos += charsPerLine;
+    cy += 10;
+  }
+
+  const int buttonY = y + h - 27;
+  const int buttonW = (w - PAD * 3) / 2;
+
+  auto drawButton = [&](int bx, const char* label, bool selected) {
+    uint16_t border = selected ? TFT_YELLOW : TFT_DARKGREY;
+    uint16_t text   = selected ? TFT_WHITE  : TFT_LIGHTGREY;
+    lcd.drawRoundRect(bx, buttonY, buttonW, 20, 3, border);
+    lcd.setTextDatum(MC_DATUM);
+    lcd.setTextColor(text, TFT_BLACK);
+    lcd.drawString(label, bx + buttonW / 2, buttonY + 10);
+    lcd.setTextDatum(TL_DATUM);
+  };
+
+  drawButton(x + PAD, "Trust", _hostKeySelection == 0);
+  drawButton(x + PAD * 2 + buttonW, "Cancel", _hostKeySelection == 1);
 }
 
 void SshClientScreen::_renderOutput() {

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
@@ -34,9 +34,15 @@ void SshClientScreen::onInit() {
 }
 
 void SshClientScreen::onUpdate() {
+  if (_state == STATE_SELECT_AUTH || _state == STATE_SELECT_KEY) {
+    ListScreen::onUpdate();
+    return;
+  }
+
   if (_state == STATE_CONNECTING) {
     if (_workerState == WORKER_RUNNING) {
       _password = "";
+      _keyData = "";
       _clearOutput();
       _remoteClosed = false;
       _state = STATE_OUTPUT;
@@ -52,6 +58,7 @@ void SshClientScreen::onUpdate() {
         xSemaphoreGive(_ioMutex);
       }
       _password = "";
+      _keyData = "";
       _workerState = WORKER_IDLE;
       _state = STATE_CONFIG;
       ShowStatusAction::show(error.c_str(), 1800);
@@ -61,6 +68,7 @@ void SshClientScreen::onUpdate() {
 
     if (_workerState == WORKER_CLOSED) {
       _password = "";
+      _keyData = "";
       _workerState = WORKER_IDLE;
       _state = STATE_CONFIG;
       _updateLabels();
@@ -121,7 +129,7 @@ void SshClientScreen::onUpdate() {
 }
 
 void SshClientScreen::onRender() {
-  if (_state == STATE_CONFIG) {
+  if (_state == STATE_CONFIG || _state == STATE_SELECT_AUTH || _state == STATE_SELECT_KEY) {
     ListScreen::onRender();
     return;
   }
@@ -133,12 +141,26 @@ void SshClientScreen::onRender() {
 }
 
 void SshClientScreen::onItemSelected(uint8_t index) {
+  if (_state == STATE_SELECT_AUTH) {
+    _selectAuth(index);
+    return;
+  }
+
+  if (_state == STATE_SELECT_KEY) {
+    _selectKey(index);
+    return;
+  }
+
   switch (index) {
     case 0: _configHost();     break;
     case 1: _configPort();     break;
     case 2: _configUsername(); break;
     case 3: _auth();           break;
-    case 4: _connect();        break;
+    case 4:
+      if (_authMode == AUTH_PRIVATE_KEY) _openKeyPicker();
+      else                               _connect();
+      break;
+    case 5: _connect();        break;
     default: break;
   }
 }
@@ -148,6 +170,15 @@ void SshClientScreen::onBack() {
     _stopRequested = true;
     return;
   }
+
+  if (_state == STATE_SELECT_AUTH || _state == STATE_SELECT_KEY) {
+    _state = STATE_CONFIG;
+    _updateLabels();
+    _rebuildItems();
+    render();
+    return;
+  }
+
   if (_state == STATE_OUTPUT) _closeConnection(true);
   else Screen.goBack();
 }
@@ -159,8 +190,20 @@ void SshClientScreen::_updateLabels() {
   if (_username.length() == 0) snprintf(_userLabel, sizeof(_userLabel), "-");
   else                         _username.toCharArray(_userLabel, sizeof(_userLabel));
 
-  snprintf(_authLabel, sizeof(_authLabel), "%s",
-           _password.length() > 0 ? "Password *" : "Password");
+  if (_authMode == AUTH_PASSWORD) {
+    snprintf(_authLabel, sizeof(_authLabel), "%s",
+             _password.length() > 0 ? "Password *" : "Password");
+  } else {
+    snprintf(_authLabel, sizeof(_authLabel), "Private Key");
+  }
+
+  if (_keyPath.length() == 0) {
+    snprintf(_keyLabel, sizeof(_keyLabel), "-");
+  } else {
+    int slash = _keyPath.lastIndexOf('/');
+    String keyName = (slash >= 0) ? _keyPath.substring(slash + 1) : _keyPath;
+    keyName.toCharArray(_keyLabel, sizeof(_keyLabel));
+  }
 
   snprintf(_portLabel, sizeof(_portLabel), "%d", _port);
 }
@@ -171,8 +214,15 @@ void SshClientScreen::_rebuildItems() {
   _items[1] = {"Port", _portLabel};
   _items[2] = {"Username", _userLabel};
   _items[3] = {"Auth", _authLabel};
-  _items[4] = {"Connect", nullptr};
-  setItems(_items, 5, sel);
+
+  if (_authMode == AUTH_PRIVATE_KEY) {
+    _items[4] = {"Key File", _keyLabel};
+    _items[5] = {"Connect", nullptr};
+    setItems(_items, 6, min<uint8_t>(sel, 5));
+  } else {
+    _items[4] = {"Connect", nullptr};
+    setItems(_items, 5, min<uint8_t>(sel, 4));
+  }
 }
 
 void SshClientScreen::_configHost() {
@@ -212,12 +262,67 @@ void SshClientScreen::_configUsername() {
 }
 
 void SshClientScreen::_auth() {
-  String value = InputTextAction::popup("Password", "", InputTextAction::INPUT_TEXT);
-  if (!InputTextAction::wasCancelled()) {
-    _password = value;
-    _updateLabels();
-    _rebuildItems();
+  _state = STATE_SELECT_AUTH;
+  setItems(_authItems, 2, _authMode == AUTH_PRIVATE_KEY ? 1 : 0);
+  render();
+}
+
+void SshClientScreen::_selectAuth(uint8_t index) {
+  if (index > 1) return;
+
+  _authMode = (index == 0) ? AUTH_PASSWORD : AUTH_PRIVATE_KEY;
+
+  if (_authMode == AUTH_PASSWORD) {
+    _keyData = "";
+  } else {
+    _password = "";
   }
+
+  _state = STATE_CONFIG;
+  _updateLabels();
+  _rebuildItems();
+  render();
+}
+
+void SshClientScreen::_openKeyPicker() {
+  if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+    ShowStatusAction::show("Storage not available", 1500);
+    render();
+    return;
+  }
+
+  // Keep SSH keys under the Wi-Fi subtree by default. Create each level
+  // explicitly because not every storage backend creates parent directories.
+  Uni.Storage->makeDir("/unigeek");
+  Uni.Storage->makeDir("/unigeek/wifi");
+  Uni.Storage->makeDir("/unigeek/wifi/ssh");
+
+  _browsePath = "/unigeek/wifi/ssh";
+  _browser.root = "/";
+  _state = STATE_SELECT_KEY;
+  _loadKeyDir(_browsePath);
+}
+
+void SshClientScreen::_loadKeyDir(const String& path) {
+  _browsePath = path;
+  uint8_t n = _browser.load(this, path, {}, "KEY");
+  setItems(_browser.items(), n);
+  render();
+}
+
+void SshClientScreen::_selectKey(uint8_t index) {
+  if (index >= _browser.count()) return;
+
+  const auto& entry = _browser.entry(index);
+  if (entry.isDir) {
+    _loadKeyDir(entry.path);
+    return;
+  }
+
+  _keyPath = entry.path;
+  _state = STATE_CONFIG;
+  _updateLabels();
+  _rebuildItems();
   render();
 }
 
@@ -243,13 +348,32 @@ void SshClientScreen::_connect() {
     return;
   }
 
-  if (_password.length() == 0) {
-    String value = InputTextAction::popup("Password", "", InputTextAction::INPUT_TEXT);
-    if (InputTextAction::wasCancelled()) {
+  if (_authMode == AUTH_PASSWORD) {
+    if (_password.length() == 0) {
+      String value = InputTextAction::popup("Password", "", InputTextAction::INPUT_TEXT);
+      if (InputTextAction::wasCancelled()) {
+        render();
+        return;
+      }
+      _password = value;
+    }
+  } else {
+    if (_keyPath.length() == 0) {
+      ShowStatusAction::show("Key file required", 1500);
       render();
       return;
     }
-    _password = value;
+    if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+      ShowStatusAction::show("Storage not available", 1500);
+      render();
+      return;
+    }
+    _keyData = Uni.Storage->readFile(_keyPath.c_str());
+    if (_keyData.length() == 0) {
+      ShowStatusAction::show("Key read failed", 1500);
+      render();
+      return;
+    }
   }
 
   if (!_ioMutex) _ioMutex = xSemaphoreCreateMutex();
@@ -260,6 +384,7 @@ void SshClientScreen::_connect() {
 
   if (!_startSshWorker()) {
     _password = "";
+    _keyData = "";
     ShowStatusAction::show("SSH task failed", 1500);
     render();
     return;
@@ -320,6 +445,8 @@ void SshClientScreen::_sshWorker() {
   String host = _host;
   String user = _username;
   String password = _password;
+  String keyData = _keyData;
+  AuthMode authMode = _authMode;
   int port = _port;
   int cols = _terminalCols();
   int rows = _terminalRows();
@@ -346,13 +473,51 @@ void SshClientScreen::_sshWorker() {
 
   if (_stopRequested) goto cleanup;
 
-  if (ssh_userauth_password(session, nullptr, password.c_str()) != SSH_AUTH_SUCCESS) {
-    _setWorkerError("SSH authentication failed");
-    goto cleanup;
+  if (authMode == AUTH_PASSWORD) {
+    if (ssh_userauth_password(session, nullptr, password.c_str()) != SSH_AUTH_SUCCESS) {
+      _setWorkerError("SSH authentication failed");
+      goto cleanup;
+    }
+  } else {
+    ssh_key privateKey = nullptr;
+    ssh_key publicKey = nullptr;
+
+    int rc = ssh_pki_import_privkey_base64(
+      keyData.c_str(), nullptr, nullptr, nullptr, &privateKey);
+    if (rc != SSH_OK || !privateKey) {
+      if (privateKey) ssh_key_free(privateKey);
+      _setWorkerError("SSH key import failed");
+      goto cleanup;
+    }
+
+    rc = ssh_pki_export_privkey_to_pubkey(privateKey, &publicKey);
+    if (rc != SSH_OK || !publicKey) {
+      if (publicKey) ssh_key_free(publicKey);
+      ssh_key_free(privateKey);
+      _setWorkerError("SSH public key failed");
+      goto cleanup;
+    }
+
+    rc = ssh_userauth_try_publickey(session, nullptr, publicKey);
+    if (rc != SSH_AUTH_SUCCESS) {
+      ssh_key_free(publicKey);
+      ssh_key_free(privateKey);
+      _setWorkerError("SSH key not accepted");
+      goto cleanup;
+    }
+
+    rc = ssh_userauth_publickey(session, nullptr, privateKey);
+    ssh_key_free(publicKey);
+    ssh_key_free(privateKey);
+
+    if (rc != SSH_AUTH_SUCCESS) {
+      _setWorkerError("SSH key auth failed");
+      goto cleanup;
+    }
   }
 
-  // Clear the worker's private copy as soon as authentication is complete.
   password = "";
+  keyData = "";
 
   channel = ssh_channel_new(session);
   if (!channel || ssh_channel_open_session(channel) != SSH_OK) {
@@ -448,6 +613,7 @@ cleanup:
   }
 
   password = "";
+  keyData = "";
   _sshTask = nullptr;
   vTaskDelete(nullptr);
 }
@@ -464,6 +630,7 @@ void SshClientScreen::_closeConnection(bool returnToConfig) {
   }
 
   _password = "";
+  _keyData = "";
   _remoteClosed = false;
 
   if (returnToConfig) {

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
@@ -1,0 +1,95 @@
+#include "SshClientScreen.h"
+
+#include "core/ScreenManager.h"
+#include "ui/actions/InputTextAction.h"
+#include "ui/actions/InputNumberAction.h"
+#include "ui/actions/ShowStatusAction.h"
+#include <WiFi.h>
+
+void SshClientScreen::onInit() {
+  _updateLabels();
+  _rebuildItems();
+}
+
+void SshClientScreen::onItemSelected(uint8_t index) {
+  switch (index) {
+    case 0: _configHost();     break;
+    case 1: _configPort();     break;
+    case 2: _configUsername(); break;
+    case 3: _auth();           break;
+    case 4: _connect();        break;
+    default: break;
+  }
+}
+
+void SshClientScreen::onBack() {
+  Screen.goBack();
+}
+
+void SshClientScreen::_updateLabels() {
+  if (_host.length() == 0) snprintf(_hostLabel, sizeof(_hostLabel), "tap to set");
+  else                     _host.toCharArray(_hostLabel, sizeof(_hostLabel));
+
+  if (_username.length() == 0) snprintf(_userLabel, sizeof(_userLabel), "tap to set");
+  else                         _username.toCharArray(_userLabel, sizeof(_userLabel));
+
+  snprintf(_portLabel, sizeof(_portLabel), "%d", _port);
+}
+
+void SshClientScreen::_rebuildItems() {
+  uint8_t sel = _selectedIndex;
+  _items[0] = {"Host", _hostLabel};
+  _items[1] = {"Port", _portLabel};
+  _items[2] = {"Username", _userLabel};
+  _items[3] = {"Auth", _authLabel};
+  _items[4] = {"Connect", nullptr};
+  setItems(_items, 5, sel);
+}
+
+void SshClientScreen::_configHost() {
+  String initial = _host;
+  if (initial.length() == 0 && WiFi.status() == WL_CONNECTED) {
+    IPAddress ip = WiFi.localIP();
+    initial = String(ip[0]) + "." + String(ip[1]) + "." + String(ip[2]) + ".";
+  }
+
+  String value = InputTextAction::popup("Host", initial, InputTextAction::INPUT_IP_ADDRESS);
+  if (!InputTextAction::wasCancelled() && value.length() > 0) {
+    _host = value;
+    _updateLabels();
+    _rebuildItems();
+  }
+  render();
+}
+
+void SshClientScreen::_configPort() {
+  int value = InputNumberAction::popup("Port", 1, 65535, _port);
+  if (!InputNumberAction::wasCancelled()) {
+    _port = value;
+    _updateLabels();
+    _rebuildItems();
+  }
+  render();
+}
+
+void SshClientScreen::_configUsername() {
+  String value = InputTextAction::popup("Username", _username, InputTextAction::INPUT_TEXT);
+  if (!InputTextAction::wasCancelled() && value.length() > 0) {
+    _username = value;
+    _updateLabels();
+    _rebuildItems();
+  }
+  render();
+}
+
+void SshClientScreen::_auth() {
+  // TODO: Password / Private Key selection once the libssh integration is added.
+  ShowStatusAction::show("SSH Auth: TODO", 1200);
+  render();
+}
+
+void SshClientScreen::_connect() {
+  // TODO: libssh session, host-key verification, authentication, PTY and shell.
+  ShowStatusAction::show("SSH Client: TODO", 1200);
+  render();
+}

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
@@ -674,8 +674,9 @@ void SshClientScreen::_sshWorker() {
     bool activity = false;
     char buf[256];
 
-    // TX queue: UI only appends complete commands, so moving the whole String is
-    // enough and keeps libssh calls entirely inside this worker.
+    // TX queue: move complete commands out of the shared String, then keep
+    // retrying a temporarily non-writable channel. A zero-byte write is not an
+    // error in non-blocking mode and must not silently discard the tail.
     String tx;
     if (_ioMutex && xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(10)) == pdTRUE) {
       if (_workerTx.length() > 0) {
@@ -687,21 +688,35 @@ void SshClientScreen::_sshWorker() {
 
     if (tx.length() > 0) {
       int sent = 0;
+      uint32_t lastProgress = millis();
+
       while (sent < (int)tx.length() && !_stopRequested) {
         int n = ssh_channel_write(channel, tx.c_str() + sent, tx.length() - sent);
         if (n == SSH_ERROR) {
           _setWorkerError("SSH write failed");
           goto cleanup;
         }
-        if (n <= 0) break;
-        sent += n;
+
+        if (n > 0) {
+          sent += n;
+          lastProgress = millis();
+          activity = true;
+          continue;
+        }
+
+        if (millis() - lastProgress >= WRITE_STALL_TIMEOUT_MS) {
+          _setWorkerError("SSH write timed out");
+          goto cleanup;
+        }
+        vTaskDelay(pdMS_TO_TICKS(2));
       }
-      activity = true;
     }
 
-    for (int stream = 0; stream <= 1; ++stream) {
-      while (!_stopRequested) {
-        int n = ssh_channel_read_nonblocking(channel, buf, sizeof(buf), stream);
+    int rxThisLoop = 0;
+    for (int stream = 0; stream <= 1 && rxThisLoop < MAX_RX_PER_WORKER_LOOP; ++stream) {
+      while (!_stopRequested && rxThisLoop < MAX_RX_PER_WORKER_LOOP) {
+        int room = min<int>(sizeof(buf), MAX_RX_PER_WORKER_LOOP - rxThisLoop);
+        int n = ssh_channel_read_nonblocking(channel, buf, room, stream);
         if (n == SSH_ERROR) {
           _setWorkerError("SSH read failed");
           goto cleanup;
@@ -716,6 +731,8 @@ void SshClientScreen::_sshWorker() {
           _workerRx.concat(buf, n);
           xSemaphoreGive(_ioMutex);
         }
+
+        rxThisLoop += n;
         activity = true;
       }
     }
@@ -789,9 +806,22 @@ void SshClientScreen::_sendCommand(const String& command) {
   String outgoing = command;
   outgoing += "\r\n";
 
+  bool queued = false;
+  bool queueFull = false;
+
   if (xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
-    _workerTx += outgoing;
+    if ((int)_workerTx.length() + (int)outgoing.length() <= MAX_SHARED_TX_CHARS) {
+      _workerTx += outgoing;
+      queued = true;
+    } else {
+      queueFull = true;
+    }
     xSemaphoreGive(_ioMutex);
+  }
+
+  if (!queued) {
+    _pushOutputLine(queueFull ? "[Send queue full]" : "[Send queue busy]");
+    render();
   }
 }
 

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
@@ -280,7 +280,13 @@ void SshClientScreen::_configHost() {
     initial = String(ip[0]) + "." + String(ip[1]) + "." + String(ip[2]) + ".";
   }
 
-  String value = InputTextAction::popup("Host", initial, InputTextAction::INPUT_IP_ADDRESS);
+#ifdef DEVICE_HAS_KEYBOARD
+  const auto hostInputMode = InputTextAction::INPUT_TEXT;
+#else
+  const auto hostInputMode = InputTextAction::INPUT_IP_ADDRESS;
+#endif
+
+  String value = InputTextAction::popup("Host", initial, hostInputMode);
   if (!InputTextAction::wasCancelled() && value.length() > 0) {
     _host = value;
     _updateLabels();

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
@@ -1,14 +1,135 @@
 #include "SshClientScreen.h"
 
+#include "core/Device.h"
+#include "core/INavigation.h"
 #include "core/ScreenManager.h"
 #include "ui/actions/InputTextAction.h"
 #include "ui/actions/InputNumberAction.h"
 #include "ui/actions/ShowStatusAction.h"
+
 #include <WiFi.h>
+#include <libssh/libssh.h>
+
+SshClientScreen::~SshClientScreen() {
+  _closeConnection(false);
+
+  // The worker owns libssh objects. Do not destroy synchronization primitives
+  // until it has finished its cleanup.
+  uint32_t start = millis();
+  while (_sshTask && millis() - start < 3000) {
+    delay(10);
+  }
+
+  if (_ioMutex && !_sshTask) {
+    vSemaphoreDelete(_ioMutex);
+    _ioMutex = nullptr;
+  }
+}
 
 void SshClientScreen::onInit() {
+  _outputView.setWrapMode(TextScrollView::WRAP_CHARACTER);
+  if (!_ioMutex) _ioMutex = xSemaphoreCreateMutex();
   _updateLabels();
   _rebuildItems();
+}
+
+void SshClientScreen::onUpdate() {
+  if (_state == STATE_CONNECTING) {
+    if (_workerState == WORKER_RUNNING) {
+      _password = "";
+      _clearOutput();
+      _remoteClosed = false;
+      _state = STATE_OUTPUT;
+      _followOutput = true;
+      render();
+      return;
+    }
+
+    if (_workerState == WORKER_FAILED) {
+      String error = "SSH connection failed";
+      if (_ioMutex && xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+        if (_workerError.length() > 0) error = _workerError;
+        xSemaphoreGive(_ioMutex);
+      }
+      _password = "";
+      _workerState = WORKER_IDLE;
+      _state = STATE_CONFIG;
+      ShowStatusAction::show(error.c_str(), 1800);
+      render();
+      return;
+    }
+
+    if (_workerState == WORKER_CLOSED) {
+      _password = "";
+      _workerState = WORKER_IDLE;
+      _state = STATE_CONFIG;
+      _updateLabels();
+      _rebuildItems();
+      render();
+      return;
+    }
+
+    if (Uni.Nav->wasPressed() && Uni.Nav->readDirection() == INavigation::DIR_BACK) {
+      // Request cancellation, but stay in CONNECTING until the worker has
+      // actually released its libssh objects.
+      _stopRequested = true;
+    }
+    return;
+  }
+
+  if (_state == STATE_CONFIG) {
+    ListScreen::onUpdate();
+    return;
+  }
+
+  _drainWorkerRx();
+
+  if (!_remoteClosed && (_workerState == WORKER_CLOSED || _workerState == WORKER_FAILED)) {
+    _remoteClosed = true;
+    if (_partialLine.length() > 0) _commitPartial();
+
+    if (_workerState == WORKER_FAILED) {
+      String error = "SSH session error";
+      if (_ioMutex && xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+        if (_workerError.length() > 0) error = _workerError;
+        xSemaphoreGive(_ioMutex);
+      }
+      _pushOutputLine("[" + error + "]");
+    } else {
+      _pushOutputLine("[Connection closed]");
+    }
+    render();
+  }
+
+  if (!Uni.Nav->wasPressed()) return;
+  auto dir = Uni.Nav->readDirection();
+
+  if (dir == INavigation::DIR_BACK) {
+    _closeConnection(true);
+    return;
+  }
+
+  if (dir == INavigation::DIR_PRESS && !_remoteClosed) {
+    _openCommandInput();
+    return;
+  }
+
+  if (dir == INavigation::DIR_UP || dir == INavigation::DIR_DOWN ||
+      dir == INavigation::DIR_LEFT || dir == INavigation::DIR_RIGHT) {
+    if (_outputView.onNav(dir)) _followOutput = _outputView.isAtBottom();
+  }
+}
+
+void SshClientScreen::onRender() {
+  if (_state == STATE_CONFIG) {
+    ListScreen::onRender();
+    return;
+  }
+  if (_state == STATE_CONNECTING) {
+    _renderConnecting();
+    return;
+  }
+  _renderOutput();
 }
 
 void SshClientScreen::onItemSelected(uint8_t index) {
@@ -23,15 +144,23 @@ void SshClientScreen::onItemSelected(uint8_t index) {
 }
 
 void SshClientScreen::onBack() {
-  Screen.goBack();
+  if (_state == STATE_CONNECTING) {
+    _stopRequested = true;
+    return;
+  }
+  if (_state == STATE_OUTPUT) _closeConnection(true);
+  else Screen.goBack();
 }
 
 void SshClientScreen::_updateLabels() {
-  if (_host.length() == 0) snprintf(_hostLabel, sizeof(_hostLabel), "tap to set");
+  if (_host.length() == 0) snprintf(_hostLabel, sizeof(_hostLabel), "-");
   else                     _host.toCharArray(_hostLabel, sizeof(_hostLabel));
 
-  if (_username.length() == 0) snprintf(_userLabel, sizeof(_userLabel), "tap to set");
+  if (_username.length() == 0) snprintf(_userLabel, sizeof(_userLabel), "-");
   else                         _username.toCharArray(_userLabel, sizeof(_userLabel));
+
+  snprintf(_authLabel, sizeof(_authLabel), "%s",
+           _password.length() > 0 ? "Password *" : "Password");
 
   snprintf(_portLabel, sizeof(_portLabel), "%d", _port);
 }
@@ -83,13 +212,535 @@ void SshClientScreen::_configUsername() {
 }
 
 void SshClientScreen::_auth() {
-  // TODO: Password / Private Key selection once the libssh integration is added.
-  ShowStatusAction::show("SSH Auth: TODO", 1200);
+  String value = InputTextAction::popup("Password", "", InputTextAction::INPUT_TEXT);
+  if (!InputTextAction::wasCancelled()) {
+    _password = value;
+    _updateLabels();
+    _rebuildItems();
+  }
   render();
 }
 
 void SshClientScreen::_connect() {
-  // TODO: libssh session, host-key verification, authentication, PTY and shell.
-  ShowStatusAction::show("SSH Client: TODO", 1200);
+  if (_host.length() == 0) {
+    ShowStatusAction::show("Host required", 1200);
+    render();
+    return;
+  }
+  if (_username.length() == 0) {
+    ShowStatusAction::show("Username required", 1200);
+    render();
+    return;
+  }
+  if (_port < 1 || _port > 65535) {
+    ShowStatusAction::show("Port required", 1200);
+    render();
+    return;
+  }
+  if (WiFi.status() != WL_CONNECTED) {
+    ShowStatusAction::show("WiFi not connected", 1500);
+    render();
+    return;
+  }
+
+  if (_password.length() == 0) {
+    String value = InputTextAction::popup("Password", "", InputTextAction::INPUT_TEXT);
+    if (InputTextAction::wasCancelled()) {
+      render();
+      return;
+    }
+    _password = value;
+  }
+
+  if (!_ioMutex) _ioMutex = xSemaphoreCreateMutex();
+  if (!_ioMutex) {
+    ShowStatusAction::show("SSH mutex failed", 1500);
+    return;
+  }
+
+  if (!_startSshWorker()) {
+    _password = "";
+    ShowStatusAction::show("SSH task failed", 1500);
+    render();
+    return;
+  }
+
+  _state = STATE_CONNECTING;
   render();
+}
+
+bool SshClientScreen::_startSshWorker() {
+  if (_sshTask) return false;
+
+  _stopRequested = false;
+  _workerState = WORKER_CONNECTING;
+
+  if (xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _workerRx = "";
+    _workerTx = "";
+    _workerError = "";
+    xSemaphoreGive(_ioMutex);
+  }
+
+  BaseType_t ok;
+#if defined(SOC_CPU_CORES_NUM) && SOC_CPU_CORES_NUM > 1
+  ok = xTaskCreatePinnedToCore(
+    _sshWorkerEntry, "UG SSH", SSH_TASK_STACK_SIZE, this, 1, &_sshTask, 1);
+#else
+  ok = xTaskCreate(
+    _sshWorkerEntry, "UG SSH", SSH_TASK_STACK_SIZE, this, 1, &_sshTask);
+#endif
+
+  if (ok != pdPASS) {
+    _sshTask = nullptr;
+    _workerState = WORKER_IDLE;
+    return false;
+  }
+  return true;
+}
+
+void SshClientScreen::_sshWorkerEntry(void* arg) {
+  static_cast<SshClientScreen*>(arg)->_sshWorker();
+}
+
+void SshClientScreen::_setWorkerError(const char* message) {
+  if (_ioMutex && xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+    _workerError = message ? message : "SSH failed";
+    xSemaphoreGive(_ioMutex);
+  }
+  _workerState = WORKER_FAILED;
+}
+
+void SshClientScreen::_sshWorker() {
+  ssh_session session = nullptr;
+  ssh_channel channel = nullptr;
+
+  // Copy connection settings before entering libssh. The CONFIG UI is no longer
+  // editable while STATE_CONNECTING is active.
+  String host = _host;
+  String user = _username;
+  String password = _password;
+  int port = _port;
+  int cols = _terminalCols();
+  int rows = _terminalRows();
+
+  session = ssh_new();
+  if (!session) {
+    _setWorkerError("SSH session failed");
+    goto cleanup;
+  }
+
+  if (ssh_options_set(session, SSH_OPTIONS_HOST, host.c_str()) != SSH_OK ||
+      ssh_options_set(session, SSH_OPTIONS_USER, user.c_str()) != SSH_OK ||
+      ssh_options_set(session, SSH_OPTIONS_PORT, &port) != SSH_OK) {
+    _setWorkerError("SSH options failed");
+    goto cleanup;
+  }
+
+  if (_stopRequested) goto cleanup;
+
+  if (ssh_connect(session) != SSH_OK) {
+    _setWorkerError("SSH connect failed");
+    goto cleanup;
+  }
+
+  if (_stopRequested) goto cleanup;
+
+  if (ssh_userauth_password(session, nullptr, password.c_str()) != SSH_AUTH_SUCCESS) {
+    _setWorkerError("SSH authentication failed");
+    goto cleanup;
+  }
+
+  // Clear the worker's private copy as soon as authentication is complete.
+  password = "";
+
+  channel = ssh_channel_new(session);
+  if (!channel || ssh_channel_open_session(channel) != SSH_OK) {
+    _setWorkerError("SSH channel failed");
+    goto cleanup;
+  }
+
+  if (ssh_channel_request_pty_size(channel, "vt100", cols, rows) != SSH_OK) {
+    _setWorkerError("SSH PTY failed");
+    goto cleanup;
+  }
+
+  if (ssh_channel_request_shell(channel) != SSH_OK) {
+    _setWorkerError("SSH shell failed");
+    goto cleanup;
+  }
+
+  ssh_set_blocking(session, 0);
+  _workerState = WORKER_RUNNING;
+
+  while (!_stopRequested) {
+    bool activity = false;
+    char buf[256];
+
+    // TX queue: UI only appends complete commands, so moving the whole String is
+    // enough and keeps libssh calls entirely inside this worker.
+    String tx;
+    if (_ioMutex && xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+      if (_workerTx.length() > 0) {
+        tx = _workerTx;
+        _workerTx = "";
+      }
+      xSemaphoreGive(_ioMutex);
+    }
+
+    if (tx.length() > 0) {
+      int sent = 0;
+      while (sent < (int)tx.length() && !_stopRequested) {
+        int n = ssh_channel_write(channel, tx.c_str() + sent, tx.length() - sent);
+        if (n == SSH_ERROR) {
+          _setWorkerError("SSH write failed");
+          goto cleanup;
+        }
+        if (n <= 0) break;
+        sent += n;
+      }
+      activity = true;
+    }
+
+    for (int stream = 0; stream <= 1; ++stream) {
+      while (!_stopRequested) {
+        int n = ssh_channel_read_nonblocking(channel, buf, sizeof(buf), stream);
+        if (n == SSH_ERROR) {
+          _setWorkerError("SSH read failed");
+          goto cleanup;
+        }
+        if (n <= 0) break;
+
+        if (_ioMutex && xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(20)) == pdTRUE) {
+          if ((int)_workerRx.length() + n > MAX_SHARED_RX_CHARS) {
+            int drop = (int)_workerRx.length() + n - MAX_SHARED_RX_CHARS;
+            _workerRx.remove(0, min(drop, (int)_workerRx.length()));
+          }
+          _workerRx.concat(buf, n);
+          xSemaphoreGive(_ioMutex);
+        }
+        activity = true;
+      }
+    }
+
+    if (!ssh_is_connected(session) || !ssh_channel_is_open(channel) ||
+        ssh_channel_is_eof(channel)) {
+      break;
+    }
+
+    if (!activity) vTaskDelay(pdMS_TO_TICKS(10));
+  }
+
+  if (_workerState != WORKER_FAILED) _workerState = WORKER_CLOSED;
+
+cleanup:
+  if (channel) {
+    ssh_channel_send_eof(channel);
+    ssh_channel_close(channel);
+    ssh_channel_free(channel);
+    channel = nullptr;
+  }
+
+  if (session) {
+    ssh_disconnect(session);
+    ssh_free(session);
+    session = nullptr;
+  }
+
+  password = "";
+  _sshTask = nullptr;
+  vTaskDelete(nullptr);
+}
+
+void SshClientScreen::_closeConnection(bool returnToConfig) {
+  _stopRequested = true;
+
+  // When the session is already running, the worker is non-blocking and should
+  // exit promptly. Avoid deleting it from the UI task because libssh objects
+  // belong exclusively to the worker.
+  uint32_t start = millis();
+  while (_sshTask && _workerState == WORKER_RUNNING && millis() - start < 500) {
+    delay(5);
+  }
+
+  _password = "";
+  _remoteClosed = false;
+
+  if (returnToConfig) {
+    _state = STATE_CONFIG;
+    _updateLabels();
+    _rebuildItems();
+    render();
+  }
+}
+
+void SshClientScreen::_openCommandInput() {
+  String command = InputTextAction::popup("Command", "", InputTextAction::INPUT_TEXT);
+
+  if (!InputTextAction::wasCancelled()) _sendCommand(command);
+
+  _drainWorkerRx();
+  render();
+}
+
+void SshClientScreen::_sendCommand(const String& command) {
+  if (_remoteClosed || _workerState != WORKER_RUNNING || !_ioMutex) return;
+
+  String outgoing = command;
+  outgoing += "\r\n";
+
+  if (xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(50)) == pdTRUE) {
+    _workerTx += outgoing;
+    xSemaphoreGive(_ioMutex);
+  }
+}
+
+void SshClientScreen::_drainWorkerRx() {
+  if (!_ioMutex) return;
+
+  String data;
+  if (xSemaphoreTake(_ioMutex, pdMS_TO_TICKS(10)) == pdTRUE) {
+    if (_workerRx.length() > 0) {
+      data = _workerRx;
+      _workerRx = "";
+    }
+    xSemaphoreGive(_ioMutex);
+  }
+
+  if (data.length() == 0) return;
+
+  for (int i = 0; i < (int)data.length(); ++i) {
+    _appendByte((uint8_t)data[i]);
+  }
+  render();
+}
+
+void SshClientScreen::_appendByte(uint8_t c) {
+  switch (_ansiState) {
+    case ANSI_ESC:
+      _ansiParams = "";
+      if (c == '[')      _ansiState = ANSI_CSI;
+      else if (c == ']') _ansiState = ANSI_OSC;
+      else               _ansiState = ANSI_DATA;
+      return;
+
+    case ANSI_CSI:
+      if (c >= 0x40 && c <= 0x7e) {
+        _handleAnsiCsi(c);
+        _ansiState = ANSI_DATA;
+        _ansiParams = "";
+      } else if (_ansiParams.length() < 24 &&
+                 ((c >= '0' && c <= '9') || c == ';' || c == '?' || c == '>')) {
+        _ansiParams += (char)c;
+      }
+      return;
+
+    case ANSI_OSC:
+      if (c == 0x07)      _ansiState = ANSI_DATA;
+      else if (c == 0x1b) _ansiState = ANSI_OSC_ESC;
+      return;
+
+    case ANSI_OSC_ESC:
+      _ansiState = (c == '\\') ? ANSI_DATA : ANSI_OSC;
+      return;
+
+    case ANSI_DATA:
+    default:
+      if (c == 0x1b) {
+        _ansiState = ANSI_ESC;
+        return;
+      }
+      break;
+  }
+
+  if (c == '\r') {
+    _lineCursor = 0;
+    return;
+  }
+
+  if (c == '\n') {
+    _commitPartial();
+    return;
+  }
+
+  if (c == '\b' || c == 0x7f) {
+    if (_lineCursor > 0) _lineCursor--;
+    return;
+  }
+
+  if (c == '\t') {
+    int spaces = 8 - (_lineCursor % 8);
+    while (spaces-- > 0) _putLineChar(' ');
+  } else if (c >= 0x20 && c <= 0x7e) {
+    _putLineChar((char)c);
+  }
+
+  if ((int)_partialLine.length() >= MAX_PARTIAL_LEN) _commitPartial();
+}
+
+void SshClientScreen::_putLineChar(char c) {
+  if (_lineCursor < 0) _lineCursor = 0;
+  if (_lineCursor > (int)_partialLine.length()) {
+    while ((int)_partialLine.length() < _lineCursor) _partialLine += ' ';
+  }
+
+  if (_lineCursor < (int)_partialLine.length())
+    _partialLine.setCharAt(_lineCursor, c);
+  else
+    _partialLine += c;
+
+  _lineCursor++;
+}
+
+int SshClientScreen::_ansiParam(int index, int defaultValue) const {
+  int current = 0;
+  int value = 0;
+  bool haveDigit = false;
+
+  for (int i = 0; i <= (int)_ansiParams.length(); i++) {
+    char c = (i < (int)_ansiParams.length()) ? _ansiParams[i] : ';';
+    if (c >= '0' && c <= '9') {
+      value = value * 10 + (c - '0');
+      haveDigit = true;
+    } else if (c == ';') {
+      if (current == index) return haveDigit ? value : defaultValue;
+      current++;
+      value = 0;
+      haveDigit = false;
+    }
+  }
+  return defaultValue;
+}
+
+void SshClientScreen::_handleAnsiCsi(uint8_t finalByte) {
+  int n = _ansiParam(0, 1);
+  if (n < 1) n = 1;
+
+  switch (finalByte) {
+    case 'm':
+      break;
+    case 'C':
+      _lineCursor = min((int)_partialLine.length(), _lineCursor + n);
+      break;
+    case 'D':
+      _lineCursor = max(0, _lineCursor - n);
+      break;
+    case 'G':
+      _lineCursor = max(0, n - 1);
+      if (_lineCursor > MAX_PARTIAL_LEN) _lineCursor = MAX_PARTIAL_LEN;
+      break;
+    case 'K': {
+      int mode = _ansiParam(0, 0);
+      if (mode == 2) {
+        _partialLine = "";
+        _lineCursor = 0;
+      } else if (mode == 1) {
+        int upto = min(_lineCursor + 1, (int)_partialLine.length());
+        for (int i = 0; i < upto; i++) _partialLine.setCharAt(i, ' ');
+      } else if (_lineCursor < (int)_partialLine.length()) {
+        _partialLine.remove(_lineCursor);
+      }
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+void SshClientScreen::_commitPartial() {
+  _pushOutputLine(_partialLine);
+  _partialLine = "";
+  _lineCursor = 0;
+}
+
+void SshClientScreen::_pushOutputLine(const String& line) {
+  _transcript += line;
+  _transcript += '\n';
+  _trimTranscript();
+}
+
+void SshClientScreen::_trimTranscript() {
+  if ((int)_transcript.length() <= MAX_TRANSCRIPT_CHARS) return;
+  int excess = (int)_transcript.length() - MAX_TRANSCRIPT_CHARS;
+  int cut = _transcript.indexOf('\n', excess);
+  if (cut >= 0) _transcript.remove(0, cut + 1);
+  else          _transcript.remove(0, excess);
+}
+
+void SshClientScreen::_clearOutput() {
+  _transcript = "";
+  _partialLine = "";
+  _lineCursor = 0;
+  _ansiParams = "";
+  _ansiState = ANSI_DATA;
+  _followOutput = true;
+  _outputView.setContent("");
+}
+
+int SshClientScreen::_terminalCols() {
+  const int textW = max(1, bodyW() - 3 - 8);
+  return max(8, textW / 6);
+}
+
+int SshClientScreen::_terminalRows() {
+  const int outputH = max(1, bodyH() - PAD - 11 - 4 - FOOTER_H - 2);
+  return max(1, outputH / 11);
+}
+
+void SshClientScreen::_renderConnecting() {
+  auto& lcd = Uni.Lcd;
+  const int x = bodyX();
+  const int y = bodyY();
+  const int w = bodyW();
+  const int h = bodyH();
+
+  lcd.fillRect(x, y, w, h, TFT_BLACK);
+  lcd.setTextFont(1);
+  lcd.setTextSize(1);
+  lcd.setTextDatum(MC_DATUM);
+  lcd.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+
+  String msg = "Connecting to " + _host + ":" + String(_port) + "...";
+  lcd.drawString(msg.c_str(), x + w / 2, y + h / 2);
+  lcd.setTextDatum(TL_DATUM);
+}
+
+void SshClientScreen::_renderOutput() {
+  auto& lcd = Uni.Lcd;
+  const int x = bodyX();
+  const int y = bodyY();
+  const int w = bodyW();
+  const int h = bodyH();
+
+  lcd.fillRect(x, y, w, h, TFT_BLACK);
+  lcd.setTextFont(1);
+  lcd.setTextSize(1);
+  lcd.setTextDatum(TL_DATUM);
+
+  int cy = y + PAD;
+
+  lcd.setTextColor(TFT_GREEN, TFT_BLACK);
+  String connected = "Connected to " + _host + ":" + String(_port);
+  lcd.drawString(connected.c_str(), x + PAD, cy);
+  cy += 11;
+
+  lcd.drawFastHLine(x + PAD, cy, w - PAD * 2, TFT_DARKGREY);
+  cy += 4;
+
+  const int footerY = y + h - FOOTER_H;
+  const int outputBottom = footerY - 2;
+
+  String display = _transcript;
+  if (_partialLine.length() > 0) display += _partialLine;
+  if (display.length() == 0 && !_remoteClosed) display = "Waiting for data...";
+
+  _outputView.updateContent(display, _followOutput);
+  _outputView.render(x, cy, w, max(1, outputBottom - cy));
+
+  lcd.drawFastHLine(x + PAD, footerY - 2, w - PAD * 2, TFT_DARKGREY);
+  lcd.setTextDatum(MC_DATUM);
+  lcd.setTextColor(TFT_DARKGREY, TFT_BLACK);
+  lcd.drawString(_remoteClosed ? "BACK: Exit" : "PRESS: Cmd | BACK: Exit",
+                 x + w / 2, footerY + FOOTER_H / 2 - 1);
+  lcd.setTextDatum(TL_DATUM);
 }

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.cpp
@@ -11,6 +11,9 @@
 #include <libssh/libssh.h>
 
 SshClientScreen::~SshClientScreen() {
+#ifdef DEVICE_HAS_KEYBOARD
+  if (Uni.Nav) Uni.Nav->setSuppressKeys(false);
+#endif
   _closeConnection(false);
 
   // The worker owns libssh objects. Do not destroy synchronization primitives
@@ -77,6 +80,10 @@ void SshClientScreen::onUpdate() {
       _remoteClosed = false;
       _state = STATE_OUTPUT;
       _followOutput = true;
+      _inputLine.clear();
+#ifdef DEVICE_HAS_KEYBOARD
+      if (Uni.Nav) Uni.Nav->setSuppressKeys(true);
+#endif
       render();
       return;
     }
@@ -139,6 +146,11 @@ void SshClientScreen::onUpdate() {
     render();
   }
 
+#ifdef DEVICE_HAS_KEYBOARD
+  _handleTerminalInput();
+  if (_state != STATE_OUTPUT) return;
+#endif
+
   if (!Uni.Nav->wasPressed()) return;
   auto dir = Uni.Nav->readDirection();
 
@@ -148,7 +160,9 @@ void SshClientScreen::onUpdate() {
   }
 
   if (dir == INavigation::DIR_PRESS && !_remoteClosed) {
+#ifndef DEVICE_HAS_KEYBOARD
     _openCommandInput();
+#endif
     return;
   }
 
@@ -774,6 +788,10 @@ cleanup:
 }
 
 void SshClientScreen::_closeConnection(bool returnToConfig) {
+#ifdef DEVICE_HAS_KEYBOARD
+  if (Uni.Nav) Uni.Nav->setSuppressKeys(false);
+#endif
+  _inputLine.clear();
   _stopRequested = true;
   _hostKeyDecision = -1;
 
@@ -798,12 +816,59 @@ void SshClientScreen::_closeConnection(bool returnToConfig) {
 }
 
 void SshClientScreen::_openCommandInput() {
-  String command = InputTextAction::popup("Command", "", InputTextAction::INPUT_TEXT);
+#ifdef DEVICE_HAS_KEYBOARD
+  return;
+#else
+  String command = InputTextAction::popup(
+    "Command", _inputLine.text(), InputTextAction::INPUT_TEXT);
 
-  if (!InputTextAction::wasCancelled()) _sendCommand(command);
+  if (!InputTextAction::wasCancelled()) {
+    _inputLine.clear();
+    _sendCommand(command);
+  }
 
   _drainWorkerRx();
   render();
+#endif
+}
+
+void SshClientScreen::_handleTerminalInput() {
+#ifdef DEVICE_HAS_KEYBOARD
+  if (!Uni.Keyboard) return;
+
+  auto action = _inputLine.consume(Uni.Keyboard);
+  switch (action) {
+    case TerminalCommandLine::ACTION_EXIT:
+      _closeConnection(true);
+      return;
+    case TerminalCommandLine::ACTION_SUBMIT:
+      if (!_remoteClosed) {
+        String command = _inputLine.text();
+        _inputLine.clear();
+        _sendCommand(command);
+        _followOutput = true;
+      }
+      render();
+      return;
+    case TerminalCommandLine::ACTION_SCROLL_UP:
+      if (_outputView.onNav(INavigation::DIR_UP)) _followOutput = _outputView.isAtBottom();
+      return;
+    case TerminalCommandLine::ACTION_SCROLL_DOWN:
+      if (_outputView.onNav(INavigation::DIR_DOWN)) _followOutput = _outputView.isAtBottom();
+      return;
+    case TerminalCommandLine::ACTION_SCROLL_LEFT:
+      if (_outputView.onNav(INavigation::DIR_LEFT)) _followOutput = _outputView.isAtBottom();
+      return;
+    case TerminalCommandLine::ACTION_SCROLL_RIGHT:
+      if (_outputView.onNav(INavigation::DIR_RIGHT)) _followOutput = _outputView.isAtBottom();
+      return;
+    case TerminalCommandLine::ACTION_CHANGED:
+      render();
+      return;
+    default:
+      return;
+  }
+#endif
 }
 
 void SshClientScreen::_sendCommand(const String& command) {
@@ -1019,7 +1084,7 @@ int SshClientScreen::_terminalCols() {
 }
 
 int SshClientScreen::_terminalRows() {
-  const int outputH = max(1, bodyH() - PAD - 11 - 4 - FOOTER_H - 2);
+  const int outputH = max(1, bodyH() - PAD - 11 - 4 - INPUT_H - 2);
   return max(1, outputH / 11);
 }
 
@@ -1140,8 +1205,8 @@ void SshClientScreen::_renderOutput() {
   lcd.drawFastHLine(x + PAD, cy, w - PAD * 2, TFT_DARKGREY);
   cy += 4;
 
-  const int footerY = y + h - FOOTER_H;
-  const int outputBottom = footerY - 2;
+  const int inputY = y + h - INPUT_H;
+  const int outputBottom = inputY - 2;
 
   String display = _transcript;
   if (_partialLine.length() > 0) display += _partialLine;
@@ -1150,10 +1215,11 @@ void SshClientScreen::_renderOutput() {
   _outputView.updateContent(display, _followOutput);
   _outputView.render(x, cy, w, max(1, outputBottom - cy));
 
-  lcd.drawFastHLine(x + PAD, footerY - 2, w - PAD * 2, TFT_DARKGREY);
-  lcd.setTextDatum(MC_DATUM);
-  lcd.setTextColor(TFT_DARKGREY, TFT_BLACK);
-  lcd.drawString(_remoteClosed ? "BACK: Exit" : "PRESS: Cmd | BACK: Exit",
-                 x + w / 2, footerY + FOOTER_H / 2 - 1);
-  lcd.setTextDatum(TL_DATUM);
+  lcd.drawFastHLine(x + PAD, inputY - 2, w - PAD * 2, TFT_DARKGREY);
+#ifdef DEVICE_HAS_KEYBOARD
+  constexpr bool keyboardDevice = true;
+#else
+  constexpr bool keyboardDevice = false;
+#endif
+  _inputLine.render(x, inputY, w, INPUT_H, _remoteClosed, keyboardDevice);
 }

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.h
@@ -1,19 +1,43 @@
 #pragma once
 
 #include "ui/templates/ListScreen.h"
+#include "ui/views/TextScrollView.h"
 
 class SshClientScreen : public ListScreen
 {
 public:
   const char* title() override { return "SSH Client"; }
+  ~SshClientScreen();
 
   void onInit() override;
+  void onUpdate() override;
+  void onRender() override;
   void onItemSelected(uint8_t index) override;
   void onBack() override;
 
 private:
+  enum State : uint8_t { STATE_CONFIG, STATE_CONNECTING, STATE_OUTPUT };
+  enum WorkerState : uint8_t {
+    WORKER_IDLE,
+    WORKER_CONNECTING,
+    WORKER_RUNNING,
+    WORKER_FAILED,
+    WORKER_CLOSED
+  };
+  enum AnsiParseState : uint8_t { ANSI_DATA, ANSI_ESC, ANSI_CSI, ANSI_OSC, ANSI_OSC_ESC };
+
+  static constexpr int MAX_PARTIAL_LEN       = 160;
+  static constexpr int MAX_TRANSCRIPT_CHARS  = 4096;
+  static constexpr int MAX_SHARED_RX_CHARS   = 4096;
+  static constexpr int PAD                   = 4;
+  static constexpr int FOOTER_H              = 12;
+  static constexpr uint32_t SSH_TASK_STACK_SIZE = 24576;
+
+  State _state = STATE_CONFIG;
+
   String _host;
   String _username;
+  String _password;
   int    _port = 22;
 
   char _hostLabel[40] = {};
@@ -22,11 +46,51 @@ private:
   char _authLabel[16] = "Password";
   ListItem _items[5];
 
+  TaskHandle_t _sshTask = nullptr;
+  SemaphoreHandle_t _ioMutex = nullptr;
+  volatile WorkerState _workerState = WORKER_IDLE;
+  volatile bool _stopRequested = false;
+  String _workerRx;
+  String _workerTx;
+  String _workerError;
+
+  TextScrollView _outputView;
+  String _transcript;
+  String _partialLine;
+  int    _lineCursor = 0;
+  String _ansiParams;
+  AnsiParseState _ansiState = ANSI_DATA;
+  bool _remoteClosed = false;
+  bool _followOutput = true;
+
   void _updateLabels();
   void _rebuildItems();
   void _configHost();
   void _configPort();
   void _configUsername();
-  void _auth();    // TODO: later Password / Private Key selector
-  void _connect(); // TODO: libssh session + PTY/shell
+  void _auth();
+  void _connect();
+  void _closeConnection(bool returnToConfig = true);
+
+  bool _startSshWorker();
+  static void _sshWorkerEntry(void* arg);
+  void _sshWorker();
+  void _setWorkerError(const char* message);
+  void _drainWorkerRx();
+  void _openCommandInput();
+  void _sendCommand(const String& command);
+
+  void _appendByte(uint8_t c);
+  void _handleAnsiCsi(uint8_t finalByte);
+  int  _ansiParam(int index, int defaultValue) const;
+  void _putLineChar(char c);
+  void _commitPartial();
+  void _pushOutputLine(const String& line);
+  void _trimTranscript();
+  void _clearOutput();
+
+  int _terminalCols();
+  int _terminalRows();
+  void _renderConnecting();
+  void _renderOutput();
 };

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.h
@@ -2,6 +2,7 @@
 
 #include "ui/templates/ListScreen.h"
 #include "ui/views/TextScrollView.h"
+#include "ui/views/TerminalCommandLine.h"
 #include "ui/views/BrowseFileView.h"
 
 class SshClientScreen : public ListScreen
@@ -43,7 +44,7 @@ private:
   static constexpr int MAX_RX_PER_WORKER_LOOP = 2048;
   static constexpr uint32_t WRITE_STALL_TIMEOUT_MS = 2000;
   static constexpr int PAD                   = 4;
-  static constexpr int FOOTER_H              = 12;
+  static constexpr int INPUT_H               = 14;
   static constexpr uint32_t SSH_TASK_STACK_SIZE = 24576;
 
   State _state = STATE_CONFIG;
@@ -82,6 +83,7 @@ private:
   uint8_t _hostKeySelection = 0;        // 0=Trust, 1=Cancel
 
   TextScrollView _outputView;
+  TerminalCommandLine _inputLine;
   String _transcript;
   String _partialLine;
   int    _lineCursor = 0;
@@ -110,6 +112,7 @@ private:
   void _setWorkerError(const char* message);
   void _drainWorkerRx();
   void _openCommandInput();
+  void _handleTerminalInput();
   void _sendCommand(const String& command);
 
   void _appendByte(uint8_t c);

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+
+class SshClientScreen : public ListScreen
+{
+public:
+  const char* title() override { return "SSH Client"; }
+
+  void onInit() override;
+  void onItemSelected(uint8_t index) override;
+  void onBack() override;
+
+private:
+  String _host;
+  String _username;
+  int    _port = 22;
+
+  char _hostLabel[40] = {};
+  char _portLabel[16] = {};
+  char _userLabel[32] = {};
+  char _authLabel[16] = "Password";
+  ListItem _items[5];
+
+  void _updateLabels();
+  void _rebuildItems();
+  void _configHost();
+  void _configPort();
+  void _configUsername();
+  void _auth();    // TODO: later Password / Private Key selector
+  void _connect(); // TODO: libssh session + PTY/shell
+};

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.h
@@ -22,12 +22,14 @@ private:
     STATE_SELECT_AUTH,
     STATE_SELECT_KEY,
     STATE_CONNECTING,
+    STATE_HOSTKEY_CONFIRM,
     STATE_OUTPUT
   };
-  enum AuthMode : uint8_t { AUTH_PASSWORD, AUTH_PRIVATE_KEY };
+  enum AuthMode : uint8_t { AUTH_NONE, AUTH_PASSWORD, AUTH_PRIVATE_KEY };
   enum WorkerState : uint8_t {
     WORKER_IDLE,
     WORKER_CONNECTING,
+    WORKER_WAIT_HOSTKEY,
     WORKER_RUNNING,
     WORKER_FAILED,
     WORKER_CLOSED
@@ -48,13 +50,14 @@ private:
   String _password;
   String _keyPath;
   String _keyData;
-  AuthMode _authMode = AUTH_PASSWORD;
+  AuthMode _authMode = AUTH_NONE;
   int    _port = 22;
 
   char _hostLabel[40] = {};
   char _portLabel[16] = {};
   char _userLabel[32] = {};
-  char _authLabel[20] = "Password";
+  char _authLabel[20] = "-";
+  char _passwordLabel[16] = "-";
   char _keyLabel[32] = {};
   ListItem _items[6];
   BrowseFileView _browser;
@@ -71,6 +74,9 @@ private:
   String _workerRx;
   String _workerTx;
   String _workerError;
+  String _hostFingerprint;
+  volatile int8_t _hostKeyDecision = 0; // 0=pending, 1=trust, -1=cancel
+  uint8_t _hostKeySelection = 0;        // 0=Trust, 1=Cancel
 
   TextScrollView _outputView;
   String _transcript;
@@ -86,6 +92,7 @@ private:
   void _configHost();
   void _configPort();
   void _configUsername();
+  void _configPassword();
   void _auth();
   void _selectAuth(uint8_t index);
   void _openKeyPicker();
@@ -114,5 +121,7 @@ private:
   int _terminalCols();
   int _terminalRows();
   void _renderConnecting();
+  void _renderHostKeyConfirm();
+  void _acceptHostKey(bool trust);
   void _renderOutput();
 };

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.h
@@ -39,6 +39,9 @@ private:
   static constexpr int MAX_PARTIAL_LEN       = 160;
   static constexpr int MAX_TRANSCRIPT_CHARS  = 4096;
   static constexpr int MAX_SHARED_RX_CHARS   = 4096;
+  static constexpr int MAX_SHARED_TX_CHARS   = 4096;
+  static constexpr int MAX_RX_PER_WORKER_LOOP = 2048;
+  static constexpr uint32_t WRITE_STALL_TIMEOUT_MS = 2000;
   static constexpr int PAD                   = 4;
   static constexpr int FOOTER_H              = 12;
   static constexpr uint32_t SSH_TASK_STACK_SIZE = 24576;

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.h
@@ -2,6 +2,7 @@
 
 #include "ui/templates/ListScreen.h"
 #include "ui/views/TextScrollView.h"
+#include "ui/views/BrowseFileView.h"
 
 class SshClientScreen : public ListScreen
 {
@@ -16,7 +17,14 @@ public:
   void onBack() override;
 
 private:
-  enum State : uint8_t { STATE_CONFIG, STATE_CONNECTING, STATE_OUTPUT };
+  enum State : uint8_t {
+    STATE_CONFIG,
+    STATE_SELECT_AUTH,
+    STATE_SELECT_KEY,
+    STATE_CONNECTING,
+    STATE_OUTPUT
+  };
+  enum AuthMode : uint8_t { AUTH_PASSWORD, AUTH_PRIVATE_KEY };
   enum WorkerState : uint8_t {
     WORKER_IDLE,
     WORKER_CONNECTING,
@@ -38,13 +46,23 @@ private:
   String _host;
   String _username;
   String _password;
+  String _keyPath;
+  String _keyData;
+  AuthMode _authMode = AUTH_PASSWORD;
   int    _port = 22;
 
   char _hostLabel[40] = {};
   char _portLabel[16] = {};
   char _userLabel[32] = {};
-  char _authLabel[16] = "Password";
-  ListItem _items[5];
+  char _authLabel[20] = "Password";
+  char _keyLabel[32] = {};
+  ListItem _items[6];
+  BrowseFileView _browser;
+  String _browsePath = "/unigeek/wifi/ssh";
+  ListItem _authItems[2] = {
+    {"Password", nullptr},
+    {"Private Key", nullptr},
+  };
 
   TaskHandle_t _sshTask = nullptr;
   SemaphoreHandle_t _ioMutex = nullptr;
@@ -69,6 +87,10 @@ private:
   void _configPort();
   void _configUsername();
   void _auth();
+  void _selectAuth(uint8_t index);
+  void _openKeyPicker();
+  void _loadKeyDir(const String& path);
+  void _selectKey(uint8_t index);
   void _connect();
   void _closeConnection(bool returnToConfig = true);
 

--- a/firmware/src/screens/wifi/network/remote/SshClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/SshClientScreen.h
@@ -61,7 +61,7 @@ private:
   char _keyLabel[32] = {};
   ListItem _items[6];
   BrowseFileView _browser;
-  String _browsePath = "/unigeek/wifi/ssh";
+  String _browsePath = "/unigeek/wifi/remote/ssh";
   ListItem _authItems[2] = {
     {"Password", nullptr},
     {"Private Key", nullptr},

--- a/firmware/src/screens/wifi/network/remote/TcpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/TcpClientScreen.cpp
@@ -105,7 +105,13 @@ void TcpClientScreen::_configHost() {
     initial = String(ip[0]) + "." + String(ip[1]) + "." + String(ip[2]) + ".";
   }
 
-  String value = InputTextAction::popup("Host", initial, InputTextAction::INPUT_IP_ADDRESS);
+#ifdef DEVICE_HAS_KEYBOARD
+  const auto hostInputMode = InputTextAction::INPUT_TEXT;
+#else
+  const auto hostInputMode = InputTextAction::INPUT_IP_ADDRESS;
+#endif
+
+  String value = InputTextAction::popup("Host", initial, hostInputMode);
   if (!InputTextAction::wasCancelled() && value.length() > 0) {
     _host = value;
     _updateLabels();

--- a/firmware/src/screens/wifi/network/remote/TcpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/TcpClientScreen.cpp
@@ -8,6 +8,9 @@
 #include "ui/actions/ShowStatusAction.h"
 
 TcpClientScreen::~TcpClientScreen() {
+#ifdef DEVICE_HAS_KEYBOARD
+  if (Uni.Nav) Uni.Nav->setSuppressKeys(false);
+#endif
   _closeConnection(false);
 }
 
@@ -35,6 +38,11 @@ void TcpClientScreen::onUpdate() {
   }
 
 
+#ifdef DEVICE_HAS_KEYBOARD
+  _handleTerminalInput();
+  if (_state != STATE_OUTPUT) return;
+#endif
+
   if (!Uni.Nav->wasPressed()) return;
   auto dir = Uni.Nav->readDirection();
 
@@ -44,7 +52,9 @@ void TcpClientScreen::onUpdate() {
   }
 
   if (dir == INavigation::DIR_PRESS && !_remoteClosed) {
+#ifndef DEVICE_HAS_KEYBOARD
     _openCommandInput();
+#endif
     return;
   }
 
@@ -160,10 +170,18 @@ void TcpClientScreen::_connect() {
   _remoteClosed = false;
   _state = STATE_OUTPUT;
   _followOutput = true;
+  _inputLine.clear();
+#ifdef DEVICE_HAS_KEYBOARD
+  if (Uni.Nav) Uni.Nav->setSuppressKeys(true);
+#endif
   render();
 }
 
 void TcpClientScreen::_closeConnection(bool returnToConfig) {
+#ifdef DEVICE_HAS_KEYBOARD
+  if (Uni.Nav) Uni.Nav->setSuppressKeys(false);
+#endif
+  _inputLine.clear();
   if (_client) _client.stop();
   _remoteClosed = false;
 
@@ -176,17 +194,60 @@ void TcpClientScreen::_closeConnection(bool returnToConfig) {
 }
 
 void TcpClientScreen::_openCommandInput() {
-  // Always begin with an empty command. EXIT cancels and returns to OUTPUT;
-  // BACK remains owned by InputTextAction (ABC <-> 123 in text mode).
-  String command = InputTextAction::popup("Command", "", InputTextAction::INPUT_TEXT);
+#ifdef DEVICE_HAS_KEYBOARD
+  return;
+#else
+  String command = InputTextAction::popup(
+    "Command", _inputLine.text(), InputTextAction::INPUT_TEXT);
 
   if (!InputTextAction::wasCancelled()) {
+    _inputLine.clear();
     _sendCommand(command);
   }
 
   // Data may have arrived while the modal keyboard was open.
   _drainSocket();
   render();
+#endif
+}
+
+void TcpClientScreen::_handleTerminalInput() {
+#ifdef DEVICE_HAS_KEYBOARD
+  if (!Uni.Keyboard) return;
+
+  auto action = _inputLine.consume(Uni.Keyboard);
+  switch (action) {
+    case TerminalCommandLine::ACTION_EXIT:
+      _closeConnection(true);
+      return;
+    case TerminalCommandLine::ACTION_SUBMIT:
+      if (!_remoteClosed) {
+        String command = _inputLine.text();
+        _inputLine.clear();
+        _sendCommand(command);
+        _followOutput = true;
+      }
+      render();
+      return;
+    case TerminalCommandLine::ACTION_SCROLL_UP:
+      if (_outputView.onNav(INavigation::DIR_UP)) _followOutput = _outputView.isAtBottom();
+      return;
+    case TerminalCommandLine::ACTION_SCROLL_DOWN:
+      if (_outputView.onNav(INavigation::DIR_DOWN)) _followOutput = _outputView.isAtBottom();
+      return;
+    case TerminalCommandLine::ACTION_SCROLL_LEFT:
+      if (_outputView.onNav(INavigation::DIR_LEFT)) _followOutput = _outputView.isAtBottom();
+      return;
+    case TerminalCommandLine::ACTION_SCROLL_RIGHT:
+      if (_outputView.onNav(INavigation::DIR_RIGHT)) _followOutput = _outputView.isAtBottom();
+      return;
+    case TerminalCommandLine::ACTION_CHANGED:
+      render();
+      return;
+    default:
+      return;
+  }
+#endif
 }
 
 void TcpClientScreen::_sendCommand(const String& command) {
@@ -328,8 +389,8 @@ void TcpClientScreen::_renderOutput() {
   lcd.drawFastHLine(x + PAD, cy, w - PAD * 2, TFT_DARKGREY);
   cy += 4;
 
-  const int footerY = y + h - FOOTER_H;
-  const int outputBottom = footerY - 2;
+  const int inputY = y + h - INPUT_H;
+  const int outputBottom = inputY - 2;
 
   String display = _transcript;
   if (_partialLine.length() > 0) display += _partialLine;
@@ -338,10 +399,11 @@ void TcpClientScreen::_renderOutput() {
   _outputView.updateContent(display, _followOutput);
   _outputView.render(x, cy, w, max(1, outputBottom - cy));
 
-  lcd.drawFastHLine(x + PAD, footerY - 2, w - PAD * 2, TFT_DARKGREY);
-  lcd.setTextDatum(MC_DATUM);
-  lcd.setTextColor(TFT_DARKGREY, TFT_BLACK);
-  lcd.drawString(_remoteClosed ? "BACK: Exit" : "PRESS: Cmd | BACK: Exit",
-                 x + w / 2, footerY + FOOTER_H / 2 - 1);
-  lcd.setTextDatum(TL_DATUM);
+  lcd.drawFastHLine(x + PAD, inputY - 2, w - PAD * 2, TFT_DARKGREY);
+#ifdef DEVICE_HAS_KEYBOARD
+  constexpr bool keyboardDevice = true;
+#else
+  constexpr bool keyboardDevice = false;
+#endif
+  _inputLine.render(x, inputY, w, INPUT_H, _remoteClosed, keyboardDevice);
 }

--- a/firmware/src/screens/wifi/network/remote/TcpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/TcpClientScreen.cpp
@@ -186,27 +186,62 @@ void TcpClientScreen::_openCommandInput() {
 void TcpClientScreen::_sendCommand(const String& command) {
   if (_remoteClosed || !_client.connected()) return;
 
-  // v1 command mode uses conventional CRLF line termination. Keep this in one
-  // function so a future TCP setting can expose None/CR/LF/CRLF without
-  // touching the rest of the session code.
+  // Command mode uses conventional CRLF line termination.
   _pushOutputLine(String("> ") + command);
   _followOutput = true;
 
+  bool ok = true;
   if (command.length() > 0) {
-    _client.write(reinterpret_cast<const uint8_t*>(command.c_str()), command.length());
+    ok = _writeAll(reinterpret_cast<const uint8_t*>(command.c_str()),
+                   command.length());
   }
-  _client.write((uint8_t)'\r');
-  _client.write((uint8_t)'\n');
+
+  static const uint8_t CRLF[] = {'\r', '\n'};
+  if (ok) ok = _writeAll(CRLF, sizeof(CRLF));
+
+  if (!ok) {
+    _pushOutputLine("[Send failed]");
+    _remoteClosed = true;
+    _client.stop();
+  }
+}
+
+bool TcpClientScreen::_writeAll(const uint8_t* data, size_t len) {
+  if (!data || len == 0) return true;
+
+  size_t sent = 0;
+  uint32_t lastProgress = millis();
+
+  while (sent < len) {
+    if (!_client.connected()) return false;
+
+    size_t n = _client.write(data + sent, len - sent);
+    if (n > 0) {
+      sent += n;
+      lastProgress = millis();
+      continue;
+    }
+
+    if (millis() - lastProgress >= WRITE_TIMEOUT_MS) return false;
+    delay(1);
+  }
+
+  return true;
 }
 
 void TcpClientScreen::_drainSocket() {
   bool gotData = false;
+  size_t processed = 0;
+  uint8_t buf[128];
 
-  while (_client.available()) {
-    uint8_t buf[128];
-    int n = _client.read(buf, sizeof(buf));
+  // Bound work per UI update so a continuously streaming endpoint cannot
+  // starve navigation/rendering.
+  while (_client.available() && processed < MAX_RX_PER_UPDATE) {
+    size_t room = min<size_t>(sizeof(buf), MAX_RX_PER_UPDATE - processed);
+    int n = _client.read(buf, room);
     if (n <= 0) break;
 
+    processed += (size_t)n;
     gotData = true;
     for (int i = 0; i < n; i++) _appendByte(buf[i]);
   }

--- a/firmware/src/screens/wifi/network/remote/TcpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/TcpClientScreen.cpp
@@ -83,10 +83,10 @@ void TcpClientScreen::onItemSelected(uint8_t index) {
 }
 
 void TcpClientScreen::_updateLabels() {
-  if (_host.length() == 0) snprintf(_hostLabel, sizeof(_hostLabel), "tap to set");
+  if (_host.length() == 0) snprintf(_hostLabel, sizeof(_hostLabel), "-");
   else                     _host.toCharArray(_hostLabel, sizeof(_hostLabel));
 
-  if (_port <= 0) snprintf(_portLabel, sizeof(_portLabel), "tap to set");
+  if (_port <= 0) snprintf(_portLabel, sizeof(_portLabel), "-");
   else            snprintf(_portLabel, sizeof(_portLabel), "%d", _port);
 }
 

--- a/firmware/src/screens/wifi/network/remote/TcpClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/TcpClientScreen.cpp
@@ -1,0 +1,306 @@
+#include "TcpClientScreen.h"
+
+#include "core/Device.h"
+#include "core/INavigation.h"
+#include "core/ScreenManager.h"
+#include "ui/actions/InputTextAction.h"
+#include "ui/actions/InputNumberAction.h"
+#include "ui/actions/ShowStatusAction.h"
+
+TcpClientScreen::~TcpClientScreen() {
+  _closeConnection(false);
+}
+
+void TcpClientScreen::onInit() {
+  _updateLabels();
+  _rebuildItems();
+}
+
+void TcpClientScreen::onUpdate() {
+  if (_state == STATE_CONFIG) {
+    ListScreen::onUpdate();
+    return;
+  }
+
+  // OUTPUT screen: keep draining TCP continuously while the user reads it.
+  _drainSocket();
+
+  if (!_remoteClosed && !_client.connected()) {
+    // Preserve the final output on-screen instead of immediately returning to
+    // CONFIG. This lets the user inspect a service that closes after replying.
+    _remoteClosed = true;
+    if (_partialLine.length() > 0) _commitPartial();
+    _pushOutputLine("[Connection closed]");
+    render();
+  }
+
+
+  if (!Uni.Nav->wasPressed()) return;
+  auto dir = Uni.Nav->readDirection();
+
+  if (dir == INavigation::DIR_BACK) {
+    _closeConnection(true);
+    return;
+  }
+
+  if (dir == INavigation::DIR_PRESS && !_remoteClosed) {
+    _openCommandInput();
+    return;
+  }
+
+  if (dir == INavigation::DIR_UP || dir == INavigation::DIR_DOWN ||
+      dir == INavigation::DIR_LEFT || dir == INavigation::DIR_RIGHT) {
+    if (_outputView.onNav(dir)) {
+      _followOutput = _outputView.isAtBottom();
+    }
+  }
+}
+
+void TcpClientScreen::onRender() {
+  if (_state == STATE_CONFIG) {
+    ListScreen::onRender();
+    return;
+  }
+
+  _renderOutput();
+}
+
+void TcpClientScreen::onBack() {
+  if (_state == STATE_OUTPUT) {
+    _closeConnection(true);
+  } else {
+    Screen.goBack();
+  }
+}
+
+void TcpClientScreen::onItemSelected(uint8_t index) {
+  switch (index) {
+    case 0: _configHost(); break;
+    case 1: _configPort(); break;
+    case 2: _connect();    break;
+    default: break;
+  }
+}
+
+void TcpClientScreen::_updateLabels() {
+  if (_host.length() == 0) snprintf(_hostLabel, sizeof(_hostLabel), "tap to set");
+  else                     _host.toCharArray(_hostLabel, sizeof(_hostLabel));
+
+  if (_port <= 0) snprintf(_portLabel, sizeof(_portLabel), "tap to set");
+  else            snprintf(_portLabel, sizeof(_portLabel), "%d", _port);
+}
+
+void TcpClientScreen::_rebuildItems() {
+  uint8_t sel = _selectedIndex;
+  _items[0] = {"Host", _hostLabel};
+  _items[1] = {"Port", _portLabel};
+  _items[2] = {"Connect", nullptr};
+  setItems(_items, 3, sel);
+}
+
+void TcpClientScreen::_configHost() {
+  String initial = _host;
+  if (initial.length() == 0 && WiFi.status() == WL_CONNECTED) {
+    IPAddress ip = WiFi.localIP();
+    initial = String(ip[0]) + "." + String(ip[1]) + "." + String(ip[2]) + ".";
+  }
+
+  String value = InputTextAction::popup("Host", initial, InputTextAction::INPUT_IP_ADDRESS);
+  if (!InputTextAction::wasCancelled() && value.length() > 0) {
+    _host = value;
+    _updateLabels();
+    _rebuildItems();
+  }
+  render();
+}
+
+void TcpClientScreen::_configPort() {
+  int value = InputNumberAction::popup("Port", 1, 65535, _port > 0 ? _port : 0);
+  if (!InputNumberAction::wasCancelled()) {
+    _port = value;
+    _updateLabels();
+    _rebuildItems();
+  }
+  render();
+}
+
+void TcpClientScreen::_connect() {
+  if (_host.length() == 0) {
+    ShowStatusAction::show("Host required", 1200);
+    render();
+    return;
+  }
+  if (_port < 1 || _port > 65535) {
+    ShowStatusAction::show("Port required", 1200);
+    render();
+    return;
+  }
+  if (WiFi.status() != WL_CONNECTED) {
+    ShowStatusAction::show("WiFi not connected", 1500);
+    render();
+    return;
+  }
+
+  ShowStatusAction::show("Connecting...", 0);
+  _client.stop();
+
+  if (!_client.connect(_host.c_str(), (uint16_t)_port, 5000)) {
+    ShowStatusAction::show("Connection failed", 1500);
+    render();
+    return;
+  }
+
+  _clearOutput();
+  _remoteClosed = false;
+  _state = STATE_OUTPUT;
+  _followOutput = true;
+  render();
+}
+
+void TcpClientScreen::_closeConnection(bool returnToConfig) {
+  if (_client) _client.stop();
+  _remoteClosed = false;
+
+  if (returnToConfig) {
+    _state = STATE_CONFIG;
+    _updateLabels();
+    _rebuildItems();
+    render();
+  }
+}
+
+void TcpClientScreen::_openCommandInput() {
+  // Always begin with an empty command. EXIT cancels and returns to OUTPUT;
+  // BACK remains owned by InputTextAction (ABC <-> 123 in text mode).
+  String command = InputTextAction::popup("Command", "", InputTextAction::INPUT_TEXT);
+
+  if (!InputTextAction::wasCancelled()) {
+    _sendCommand(command);
+  }
+
+  // Data may have arrived while the modal keyboard was open.
+  _drainSocket();
+  render();
+}
+
+void TcpClientScreen::_sendCommand(const String& command) {
+  if (_remoteClosed || !_client.connected()) return;
+
+  // v1 command mode uses conventional CRLF line termination. Keep this in one
+  // function so a future TCP setting can expose None/CR/LF/CRLF without
+  // touching the rest of the session code.
+  _pushOutputLine(String("> ") + command);
+  _followOutput = true;
+
+  if (command.length() > 0) {
+    _client.write(reinterpret_cast<const uint8_t*>(command.c_str()), command.length());
+  }
+  _client.write((uint8_t)'\r');
+  _client.write((uint8_t)'\n');
+}
+
+void TcpClientScreen::_drainSocket() {
+  bool gotData = false;
+
+  while (_client.available()) {
+    uint8_t buf[128];
+    int n = _client.read(buf, sizeof(buf));
+    if (n <= 0) break;
+
+    gotData = true;
+    for (int i = 0; i < n; i++) _appendByte(buf[i]);
+  }
+
+  if (gotData) render();
+}
+
+void TcpClientScreen::_appendByte(uint8_t c) {
+  if (c == '\r') return;
+
+  if (c == '\n') {
+    _commitPartial();
+    return;
+  }
+
+  if (c == '\b' || c == 0x7f) {
+    if (_partialLine.length() > 0) _partialLine.remove(_partialLine.length() - 1);
+    return;
+  }
+
+  if (c == '\t') {
+    _partialLine += "    ";
+  } else if (c >= 0x20 && c <= 0x7e) {
+    _partialLine += (char)c;
+  }
+  // Other control/binary bytes are intentionally ignored in text-mode v1.
+
+  if ((int)_partialLine.length() >= MAX_PARTIAL_LEN) _commitPartial();
+}
+
+void TcpClientScreen::_commitPartial() {
+  _pushOutputLine(_partialLine);
+  _partialLine = "";
+}
+
+void TcpClientScreen::_pushOutputLine(const String& line) {
+  _transcript += line;
+  _transcript += '\n';
+  _trimTranscript();
+}
+
+void TcpClientScreen::_trimTranscript() {
+  if ((int)_transcript.length() <= MAX_TRANSCRIPT_CHARS) return;
+
+  int excess = (int)_transcript.length() - MAX_TRANSCRIPT_CHARS;
+  int cut = _transcript.indexOf('\n', excess);
+  if (cut >= 0) _transcript.remove(0, cut + 1);
+  else          _transcript.remove(0, excess);
+}
+
+void TcpClientScreen::_clearOutput() {
+  _transcript = "";
+  _partialLine = "";
+  _followOutput = true;
+  _outputView.setContent("");
+}
+
+void TcpClientScreen::_renderOutput() {
+  auto& lcd = Uni.Lcd;
+  const int x = bodyX();
+  const int y = bodyY();
+  const int w = bodyW();
+  const int h = bodyH();
+
+  lcd.fillRect(x, y, w, h, TFT_BLACK);
+  lcd.setTextFont(1);
+  lcd.setTextSize(1);
+  lcd.setTextDatum(TL_DATUM);
+
+  int cy = y + PAD;
+
+  // Fixed connection information at the top of every OUTPUT screen.
+  lcd.setTextColor(TFT_GREEN, TFT_BLACK);
+  String connected = "Connected to " + _host + ":" + String(_port);
+  lcd.drawString(connected.c_str(), x + PAD, cy);
+  cy += 11;
+
+  lcd.drawFastHLine(x + PAD, cy, w - PAD * 2, TFT_DARKGREY);
+  cy += 4;
+
+  const int footerY = y + h - FOOTER_H;
+  const int outputBottom = footerY - 2;
+
+  String display = _transcript;
+  if (_partialLine.length() > 0) display += _partialLine;
+  if (display.length() == 0 && !_remoteClosed) display = "Waiting for data...";
+
+  _outputView.updateContent(display, _followOutput);
+  _outputView.render(x, cy, w, max(1, outputBottom - cy));
+
+  lcd.drawFastHLine(x + PAD, footerY - 2, w - PAD * 2, TFT_DARKGREY);
+  lcd.setTextDatum(MC_DATUM);
+  lcd.setTextColor(TFT_DARKGREY, TFT_BLACK);
+  lcd.drawString(_remoteClosed ? "BACK: Exit" : "PRESS: Cmd | BACK: Exit",
+                 x + w / 2, footerY + FOOTER_H / 2 - 1);
+  lcd.setTextDatum(TL_DATUM);
+}

--- a/firmware/src/screens/wifi/network/remote/TcpClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/TcpClientScreen.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+#include "ui/views/TextScrollView.h"
+#include <WiFi.h>
+#include <WiFiClient.h>
+
+class TcpClientScreen : public ListScreen
+{
+public:
+  const char* title() override { return "TCP Client"; }
+  ~TcpClientScreen();
+
+  void onInit() override;
+  void onUpdate() override;
+  void onRender() override;
+  void onBack() override;
+  void onItemSelected(uint8_t index) override;
+
+private:
+  enum State : uint8_t {
+    STATE_CONFIG,
+    STATE_OUTPUT,
+  };
+
+  static constexpr int MAX_PARTIAL_LEN     = 160;
+  static constexpr int MAX_TRANSCRIPT_CHARS = 4096;
+  static constexpr int PAD                 = 4;
+  static constexpr int FOOTER_H            = 12;
+
+  State      _state = STATE_CONFIG;
+  WiFiClient _client;
+
+  String _host;
+  int    _port = 0;
+
+  char _hostLabel[40] = {};
+  char _portLabel[16] = {};
+  ListItem _items[3];
+
+  TextScrollView _outputView;
+  String _transcript;
+  String _partialLine;
+  bool   _remoteClosed = false;
+  bool   _followOutput = true;
+
+  void _updateLabels();
+  void _rebuildItems();
+  void _configHost();
+  void _configPort();
+  void _connect();
+  void _closeConnection(bool returnToConfig = true);
+
+  void _openCommandInput();
+  void _sendCommand(const String& command);
+
+  void _drainSocket();
+  void _appendByte(uint8_t c);
+  void _commitPartial();
+  void _pushOutputLine(const String& line);
+  void _trimTranscript();
+  void _clearOutput();
+
+  void _renderOutput();
+};

--- a/firmware/src/screens/wifi/network/remote/TcpClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/TcpClientScreen.h
@@ -27,6 +27,8 @@ private:
   static constexpr int MAX_TRANSCRIPT_CHARS = 4096;
   static constexpr int PAD                 = 4;
   static constexpr int FOOTER_H            = 12;
+  static constexpr size_t MAX_RX_PER_UPDATE  = 1024;
+  static constexpr uint32_t WRITE_TIMEOUT_MS  = 2000;
 
   State      _state = STATE_CONFIG;
   WiFiClient _client;
@@ -53,6 +55,7 @@ private:
 
   void _openCommandInput();
   void _sendCommand(const String& command);
+  bool _writeAll(const uint8_t* data, size_t len);
 
   void _drainSocket();
   void _appendByte(uint8_t c);

--- a/firmware/src/screens/wifi/network/remote/TcpClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/TcpClientScreen.h
@@ -2,6 +2,7 @@
 
 #include "ui/templates/ListScreen.h"
 #include "ui/views/TextScrollView.h"
+#include "ui/views/TerminalCommandLine.h"
 #include <WiFi.h>
 #include <WiFiClient.h>
 
@@ -26,7 +27,7 @@ private:
   static constexpr int MAX_PARTIAL_LEN     = 160;
   static constexpr int MAX_TRANSCRIPT_CHARS = 4096;
   static constexpr int PAD                 = 4;
-  static constexpr int FOOTER_H            = 12;
+  static constexpr int INPUT_H             = 14;
   static constexpr size_t MAX_RX_PER_UPDATE  = 1024;
   static constexpr uint32_t WRITE_TIMEOUT_MS  = 2000;
 
@@ -41,6 +42,7 @@ private:
   ListItem _items[3];
 
   TextScrollView _outputView;
+  TerminalCommandLine _inputLine;
   String _transcript;
   String _partialLine;
   bool   _remoteClosed = false;
@@ -54,6 +56,7 @@ private:
   void _closeConnection(bool returnToConfig = true);
 
   void _openCommandInput();
+  void _handleTerminalInput();
   void _sendCommand(const String& command);
   bool _writeAll(const uint8_t* data, size_t len);
 

--- a/firmware/src/screens/wifi/network/remote/TelnetClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/TelnetClientScreen.cpp
@@ -197,20 +197,58 @@ void TelnetClientScreen::_sendCommand(const String& command) {
   if (_remoteClosed || !_client.connected()) return;
 
   // Telnet server controls echo; do not duplicate commands in the local transcript.
+  bool ok = true;
   if (command.length() > 0) {
-    _client.write(reinterpret_cast<const uint8_t*>(command.c_str()), command.length());
+    ok = _writeAll(reinterpret_cast<const uint8_t*>(command.c_str()),
+                   command.length());
   }
-  _client.write((uint8_t)'\r');
-  _client.write((uint8_t)'\n');
+
+  static const uint8_t CRLF[] = {'\r', '\n'};
+  if (ok) ok = _writeAll(CRLF, sizeof(CRLF));
+
+  if (!ok) _handleSendFailure();
+}
+
+bool TelnetClientScreen::_writeAll(const uint8_t* data, size_t len) {
+  if (!data || len == 0) return true;
+
+  size_t sent = 0;
+  uint32_t lastProgress = millis();
+
+  while (sent < len) {
+    if (!_client.connected()) return false;
+
+    size_t n = _client.write(data + sent, len - sent);
+    if (n > 0) {
+      sent += n;
+      lastProgress = millis();
+      continue;
+    }
+
+    if (millis() - lastProgress >= WRITE_TIMEOUT_MS) return false;
+    delay(1);
+  }
+
+  return true;
+}
+
+void TelnetClientScreen::_handleSendFailure() {
+  if (_remoteClosed) return;
+  _remoteClosed = true;
+  _client.stop();
+  if (_partialLine.length() > 0) _commitPartial();
+  _pushOutputLine("[Send failed]");
 }
 
 void TelnetClientScreen::_sendTelnetReply(uint8_t command, uint8_t option) {
+  if (_remoteClosed || !_client.connected()) return;
+
   uint8_t reply[3] = {IAC, command, option};
-  _client.write(reply, sizeof(reply));
+  if (!_writeAll(reply, sizeof(reply))) _handleSendFailure();
 }
 
 void TelnetClientScreen::_sendNaws() {
-  if (!_client.connected()) return;
+  if (_remoteClosed || !_client.connected()) return;
 
   // Match TextScrollView's actual terminal geometry. Font 1 is 6 px wide and
   // the view reserves 3 px for the scrollbar plus 8 px horizontal padding.
@@ -224,21 +262,27 @@ void TelnetClientScreen::_sendNaws() {
 
   // RFC 1073: IAC SB NAWS <16-bit width> <16-bit height> IAC SE.
   // Width/height bytes equal to IAC must be escaped by doubling them.
-  uint8_t header[3] = {IAC, SB, OPT_NAWS};
-  _client.write(header, sizeof(header));
+  uint8_t packet[3 + 8 + 2] = {};
+  size_t len = 0;
 
-  auto writeEscaped = [this](uint8_t b) {
-    _client.write(b);
-    if (b == IAC) _client.write(b);
+  packet[len++] = IAC;
+  packet[len++] = SB;
+  packet[len++] = OPT_NAWS;
+
+  auto appendEscaped = [&](uint8_t b) {
+    packet[len++] = b;
+    if (b == IAC) packet[len++] = b;
   };
 
-  writeEscaped((uint8_t)((cols >> 8) & 0xff));
-  writeEscaped((uint8_t)(cols & 0xff));
-  writeEscaped((uint8_t)((rows >> 8) & 0xff));
-  writeEscaped((uint8_t)(rows & 0xff));
+  appendEscaped((uint8_t)((cols >> 8) & 0xff));
+  appendEscaped((uint8_t)(cols & 0xff));
+  appendEscaped((uint8_t)((rows >> 8) & 0xff));
+  appendEscaped((uint8_t)(rows & 0xff));
 
-  uint8_t trailer[2] = {IAC, SE};
-  _client.write(trailer, sizeof(trailer));
+  packet[len++] = IAC;
+  packet[len++] = SE;
+
+  if (!_writeAll(packet, len)) _handleSendFailure();
 }
 
 void TelnetClientScreen::_handleNegotiation(uint8_t command, uint8_t option) {
@@ -316,14 +360,21 @@ void TelnetClientScreen::_processTelnetByte(uint8_t c) {
 
 void TelnetClientScreen::_drainSocket() {
   bool gotData = false;
+  size_t processed = 0;
+  uint8_t buf[128];
 
-  while (_client.available()) {
-    uint8_t buf[128];
-    int n = _client.read(buf, sizeof(buf));
+  // Bound work per UI update so a busy Telnet session cannot starve input and
+  // rendering. The remaining bytes stay queued for the next update.
+  while (_client.available() && processed < MAX_RX_PER_UPDATE) {
+    size_t room = min<size_t>(sizeof(buf), MAX_RX_PER_UPDATE - processed);
+    int n = _client.read(buf, room);
     if (n <= 0) break;
 
+    processed += (size_t)n;
     gotData = true;
     for (int i = 0; i < n; i++) _processTelnetByte(buf[i]);
+
+    if (_remoteClosed) break;
   }
 
   if (gotData) render();

--- a/firmware/src/screens/wifi/network/remote/TelnetClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/TelnetClientScreen.cpp
@@ -108,7 +108,13 @@ void TelnetClientScreen::_configHost() {
     initial = String(ip[0]) + "." + String(ip[1]) + "." + String(ip[2]) + ".";
   }
 
-  String value = InputTextAction::popup("Host", initial, InputTextAction::INPUT_IP_ADDRESS);
+#ifdef DEVICE_HAS_KEYBOARD
+  const auto hostInputMode = InputTextAction::INPUT_TEXT;
+#else
+  const auto hostInputMode = InputTextAction::INPUT_IP_ADDRESS;
+#endif
+
+  String value = InputTextAction::popup("Host", initial, hostInputMode);
   if (!InputTextAction::wasCancelled() && value.length() > 0) {
     _host = value;
     _updateLabels();

--- a/firmware/src/screens/wifi/network/remote/TelnetClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/TelnetClientScreen.cpp
@@ -8,6 +8,9 @@
 #include "ui/actions/ShowStatusAction.h"
 
 TelnetClientScreen::~TelnetClientScreen() {
+#ifdef DEVICE_HAS_KEYBOARD
+  if (Uni.Nav) Uni.Nav->setSuppressKeys(false);
+#endif
   _closeConnection(false);
 }
 
@@ -38,6 +41,11 @@ void TelnetClientScreen::onUpdate() {
   }
 
 
+#ifdef DEVICE_HAS_KEYBOARD
+  _handleTerminalInput();
+  if (_state != STATE_OUTPUT) return;
+#endif
+
   if (!Uni.Nav->wasPressed()) return;
   auto dir = Uni.Nav->readDirection();
 
@@ -47,7 +55,9 @@ void TelnetClientScreen::onUpdate() {
   }
 
   if (dir == INavigation::DIR_PRESS && !_remoteClosed) {
+#ifndef DEVICE_HAS_KEYBOARD
     _openCommandInput();
+#endif
     return;
   }
 
@@ -170,10 +180,18 @@ void TelnetClientScreen::_connect() {
   _lineCursor = 0;
   _state = STATE_OUTPUT;
   _followOutput = true;
+  _inputLine.clear();
+#ifdef DEVICE_HAS_KEYBOARD
+  if (Uni.Nav) Uni.Nav->setSuppressKeys(true);
+#endif
   render();
 }
 
 void TelnetClientScreen::_closeConnection(bool returnToConfig) {
+#ifdef DEVICE_HAS_KEYBOARD
+  if (Uni.Nav) Uni.Nav->setSuppressKeys(false);
+#endif
+  _inputLine.clear();
   if (_client) _client.stop();
   _remoteClosed = false;
 
@@ -186,17 +204,60 @@ void TelnetClientScreen::_closeConnection(bool returnToConfig) {
 }
 
 void TelnetClientScreen::_openCommandInput() {
-  // Always begin with an empty command. EXIT cancels and returns to OUTPUT;
-  // BACK remains owned by InputTextAction (ABC <-> 123 in text mode).
-  String command = InputTextAction::popup("Command", "", InputTextAction::INPUT_TEXT);
+#ifdef DEVICE_HAS_KEYBOARD
+  return;
+#else
+  String command = InputTextAction::popup(
+    "Command", _inputLine.text(), InputTextAction::INPUT_TEXT);
 
   if (!InputTextAction::wasCancelled()) {
+    _inputLine.clear();
     _sendCommand(command);
   }
 
   // Data may have arrived while the modal keyboard was open.
   _drainSocket();
   render();
+#endif
+}
+
+void TelnetClientScreen::_handleTerminalInput() {
+#ifdef DEVICE_HAS_KEYBOARD
+  if (!Uni.Keyboard) return;
+
+  auto action = _inputLine.consume(Uni.Keyboard);
+  switch (action) {
+    case TerminalCommandLine::ACTION_EXIT:
+      _closeConnection(true);
+      return;
+    case TerminalCommandLine::ACTION_SUBMIT:
+      if (!_remoteClosed) {
+        String command = _inputLine.text();
+        _inputLine.clear();
+        _sendCommand(command);
+        _followOutput = true;
+      }
+      render();
+      return;
+    case TerminalCommandLine::ACTION_SCROLL_UP:
+      if (_outputView.onNav(INavigation::DIR_UP)) _followOutput = _outputView.isAtBottom();
+      return;
+    case TerminalCommandLine::ACTION_SCROLL_DOWN:
+      if (_outputView.onNav(INavigation::DIR_DOWN)) _followOutput = _outputView.isAtBottom();
+      return;
+    case TerminalCommandLine::ACTION_SCROLL_LEFT:
+      if (_outputView.onNav(INavigation::DIR_LEFT)) _followOutput = _outputView.isAtBottom();
+      return;
+    case TerminalCommandLine::ACTION_SCROLL_RIGHT:
+      if (_outputView.onNav(INavigation::DIR_RIGHT)) _followOutput = _outputView.isAtBottom();
+      return;
+    case TerminalCommandLine::ACTION_CHANGED:
+      render();
+      return;
+    default:
+      return;
+  }
+#endif
 }
 
 void TelnetClientScreen::_sendCommand(const String& command) {
@@ -263,7 +324,7 @@ void TelnetClientScreen::_sendNaws() {
 
   // Same vertical geometry used by _renderOutput(): connection header,
   // separator and footer are fixed; the remaining region is the terminal.
-  const int outputH = max(1, bodyH() - PAD - 11 - 4 - FOOTER_H - 2);
+  const int outputH = max(1, bodyH() - PAD - 11 - 4 - INPUT_H - 2);
   const int rows = max(1, outputH / 11);
 
   // RFC 1073: IAC SB NAWS <16-bit width> <16-bit height> IAC SE.
@@ -591,8 +652,8 @@ void TelnetClientScreen::_renderOutput() {
   lcd.drawFastHLine(x + PAD, cy, w - PAD * 2, TFT_DARKGREY);
   cy += 4;
 
-  const int footerY = y + h - FOOTER_H;
-  const int outputBottom = footerY - 2;
+  const int inputY = y + h - INPUT_H;
+  const int outputBottom = inputY - 2;
 
   String display = _transcript;
   if (_partialLine.length() > 0) display += _partialLine;
@@ -601,10 +662,11 @@ void TelnetClientScreen::_renderOutput() {
   _outputView.updateContent(display, _followOutput);
   _outputView.render(x, cy, w, max(1, outputBottom - cy));
 
-  lcd.drawFastHLine(x + PAD, footerY - 2, w - PAD * 2, TFT_DARKGREY);
-  lcd.setTextDatum(MC_DATUM);
-  lcd.setTextColor(TFT_DARKGREY, TFT_BLACK);
-  lcd.drawString(_remoteClosed ? "BACK: Exit" : "PRESS: Cmd | BACK: Exit",
-                 x + w / 2, footerY + FOOTER_H / 2 - 1);
-  lcd.setTextDatum(TL_DATUM);
+  lcd.drawFastHLine(x + PAD, inputY - 2, w - PAD * 2, TFT_DARKGREY);
+#ifdef DEVICE_HAS_KEYBOARD
+  constexpr bool keyboardDevice = true;
+#else
+  constexpr bool keyboardDevice = false;
+#endif
+  _inputLine.render(x, inputY, w, INPUT_H, _remoteClosed, keyboardDevice);
 }

--- a/firmware/src/screens/wifi/network/remote/TelnetClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/TelnetClientScreen.cpp
@@ -12,6 +12,9 @@ TelnetClientScreen::~TelnetClientScreen() {
 }
 
 void TelnetClientScreen::onInit() {
+  // Terminal output must preserve whitespace/columns. TCP and other users of
+  // TextScrollView keep the default word-wrap behavior.
+  _outputView.setWrapMode(TextScrollView::WRAP_CHARACTER);
   _updateLabels();
   _rebuildItems();
 }
@@ -155,7 +158,10 @@ void TelnetClientScreen::_connect() {
   _tnState = TN_DATA;
   _tnCommand = 0;
   _tnSbHasOption = false;
+  _nawsEnabled = false;
   _ansiState = ANSI_DATA;
+  _ansiParams = "";
+  _lineCursor = 0;
   _state = STATE_OUTPUT;
   _followOutput = true;
   render();
@@ -190,10 +196,7 @@ void TelnetClientScreen::_openCommandInput() {
 void TelnetClientScreen::_sendCommand(const String& command) {
   if (_remoteClosed || !_client.connected()) return;
 
-  // Telnet command mode uses conventional CRLF line termination.
-  _pushOutputLine(String("> ") + command);
-  _followOutput = true;
-
+  // Telnet server controls echo; do not duplicate commands in the local transcript.
   if (command.length() > 0) {
     _client.write(reinterpret_cast<const uint8_t*>(command.c_str()), command.length());
   }
@@ -206,6 +209,38 @@ void TelnetClientScreen::_sendTelnetReply(uint8_t command, uint8_t option) {
   _client.write(reply, sizeof(reply));
 }
 
+void TelnetClientScreen::_sendNaws() {
+  if (!_client.connected()) return;
+
+  // Match TextScrollView's actual terminal geometry. Font 1 is 6 px wide and
+  // the view reserves 3 px for the scrollbar plus 8 px horizontal padding.
+  const int textW = max(1, bodyW() - 3 - 8);
+  const int cols = max(8, textW / 6);
+
+  // Same vertical geometry used by _renderOutput(): connection header,
+  // separator and footer are fixed; the remaining region is the terminal.
+  const int outputH = max(1, bodyH() - PAD - 11 - 4 - FOOTER_H - 2);
+  const int rows = max(1, outputH / 11);
+
+  // RFC 1073: IAC SB NAWS <16-bit width> <16-bit height> IAC SE.
+  // Width/height bytes equal to IAC must be escaped by doubling them.
+  uint8_t header[3] = {IAC, SB, OPT_NAWS};
+  _client.write(header, sizeof(header));
+
+  auto writeEscaped = [this](uint8_t b) {
+    _client.write(b);
+    if (b == IAC) _client.write(b);
+  };
+
+  writeEscaped((uint8_t)((cols >> 8) & 0xff));
+  writeEscaped((uint8_t)(cols & 0xff));
+  writeEscaped((uint8_t)((rows >> 8) & 0xff));
+  writeEscaped((uint8_t)(rows & 0xff));
+
+  uint8_t trailer[2] = {IAC, SE};
+  _client.write(trailer, sizeof(trailer));
+}
+
 void TelnetClientScreen::_handleNegotiation(uint8_t command, uint8_t option) {
   // Conservative client negotiation. Accept server ECHO and suppress-go-ahead;
   // reject options we do not implement. For DO SGA, advertise WILL SGA.
@@ -213,8 +248,17 @@ void TelnetClientScreen::_handleNegotiation(uint8_t command, uint8_t option) {
     if (option == OPT_ECHO || option == OPT_SGA) _sendTelnetReply(DO, option);
     else                                         _sendTelnetReply(DONT, option);
   } else if (command == DO) {
-    if (option == OPT_SGA) _sendTelnetReply(WILL, option);
-    else                   _sendTelnetReply(WONT, option);
+    if (option == OPT_SGA) {
+      _sendTelnetReply(WILL, option);
+    } else if (option == OPT_NAWS) {
+      _sendTelnetReply(WILL, option);
+      _nawsEnabled = true;
+      _sendNaws();
+    } else {
+      _sendTelnetReply(WONT, option);
+    }
+  } else if (command == DONT && option == OPT_NAWS) {
+    _nawsEnabled = false;
   }
   // DONT/WONT require no positive response for this minimal client.
 }
@@ -286,22 +330,31 @@ void TelnetClientScreen::_drainSocket() {
 }
 
 void TelnetClientScreen::_appendByte(uint8_t c) {
-  // Strip ANSI/VT100 control sequences in v1 instead of rendering their
-  // printable payload (e.g. "[1;32m"). Terminal interpretation comes later.
+  // Minimal ANSI/VT100 interpretation for line-oriented sessions. We still do
+  // not emulate a screen: colors/styles and vertical/fullscreen operations are
+  // ignored, while horizontal editing is applied to the current logical line.
   switch (_ansiState) {
     case ANSI_ESC:
+      _ansiParams = "";
       if (c == '[')      _ansiState = ANSI_CSI;
       else if (c == ']') _ansiState = ANSI_OSC;
       else               _ansiState = ANSI_DATA;
       return;
 
     case ANSI_CSI:
-      // CSI ends at the first final byte in 0x40..0x7E.
-      if (c >= 0x40 && c <= 0x7e) _ansiState = ANSI_DATA;
+      if (c >= 0x40 && c <= 0x7e) {
+        _handleAnsiCsi(c);
+        _ansiState = ANSI_DATA;
+        _ansiParams = "";
+      } else if (_ansiParams.length() < 24 &&
+                 ((c >= '0' && c <= '9') || c == ';' || c == '?' || c == '>')) {
+        _ansiParams += (char)c;
+      }
       return;
 
     case ANSI_OSC:
-      // OSC terminates on BEL or ST (ESC \).
+      // OSC terminates on BEL or ST (ESC \). Content is metadata (often a
+      // window title), not terminal transcript text.
       if (c == 0x07)      _ansiState = ANSI_DATA;
       else if (c == 0x1b) _ansiState = ANSI_OSC_ESC;
       return;
@@ -319,31 +372,119 @@ void TelnetClientScreen::_appendByte(uint8_t c) {
       break;
   }
 
-  if (c == '\r') return;
+  // CR returns to column zero. If followed by LF, LF commits the resulting
+  // logical line; a bare CR lets subsequent bytes overwrite that line.
+  if (c == '\r') {
+    _lineCursor = 0;
+    return;
+  }
 
   if (c == '\n') {
     _commitPartial();
     return;
   }
 
+  // Backspace moves left; the common "BS SP BS" erase sequence therefore
+  // works naturally with overwrite semantics.
   if (c == '\b' || c == 0x7f) {
-    if (_partialLine.length() > 0) _partialLine.remove(_partialLine.length() - 1);
+    if (_lineCursor > 0) _lineCursor--;
     return;
   }
 
   if (c == '\t') {
-    _partialLine += "    ";
+    // Traditional terminal tab stops every 8 columns.
+    int spaces = 8 - (_lineCursor % 8);
+    while (spaces-- > 0) _putLineChar(' ');
   } else if (c >= 0x20 && c <= 0x7e) {
-    _partialLine += (char)c;
+    _putLineChar((char)c);
   }
   // Other control/binary bytes are intentionally ignored in text-mode v1.
 
   if ((int)_partialLine.length() >= MAX_PARTIAL_LEN) _commitPartial();
 }
 
+void TelnetClientScreen::_putLineChar(char c) {
+  if (_lineCursor < 0) _lineCursor = 0;
+  if (_lineCursor > (int)_partialLine.length()) {
+    while ((int)_partialLine.length() < _lineCursor) _partialLine += ' ';
+  }
+
+  if (_lineCursor < (int)_partialLine.length()) {
+    _partialLine.setCharAt(_lineCursor, c);
+  } else {
+    _partialLine += c;
+  }
+  _lineCursor++;
+}
+
+int TelnetClientScreen::_ansiParam(int index, int defaultValue) const {
+  int current = 0;
+  int value = 0;
+  bool haveDigit = false;
+
+  for (int i = 0; i <= (int)_ansiParams.length(); i++) {
+    char c = (i < (int)_ansiParams.length()) ? _ansiParams[i] : ';';
+    if (c >= '0' && c <= '9') {
+      value = value * 10 + (c - '0');
+      haveDigit = true;
+    } else if (c == ';') {
+      if (current == index) return haveDigit ? value : defaultValue;
+      current++;
+      value = 0;
+      haveDigit = false;
+    }
+  }
+  return defaultValue;
+}
+
+void TelnetClientScreen::_handleAnsiCsi(uint8_t finalByte) {
+  int n = _ansiParam(0, 1);
+  if (n < 1) n = 1;
+
+  switch (finalByte) {
+    case 'm':
+      // SGR color/style: intentionally ignored in transcript mode.
+      break;
+
+    case 'C': // CUF — cursor forward
+      _lineCursor = min((int)_partialLine.length(), _lineCursor + n);
+      break;
+
+    case 'D': // CUB — cursor backward
+      _lineCursor = max(0, _lineCursor - n);
+      break;
+
+    case 'G': // CHA — horizontal absolute, 1-based
+      _lineCursor = max(0, n - 1);
+      if (_lineCursor > MAX_PARTIAL_LEN) _lineCursor = MAX_PARTIAL_LEN;
+      break;
+
+    case 'K': { // EL — erase in line
+      int mode = _ansiParam(0, 0);
+      if (mode == 2) {
+        _partialLine = "";
+        _lineCursor = 0;
+      } else if (mode == 1) {
+        int upto = min(_lineCursor + 1, (int)_partialLine.length());
+        for (int i = 0; i < upto; i++) _partialLine.setCharAt(i, ' ');
+      } else {
+        if (_lineCursor < (int)_partialLine.length())
+          _partialLine.remove(_lineCursor);
+      }
+      break;
+    }
+
+    // J/A/B/H/f and other screen/cursor operations are intentionally ignored:
+    // the TO is a scrollable transcript, not a VT100 screen emulator.
+    default:
+      break;
+  }
+}
+
 void TelnetClientScreen::_commitPartial() {
   _pushOutputLine(_partialLine);
   _partialLine = "";
+  _lineCursor = 0;
 }
 
 void TelnetClientScreen::_pushOutputLine(const String& line) {
@@ -364,6 +505,8 @@ void TelnetClientScreen::_trimTranscript() {
 void TelnetClientScreen::_clearOutput() {
   _transcript = "";
   _partialLine = "";
+  _lineCursor = 0;
+  _ansiParams = "";
   _followOutput = true;
   _outputView.setContent("");
 }

--- a/firmware/src/screens/wifi/network/remote/TelnetClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/TelnetClientScreen.cpp
@@ -1,0 +1,410 @@
+#include "TelnetClientScreen.h"
+
+#include "core/Device.h"
+#include "core/INavigation.h"
+#include "core/ScreenManager.h"
+#include "ui/actions/InputTextAction.h"
+#include "ui/actions/InputNumberAction.h"
+#include "ui/actions/ShowStatusAction.h"
+
+TelnetClientScreen::~TelnetClientScreen() {
+  _closeConnection(false);
+}
+
+void TelnetClientScreen::onInit() {
+  _updateLabels();
+  _rebuildItems();
+}
+
+void TelnetClientScreen::onUpdate() {
+  if (_state == STATE_CONFIG) {
+    ListScreen::onUpdate();
+    return;
+  }
+
+  // OUTPUT screen: keep draining Telnet continuously while the user reads it.
+  _drainSocket();
+
+  if (!_remoteClosed && !_client.connected()) {
+    // Preserve the final output on-screen instead of immediately returning to
+    // CONFIG. This lets the user inspect a service that closes after replying.
+    _remoteClosed = true;
+    if (_partialLine.length() > 0) _commitPartial();
+    _pushOutputLine("[Connection closed]");
+    render();
+  }
+
+
+  if (!Uni.Nav->wasPressed()) return;
+  auto dir = Uni.Nav->readDirection();
+
+  if (dir == INavigation::DIR_BACK) {
+    _closeConnection(true);
+    return;
+  }
+
+  if (dir == INavigation::DIR_PRESS && !_remoteClosed) {
+    _openCommandInput();
+    return;
+  }
+
+  if (dir == INavigation::DIR_UP || dir == INavigation::DIR_DOWN ||
+      dir == INavigation::DIR_LEFT || dir == INavigation::DIR_RIGHT) {
+    if (_outputView.onNav(dir)) {
+      _followOutput = _outputView.isAtBottom();
+    }
+  }
+}
+
+void TelnetClientScreen::onRender() {
+  if (_state == STATE_CONFIG) {
+    ListScreen::onRender();
+    return;
+  }
+
+  _renderOutput();
+}
+
+void TelnetClientScreen::onBack() {
+  if (_state == STATE_OUTPUT) {
+    _closeConnection(true);
+  } else {
+    Screen.goBack();
+  }
+}
+
+void TelnetClientScreen::onItemSelected(uint8_t index) {
+  switch (index) {
+    case 0: _configHost(); break;
+    case 1: _configPort(); break;
+    case 2: _connect();    break;
+    default: break;
+  }
+}
+
+void TelnetClientScreen::_updateLabels() {
+  if (_host.length() == 0) snprintf(_hostLabel, sizeof(_hostLabel), "tap to set");
+  else                     _host.toCharArray(_hostLabel, sizeof(_hostLabel));
+
+  if (_port <= 0) snprintf(_portLabel, sizeof(_portLabel), "tap to set");
+  else            snprintf(_portLabel, sizeof(_portLabel), "%d", _port);
+}
+
+void TelnetClientScreen::_rebuildItems() {
+  uint8_t sel = _selectedIndex;
+  _items[0] = {"Host", _hostLabel};
+  _items[1] = {"Port", _portLabel};
+  _items[2] = {"Connect", nullptr};
+  setItems(_items, 3, sel);
+}
+
+void TelnetClientScreen::_configHost() {
+  String initial = _host;
+  if (initial.length() == 0 && WiFi.status() == WL_CONNECTED) {
+    IPAddress ip = WiFi.localIP();
+    initial = String(ip[0]) + "." + String(ip[1]) + "." + String(ip[2]) + ".";
+  }
+
+  String value = InputTextAction::popup("Host", initial, InputTextAction::INPUT_IP_ADDRESS);
+  if (!InputTextAction::wasCancelled() && value.length() > 0) {
+    _host = value;
+    _updateLabels();
+    _rebuildItems();
+  }
+  render();
+}
+
+void TelnetClientScreen::_configPort() {
+  int value = InputNumberAction::popup("Port", 1, 65535, _port > 0 ? _port : 0);
+  if (!InputNumberAction::wasCancelled()) {
+    _port = value;
+    _updateLabels();
+    _rebuildItems();
+  }
+  render();
+}
+
+void TelnetClientScreen::_connect() {
+  if (_host.length() == 0) {
+    ShowStatusAction::show("Host required", 1200);
+    render();
+    return;
+  }
+  if (_port < 1 || _port > 65535) {
+    ShowStatusAction::show("Port required", 1200);
+    render();
+    return;
+  }
+  if (WiFi.status() != WL_CONNECTED) {
+    ShowStatusAction::show("WiFi not connected", 1500);
+    render();
+    return;
+  }
+
+  ShowStatusAction::show("Connecting...", 0);
+  _client.stop();
+
+  if (!_client.connect(_host.c_str(), (uint16_t)_port, 5000)) {
+    ShowStatusAction::show("Connection failed", 1500);
+    render();
+    return;
+  }
+
+  _clearOutput();
+  _remoteClosed = false;
+  _tnState = TN_DATA;
+  _tnCommand = 0;
+  _tnSbHasOption = false;
+  _ansiState = ANSI_DATA;
+  _state = STATE_OUTPUT;
+  _followOutput = true;
+  render();
+}
+
+void TelnetClientScreen::_closeConnection(bool returnToConfig) {
+  if (_client) _client.stop();
+  _remoteClosed = false;
+
+  if (returnToConfig) {
+    _state = STATE_CONFIG;
+    _updateLabels();
+    _rebuildItems();
+    render();
+  }
+}
+
+void TelnetClientScreen::_openCommandInput() {
+  // Always begin with an empty command. EXIT cancels and returns to OUTPUT;
+  // BACK remains owned by InputTextAction (ABC <-> 123 in text mode).
+  String command = InputTextAction::popup("Command", "", InputTextAction::INPUT_TEXT);
+
+  if (!InputTextAction::wasCancelled()) {
+    _sendCommand(command);
+  }
+
+  // Data may have arrived while the modal keyboard was open.
+  _drainSocket();
+  render();
+}
+
+void TelnetClientScreen::_sendCommand(const String& command) {
+  if (_remoteClosed || !_client.connected()) return;
+
+  // Telnet command mode uses conventional CRLF line termination.
+  _pushOutputLine(String("> ") + command);
+  _followOutput = true;
+
+  if (command.length() > 0) {
+    _client.write(reinterpret_cast<const uint8_t*>(command.c_str()), command.length());
+  }
+  _client.write((uint8_t)'\r');
+  _client.write((uint8_t)'\n');
+}
+
+void TelnetClientScreen::_sendTelnetReply(uint8_t command, uint8_t option) {
+  uint8_t reply[3] = {IAC, command, option};
+  _client.write(reply, sizeof(reply));
+}
+
+void TelnetClientScreen::_handleNegotiation(uint8_t command, uint8_t option) {
+  // Conservative client negotiation. Accept server ECHO and suppress-go-ahead;
+  // reject options we do not implement. For DO SGA, advertise WILL SGA.
+  if (command == WILL) {
+    if (option == OPT_ECHO || option == OPT_SGA) _sendTelnetReply(DO, option);
+    else                                         _sendTelnetReply(DONT, option);
+  } else if (command == DO) {
+    if (option == OPT_SGA) _sendTelnetReply(WILL, option);
+    else                   _sendTelnetReply(WONT, option);
+  }
+  // DONT/WONT require no positive response for this minimal client.
+}
+
+void TelnetClientScreen::_processTelnetByte(uint8_t c) {
+  switch (_tnState) {
+    case TN_DATA:
+      if (c == IAC) _tnState = TN_IAC;
+      else          _appendByte(c);
+      break;
+
+    case TN_IAC:
+      if (c == IAC) {
+        // Escaped 0xFF data byte. Text-mode TO cannot render it, so ignore.
+        _tnState = TN_DATA;
+      } else if (c == WILL || c == WONT || c == DO || c == DONT) {
+        _tnCommand = c;
+        _tnState = TN_NEGOTIATE;
+      } else if (c == SB) {
+        _tnSbHasOption = false;
+        _tnState = TN_SB;
+      } else {
+        // Other one-byte Telnet commands (NOP, GA, etc.) are ignored.
+        _tnState = TN_DATA;
+      }
+      break;
+
+    case TN_NEGOTIATE:
+      _handleNegotiation(_tnCommand, c);
+      _tnState = TN_DATA;
+      break;
+
+    case TN_SB:
+      if (!_tnSbHasOption) {
+        _tnSbOption = c;
+        _tnSbHasOption = true;
+      } else if (c == IAC) {
+        _tnState = TN_SB_IAC;
+      }
+      // Subnegotiation payload is intentionally ignored in v1.
+      break;
+
+    case TN_SB_IAC:
+      if (c == SE) {
+        _tnState = TN_DATA;
+        _tnSbHasOption = false;
+      } else if (c != IAC) {
+        _tnState = TN_SB;
+      } else {
+        _tnState = TN_SB;
+      }
+      break;
+  }
+}
+
+void TelnetClientScreen::_drainSocket() {
+  bool gotData = false;
+
+  while (_client.available()) {
+    uint8_t buf[128];
+    int n = _client.read(buf, sizeof(buf));
+    if (n <= 0) break;
+
+    gotData = true;
+    for (int i = 0; i < n; i++) _processTelnetByte(buf[i]);
+  }
+
+  if (gotData) render();
+}
+
+void TelnetClientScreen::_appendByte(uint8_t c) {
+  // Strip ANSI/VT100 control sequences in v1 instead of rendering their
+  // printable payload (e.g. "[1;32m"). Terminal interpretation comes later.
+  switch (_ansiState) {
+    case ANSI_ESC:
+      if (c == '[')      _ansiState = ANSI_CSI;
+      else if (c == ']') _ansiState = ANSI_OSC;
+      else               _ansiState = ANSI_DATA;
+      return;
+
+    case ANSI_CSI:
+      // CSI ends at the first final byte in 0x40..0x7E.
+      if (c >= 0x40 && c <= 0x7e) _ansiState = ANSI_DATA;
+      return;
+
+    case ANSI_OSC:
+      // OSC terminates on BEL or ST (ESC \).
+      if (c == 0x07)      _ansiState = ANSI_DATA;
+      else if (c == 0x1b) _ansiState = ANSI_OSC_ESC;
+      return;
+
+    case ANSI_OSC_ESC:
+      _ansiState = (c == '\\') ? ANSI_DATA : ANSI_OSC;
+      return;
+
+    case ANSI_DATA:
+    default:
+      if (c == 0x1b) {
+        _ansiState = ANSI_ESC;
+        return;
+      }
+      break;
+  }
+
+  if (c == '\r') return;
+
+  if (c == '\n') {
+    _commitPartial();
+    return;
+  }
+
+  if (c == '\b' || c == 0x7f) {
+    if (_partialLine.length() > 0) _partialLine.remove(_partialLine.length() - 1);
+    return;
+  }
+
+  if (c == '\t') {
+    _partialLine += "    ";
+  } else if (c >= 0x20 && c <= 0x7e) {
+    _partialLine += (char)c;
+  }
+  // Other control/binary bytes are intentionally ignored in text-mode v1.
+
+  if ((int)_partialLine.length() >= MAX_PARTIAL_LEN) _commitPartial();
+}
+
+void TelnetClientScreen::_commitPartial() {
+  _pushOutputLine(_partialLine);
+  _partialLine = "";
+}
+
+void TelnetClientScreen::_pushOutputLine(const String& line) {
+  _transcript += line;
+  _transcript += '\n';
+  _trimTranscript();
+}
+
+void TelnetClientScreen::_trimTranscript() {
+  if ((int)_transcript.length() <= MAX_TRANSCRIPT_CHARS) return;
+
+  int excess = (int)_transcript.length() - MAX_TRANSCRIPT_CHARS;
+  int cut = _transcript.indexOf('\n', excess);
+  if (cut >= 0) _transcript.remove(0, cut + 1);
+  else          _transcript.remove(0, excess);
+}
+
+void TelnetClientScreen::_clearOutput() {
+  _transcript = "";
+  _partialLine = "";
+  _followOutput = true;
+  _outputView.setContent("");
+}
+
+void TelnetClientScreen::_renderOutput() {
+  auto& lcd = Uni.Lcd;
+  const int x = bodyX();
+  const int y = bodyY();
+  const int w = bodyW();
+  const int h = bodyH();
+
+  lcd.fillRect(x, y, w, h, TFT_BLACK);
+  lcd.setTextFont(1);
+  lcd.setTextSize(1);
+  lcd.setTextDatum(TL_DATUM);
+
+  int cy = y + PAD;
+
+  // Fixed connection information at the top of every OUTPUT screen.
+  lcd.setTextColor(TFT_GREEN, TFT_BLACK);
+  String connected = "Connected to " + _host + ":" + String(_port);
+  lcd.drawString(connected.c_str(), x + PAD, cy);
+  cy += 11;
+
+  lcd.drawFastHLine(x + PAD, cy, w - PAD * 2, TFT_DARKGREY);
+  cy += 4;
+
+  const int footerY = y + h - FOOTER_H;
+  const int outputBottom = footerY - 2;
+
+  String display = _transcript;
+  if (_partialLine.length() > 0) display += _partialLine;
+  if (display.length() == 0 && !_remoteClosed) display = "Waiting for data...";
+
+  _outputView.updateContent(display, _followOutput);
+  _outputView.render(x, cy, w, max(1, outputBottom - cy));
+
+  lcd.drawFastHLine(x + PAD, footerY - 2, w - PAD * 2, TFT_DARKGREY);
+  lcd.setTextDatum(MC_DATUM);
+  lcd.setTextColor(TFT_DARKGREY, TFT_BLACK);
+  lcd.drawString(_remoteClosed ? "BACK: Exit" : "PRESS: Cmd | BACK: Exit",
+                 x + w / 2, footerY + FOOTER_H / 2 - 1);
+  lcd.setTextDatum(TL_DATUM);
+}

--- a/firmware/src/screens/wifi/network/remote/TelnetClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/TelnetClientScreen.cpp
@@ -86,7 +86,7 @@ void TelnetClientScreen::onItemSelected(uint8_t index) {
 }
 
 void TelnetClientScreen::_updateLabels() {
-  if (_host.length() == 0) snprintf(_hostLabel, sizeof(_hostLabel), "tap to set");
+  if (_host.length() == 0) snprintf(_hostLabel, sizeof(_hostLabel), "-");
   else                     _host.toCharArray(_hostLabel, sizeof(_hostLabel));
 
   if (_port <= 0) snprintf(_portLabel, sizeof(_portLabel), "tap to set");

--- a/firmware/src/screens/wifi/network/remote/TelnetClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/TelnetClientScreen.h
@@ -26,6 +26,8 @@ private:
   static constexpr int MAX_TRANSCRIPT_CHARS = 4096;
   static constexpr int PAD                  = 4;
   static constexpr int FOOTER_H             = 12;
+  static constexpr size_t MAX_RX_PER_UPDATE   = 1024;
+  static constexpr uint32_t WRITE_TIMEOUT_MS   = 2000;
 
   static constexpr uint8_t IAC  = 255;
   static constexpr uint8_t DONT = 254;
@@ -71,6 +73,8 @@ private:
 
   void _openCommandInput();
   void _sendCommand(const String& command);
+  bool _writeAll(const uint8_t* data, size_t len);
+  void _handleSendFailure();
   void _sendTelnetReply(uint8_t command, uint8_t option);
   void _sendNaws();
   void _handleNegotiation(uint8_t command, uint8_t option);

--- a/firmware/src/screens/wifi/network/remote/TelnetClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/TelnetClientScreen.h
@@ -36,6 +36,7 @@ private:
   static constexpr uint8_t SE   = 240;
   static constexpr uint8_t OPT_ECHO = 1;
   static constexpr uint8_t OPT_SGA  = 3;
+  static constexpr uint8_t OPT_NAWS = 31;
 
   State      _state = STATE_CONFIG;
   WiFiClient _client;
@@ -49,6 +50,8 @@ private:
   TextScrollView _outputView;
   String _transcript;
   String _partialLine;
+  int    _lineCursor = 0;
+  String _ansiParams;
   bool   _remoteClosed = false;
   bool   _followOutput = true;
 
@@ -56,6 +59,7 @@ private:
   uint8_t _tnCommand = 0;
   uint8_t _tnSbOption = 0;
   bool _tnSbHasOption = false;
+  bool _nawsEnabled = false;
   AnsiParseState _ansiState = ANSI_DATA;
 
   void _updateLabels();
@@ -68,11 +72,15 @@ private:
   void _openCommandInput();
   void _sendCommand(const String& command);
   void _sendTelnetReply(uint8_t command, uint8_t option);
+  void _sendNaws();
   void _handleNegotiation(uint8_t command, uint8_t option);
   void _processTelnetByte(uint8_t c);
 
   void _drainSocket();
   void _appendByte(uint8_t c);
+  void _handleAnsiCsi(uint8_t finalByte);
+  int  _ansiParam(int index, int defaultValue) const;
+  void _putLineChar(char c);
   void _commitPartial();
   void _pushOutputLine(const String& line);
   void _trimTranscript();

--- a/firmware/src/screens/wifi/network/remote/TelnetClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/TelnetClientScreen.h
@@ -2,6 +2,7 @@
 
 #include "ui/templates/ListScreen.h"
 #include "ui/views/TextScrollView.h"
+#include "ui/views/TerminalCommandLine.h"
 #include <WiFi.h>
 #include <WiFiClient.h>
 
@@ -25,7 +26,7 @@ private:
   static constexpr int MAX_PARTIAL_LEN      = 160;
   static constexpr int MAX_TRANSCRIPT_CHARS = 4096;
   static constexpr int PAD                  = 4;
-  static constexpr int FOOTER_H             = 12;
+  static constexpr int INPUT_H              = 14;
   static constexpr size_t MAX_RX_PER_UPDATE   = 1024;
   static constexpr uint32_t WRITE_TIMEOUT_MS   = 2000;
 
@@ -50,6 +51,7 @@ private:
   ListItem _items[3];
 
   TextScrollView _outputView;
+  TerminalCommandLine _inputLine;
   String _transcript;
   String _partialLine;
   int    _lineCursor = 0;
@@ -72,6 +74,7 @@ private:
   void _closeConnection(bool returnToConfig = true);
 
   void _openCommandInput();
+  void _handleTerminalInput();
   void _sendCommand(const String& command);
   bool _writeAll(const uint8_t* data, size_t len);
   void _handleSendFailure();

--- a/firmware/src/screens/wifi/network/remote/TelnetClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/TelnetClientScreen.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+#include "ui/views/TextScrollView.h"
+#include <WiFi.h>
+#include <WiFiClient.h>
+
+class TelnetClientScreen : public ListScreen
+{
+public:
+  const char* title() override { return "Telnet Client"; }
+  ~TelnetClientScreen();
+
+  void onInit() override;
+  void onUpdate() override;
+  void onRender() override;
+  void onBack() override;
+  void onItemSelected(uint8_t index) override;
+
+private:
+  enum State : uint8_t { STATE_CONFIG, STATE_OUTPUT };
+  enum TelnetParseState : uint8_t { TN_DATA, TN_IAC, TN_NEGOTIATE, TN_SB, TN_SB_IAC };
+  enum AnsiParseState   : uint8_t { ANSI_DATA, ANSI_ESC, ANSI_CSI, ANSI_OSC, ANSI_OSC_ESC };
+
+  static constexpr int MAX_PARTIAL_LEN      = 160;
+  static constexpr int MAX_TRANSCRIPT_CHARS = 4096;
+  static constexpr int PAD                  = 4;
+  static constexpr int FOOTER_H             = 12;
+
+  static constexpr uint8_t IAC  = 255;
+  static constexpr uint8_t DONT = 254;
+  static constexpr uint8_t DO   = 253;
+  static constexpr uint8_t WONT = 252;
+  static constexpr uint8_t WILL = 251;
+  static constexpr uint8_t SB   = 250;
+  static constexpr uint8_t SE   = 240;
+  static constexpr uint8_t OPT_ECHO = 1;
+  static constexpr uint8_t OPT_SGA  = 3;
+
+  State      _state = STATE_CONFIG;
+  WiFiClient _client;
+
+  String _host;
+  int    _port = 23;
+  char _hostLabel[40] = {};
+  char _portLabel[16] = {};
+  ListItem _items[3];
+
+  TextScrollView _outputView;
+  String _transcript;
+  String _partialLine;
+  bool   _remoteClosed = false;
+  bool   _followOutput = true;
+
+  TelnetParseState _tnState = TN_DATA;
+  uint8_t _tnCommand = 0;
+  uint8_t _tnSbOption = 0;
+  bool _tnSbHasOption = false;
+  AnsiParseState _ansiState = ANSI_DATA;
+
+  void _updateLabels();
+  void _rebuildItems();
+  void _configHost();
+  void _configPort();
+  void _connect();
+  void _closeConnection(bool returnToConfig = true);
+
+  void _openCommandInput();
+  void _sendCommand(const String& command);
+  void _sendTelnetReply(uint8_t command, uint8_t option);
+  void _handleNegotiation(uint8_t command, uint8_t option);
+  void _processTelnetByte(uint8_t c);
+
+  void _drainSocket();
+  void _appendByte(uint8_t c);
+  void _commitPartial();
+  void _pushOutputLine(const String& line);
+  void _trimTranscript();
+  void _clearOutput();
+
+  void _renderOutput();
+};

--- a/firmware/src/screens/wifi/network/remote/WebDavClientScreen.cpp
+++ b/firmware/src/screens/wifi/network/remote/WebDavClientScreen.cpp
@@ -1,0 +1,1472 @@
+#include "WebDavClientScreen.h"
+
+#include "core/Device.h"
+#include "core/INavigation.h"
+#include "core/ScreenManager.h"
+#include "ui/actions/InputSelectAction.h"
+#include "ui/actions/InputTextAction.h"
+#include "ui/actions/ShowStatusAction.h"
+#include "ui/views/ProgressView.h"
+
+#include <FS.h>
+#include <HTTPClient.h>
+#include <WiFi.h>
+#include <WiFiClient.h>
+#include <WiFiClientSecure.h>
+#include <new>
+
+static bool _davOk(int code) {
+  return code >= 200 && code < 300;
+}
+
+static bool _davTagLocalEquals(const String& qname, const char* localName) {
+  int colon = qname.lastIndexOf(':');
+  String local = colon >= 0 ? qname.substring(colon + 1) : qname;
+  return local.equalsIgnoreCase(localName);
+}
+
+static bool _davNextElementBlock(const String& xml,
+                                 const char* localName,
+                                 int& pos,
+                                 String& block) {
+  block = "";
+
+  while (pos < (int)xml.length()) {
+    int lt = xml.indexOf('<', pos);
+    if (lt < 0) return false;
+
+    int nameStart = lt + 1;
+    if (nameStart >= (int)xml.length()) return false;
+
+    char first = xml[nameStart];
+    if (first == '/' || first == '?' || first == '!') {
+      pos = nameStart + 1;
+      continue;
+    }
+
+    int nameEnd = nameStart;
+    while (nameEnd < (int)xml.length()) {
+      char c = xml[nameEnd];
+      if (c == '>' || c == '/' || c == ' ' || c == '\t' ||
+          c == '\r' || c == '\n')
+        break;
+      nameEnd++;
+    }
+
+    if (nameEnd <= nameStart) {
+      pos = nameStart + 1;
+      continue;
+    }
+
+    String qname = xml.substring(nameStart, nameEnd);
+    if (!_davTagLocalEquals(qname, localName)) {
+      pos = nameEnd;
+      continue;
+    }
+
+    int openEnd = xml.indexOf('>', nameEnd);
+    if (openEnd < 0) return false;
+
+    String closeTag = "</" + qname + ">";
+    int close = xml.indexOf(closeTag, openEnd + 1);
+    if (close < 0) return false;
+
+    int end = close + closeTag.length();
+    block = xml.substring(lt, end);
+    pos = end;
+    return true;
+  }
+
+  return false;
+}
+
+static bool _davHasElement(const String& xml, const char* localName) {
+  int pos = 0;
+
+  while (pos < (int)xml.length()) {
+    int lt = xml.indexOf('<', pos);
+    if (lt < 0) return false;
+
+    int nameStart = lt + 1;
+    if (nameStart >= (int)xml.length()) return false;
+
+    char first = xml[nameStart];
+    if (first == '/' || first == '?' || first == '!') {
+      pos = nameStart + 1;
+      continue;
+    }
+
+    int nameEnd = nameStart;
+    while (nameEnd < (int)xml.length()) {
+      char c = xml[nameEnd];
+      if (c == '>' || c == '/' || c == ' ' || c == '\t' ||
+          c == '\r' || c == '\n')
+        break;
+      nameEnd++;
+    }
+
+    if (nameEnd > nameStart) {
+      String qname = xml.substring(nameStart, nameEnd);
+      if (_davTagLocalEquals(qname, localName)) return true;
+    }
+
+    pos = nameEnd > nameStart ? nameEnd : nameStart + 1;
+  }
+
+  return false;
+}
+
+static bool _davReadBodyLimited(HTTPClient& http, String& out, size_t maxBytes) {
+  out = "";
+  int remaining = http.getSize();
+
+  if (remaining > 0 && (size_t)remaining > maxBytes) return false;
+
+  size_t reserveBytes = remaining > 0
+      ? min<size_t>((size_t)remaining + 1, maxBytes)
+      : min<size_t>(4096, maxBytes);
+  out.reserve(reserveBytes);
+
+  WiFiClient* stream = http.getStreamPtr();
+  if (!stream) return false;
+
+  uint8_t buf[512];
+  uint32_t lastData = millis();
+
+  while ((http.connected() || stream->available()) &&
+         (remaining > 0 || remaining == -1)) {
+    int avail = stream->available();
+    if (avail > 0) {
+      int n = stream->read(buf, min<int>(avail, sizeof(buf)));
+      if (n <= 0) break;
+
+      if (out.length() + (size_t)n > maxBytes) return false;
+      out.concat(reinterpret_cast<const char*>(buf), (unsigned int)n);
+
+      lastData = millis();
+      if (remaining > 0) remaining -= n;
+    } else {
+      if (remaining == 0) break;
+      if (millis() - lastData > 12000) return false;
+      delay(2);
+    }
+  }
+
+  return remaining <= 0;
+}
+
+const char* WebDavClientScreen::title() {
+  switch (_state) {
+    case STATE_REMOTE_BROWSER:
+      return _remoteMode == REMOTE_UPLOAD_DEST ? "WebDAV Upload" : "WebDAV Download";
+    case STATE_LOCAL_BROWSER:
+      return "WebDAV Upload";
+    case STATE_TRANSFER:
+      return _transferIsUpload ? "WebDAV Upload" : "WebDAV Download";
+    default:
+      return "WebDAV Client";
+  }
+}
+
+void WebDavClientScreen::onInit() {
+  _updateLabels();
+  _rebuildConfig();
+}
+
+void WebDavClientScreen::onUpdate() {
+  if (_state == STATE_TRANSFER) {
+    _updateProgress();
+    if (Uni.Nav->wasPressed() &&
+        Uni.Nav->readDirection() == INavigation::DIR_BACK) {
+      _cancelTransfer = true;
+    }
+    return;
+  }
+
+  if (_state == STATE_LOCAL_BROWSER) {
+    if (Uni.Nav->isPressed() && !_holdHandled &&
+        Uni.Nav->heldDuration() >= HOLD_MS) {
+      _holdHandled = true;
+      Uni.Nav->suppressCurrentPress();
+      _holdLocal(_selectedIndex);
+      return;
+    }
+    if (!Uni.Nav->isPressed()) _holdHandled = false;
+    ListScreen::onUpdate();
+    return;
+  }
+
+  if (_state == STATE_REMOTE_BROWSER) {
+    if (Uni.Nav->isPressed() && !_holdHandled &&
+        Uni.Nav->heldDuration() >= HOLD_MS) {
+      _holdHandled = true;
+      Uni.Nav->suppressCurrentPress();
+      _holdRemote(_selectedIndex);
+      return;
+    }
+    if (!Uni.Nav->isPressed()) _holdHandled = false;
+    ListScreen::onUpdate();
+    return;
+  }
+
+  ListScreen::onUpdate();
+}
+
+void WebDavClientScreen::onRender() {
+  if (_state == STATE_TRANSFER) return;
+  if (_state == STATE_REMOTE_BROWSER) {
+    _renderRemoteBrowser();
+    return;
+  }
+  if (_state == STATE_LOCAL_BROWSER) {
+    _renderLocalBrowser();
+    return;
+  }
+  ListScreen::onRender();
+}
+
+void WebDavClientScreen::onItemSelected(uint8_t index) {
+  if (_state == STATE_ACTION) {
+    if (index == 0) _beginDownload();
+    else if (index == 1) _beginUpload();
+    return;
+  }
+
+  if (_state == STATE_REMOTE_BROWSER) {
+    _selectRemote(index);
+    return;
+  }
+
+  if (_state == STATE_LOCAL_BROWSER) {
+    _selectLocal(index);
+    return;
+  }
+
+  if (_state != STATE_CONFIG) return;
+
+  switch (index) {
+    case 0: _configUrl(); break;
+    case 1: _configUsername(); break;
+    case 2: _configPassword(); break;
+    case 3: _connect(); break;
+    default: break;
+  }
+}
+
+void WebDavClientScreen::onBack() {
+  if (_state == STATE_TRANSFER) {
+    _cancelTransfer = true;
+    return;
+  }
+
+  if (_state == STATE_REMOTE_BROWSER) {
+    if (_remoteMode == REMOTE_UPLOAD_DEST) {
+      _state = STATE_LOCAL_BROWSER;
+      render();
+    } else {
+      _showActions();
+    }
+    return;
+  }
+
+  if (_state == STATE_LOCAL_BROWSER) {
+    _showActions();
+    return;
+  }
+
+  if (_state == STATE_ACTION) {
+    _state = STATE_CONFIG;
+    _updateLabels();
+    _rebuildConfig();
+    render();
+    return;
+  }
+
+  Screen.goBack();
+}
+
+void WebDavClientScreen::_updateLabels() {
+  String shown = _baseUrl.length() ? _baseUrl : "-";
+  if (shown.length() >= sizeof(_urlLabel))
+    shown = "..." + shown.substring(shown.length() - sizeof(_urlLabel) + 4);
+  shown.toCharArray(_urlLabel, sizeof(_urlLabel));
+
+  snprintf(_userLabel, sizeof(_userLabel), "%s",
+           _username.length() ? _username.c_str() : "-");
+  snprintf(_passwordLabel, sizeof(_passwordLabel), "%s",
+           _password.length() ? "********" : "-");
+}
+
+void WebDavClientScreen::_rebuildConfig() {
+  uint8_t sel = min<uint8_t>(_selectedIndex, 3);
+  _configItems[0] = {"Server URL", _urlLabel};
+  _configItems[1] = {"Username", _userLabel};
+  _configItems[2] = {"Password", _passwordLabel};
+  _configItems[3] = {"Connect", nullptr};
+  setItems(_configItems, 4, sel);
+}
+
+void WebDavClientScreen::_showActions() {
+  _state = STATE_ACTION;
+  setItems(_actionItems, 2, 0);
+  render();
+}
+
+void WebDavClientScreen::_configUrl() {
+  String initial = _baseUrl.length() ? _baseUrl : "http://";
+  String value = InputTextAction::popup("Server URL", initial.c_str());
+  if (!InputTextAction::wasCancelled() && value.length())
+    _baseUrl = _normalizeBase(value);
+  _selectedIndex = 0;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void WebDavClientScreen::_configUsername() {
+  String value = InputTextAction::popup("Username", _username.c_str());
+  if (!InputTextAction::wasCancelled()) _username = value;
+  _selectedIndex = 1;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void WebDavClientScreen::_configPassword() {
+  String value = InputTextAction::popup("Password", "");
+  if (!InputTextAction::wasCancelled()) _password = value;
+  _selectedIndex = 2;
+  _updateLabels();
+  _rebuildConfig();
+  render();
+}
+
+void WebDavClientScreen::_connect() {
+  if (!_baseUrl.startsWith("http://") && !_baseUrl.startsWith("https://")) {
+    ShowStatusAction::show("Use http:// or https://", 1500);
+    render();
+    return;
+  }
+  if (_baseUrl.indexOf('?') >= 0 || _baseUrl.indexOf('#') >= 0) {
+    ShowStatusAction::show("URL must not contain ? or #", 1600);
+    render();
+    return;
+  }
+  if (WiFi.status() != WL_CONNECTED) {
+    ShowStatusAction::show("WiFi not connected", 1500);
+    render();
+    return;
+  }
+
+  uint8_t count = 0;
+  if (!_propfind("", nullptr, count)) {
+    ShowStatusAction::show(
+        _lastError.length() ? _lastError.c_str() : "WebDAV connection failed",
+        1700);
+    render();
+    return;
+  }
+
+  _showActions();
+}
+
+void WebDavClientScreen::_beginDownload() {
+  _remoteMode = REMOTE_DOWNLOAD;
+  if (!_loadRemote("")) {
+    ShowStatusAction::show(
+        _lastError.length() ? _lastError.c_str() : "Remote listing failed",
+        1500);
+    _showActions();
+  }
+}
+
+void WebDavClientScreen::_beginUpload() {
+  if (!Uni.Storage || !Uni.Storage->isAvailable()) {
+    ShowStatusAction::show("Storage not available", 1500);
+    render();
+    return;
+  }
+
+  _uploadLocalPath = "";
+  _uploadName = "";
+  _uploadIsDir = false;
+  _localBrowser.root = "/";
+  _loadLocalDir("/");
+}
+
+void WebDavClientScreen::_loadLocalDir(const String& path) {
+  uint8_t n = _localBrowser.load(this, path, {}, "SD");
+  _state = STATE_LOCAL_BROWSER;
+  setItems(_localBrowser.items(), n);
+  render();
+}
+
+void WebDavClientScreen::_selectLocal(uint8_t index) {
+  if (index >= _localBrowser.count()) return;
+  const auto& e = _localBrowser.entry(index);
+
+  if (e.isDir) {
+    _loadLocalDir(e.path);
+    return;
+  }
+  _chooseUploadSource(e.path, e.name, false);
+}
+
+void WebDavClientScreen::_holdLocal(uint8_t index) {
+  if (index >= _localBrowser.count()) return;
+  const auto& e = _localBrowser.entry(index);
+  if (!e.isDir || e.name == "..") return;
+  _chooseUploadSource(e.path, e.name, true);
+}
+
+void WebDavClientScreen::_chooseUploadSource(const String& path,
+                                             const String& name,
+                                             bool isDir) {
+  _uploadLocalPath = path;
+  _uploadName = name;
+  _uploadIsDir = isDir;
+  _chooseUploadDestinationMode();
+}
+
+void WebDavClientScreen::_chooseUploadDestinationMode() {
+  static constexpr InputSelectAction::Option opts[] = {
+    {"Downloads", "downloads"},
+    {"Browse", "browse"},
+  };
+
+  const char* result =
+      InputSelectAction::popup("Upload Destination", opts, 2, "downloads");
+
+  if (!result) {
+    _state = STATE_LOCAL_BROWSER;
+    render();
+    return;
+  }
+
+  if (!strcmp(result, "downloads")) {
+    _chooseUploadDestination("Downloads/");
+    return;
+  }
+
+  _remoteMode = REMOTE_UPLOAD_DEST;
+  if (!_loadRemote("")) {
+    ShowStatusAction::show(
+        _lastError.length() ? _lastError.c_str() : "Remote listing failed",
+        1500);
+    _state = STATE_LOCAL_BROWSER;
+    render();
+  }
+}
+
+bool WebDavClientScreen::_loadRemote(const String& path) {
+  BrowseFileView::showLoading();
+
+  RemoteEntry temp[MAX_REMOTE_ENTRIES];
+  uint8_t count = 0;
+  if (!_propfind(path, temp, count)) return false;
+
+  _remotePath = _normalizeRemote(path, true);
+  _entryCount = count;
+  for (uint8_t i = 0; i < count; ++i) _entries[i] = temp[i];
+
+  _buildRemoteItems();
+  _state = STATE_REMOTE_BROWSER;
+  render();
+  return true;
+}
+
+void WebDavClientScreen::_buildRemoteItems() {
+  uint8_t out = 0;
+
+  if (_remoteMode == REMOTE_UPLOAD_DEST) {
+    _remoteNames[out] = ".";
+    _remoteSubs[out] = "UPLOAD HERE";
+    _remotePaths[out] = _remotePath;
+    _remoteIsDir[out] = true;
+    _remoteSizes[out] = 0;
+    _remoteItems[out] = {_remoteNames[out].c_str(), _remoteSubs[out].c_str()};
+    out++;
+  }
+
+  if (_remotePath.length()) {
+    _remoteNames[out] = "..";
+    _remoteSubs[out] = "DIR";
+    _remotePaths[out] = _parentRemote(_remotePath);
+    _remoteIsDir[out] = true;
+    _remoteSizes[out] = 0;
+    _remoteItems[out] = {_remoteNames[out].c_str(), _remoteSubs[out].c_str()};
+    out++;
+  }
+
+  for (uint8_t i = 0; i < _entryCount && out < MAX_REMOTE_ENTRIES + 2; ++i, ++out) {
+    _remoteNames[out] = _entries[i].name;
+    _remotePaths[out] = _entries[i].path;
+    _remoteIsDir[out] = _entries[i].isDir;
+    _remoteSizes[out] = _entries[i].size;
+
+    if (_entries[i].isDir)
+      _remoteSubs[out] = "DIR";
+    else if (_entries[i].size >= 1024 * 1024)
+      _remoteSubs[out] = String((double)_entries[i].size / (1024.0 * 1024.0), 1) + " MB";
+    else if (_entries[i].size >= 1024)
+      _remoteSubs[out] = String((double)_entries[i].size / 1024.0, 1) + " KB";
+    else
+      _remoteSubs[out] = String((unsigned long)_entries[i].size) + " B";
+
+    _remoteItems[out] = {_remoteNames[out].c_str(), _remoteSubs[out].c_str()};
+  }
+
+  _remoteCount = out;
+  setItems(_remoteItems, _remoteCount, 0);
+}
+
+void WebDavClientScreen::_selectRemote(uint8_t index) {
+  if (index >= _remoteCount) return;
+
+  if (_remoteMode == REMOTE_UPLOAD_DEST) {
+    if (_remoteNames[index] == ".") {
+      _chooseUploadDestination(_remotePaths[index]);
+    } else if (_remoteIsDir[index]) {
+      if (!_loadRemote(_remotePaths[index]))
+        ShowStatusAction::show(
+        _lastError.length() ? _lastError.c_str() : "Remote listing failed",
+        1500);
+    }
+    return;
+  }
+
+  if (_remoteIsDir[index]) {
+    if (!_loadRemote(_remotePaths[index]))
+      ShowStatusAction::show(
+        _lastError.length() ? _lastError.c_str() : "Remote listing failed",
+        1500);
+    return;
+  }
+
+  if (!_confirm("Download file?")) {
+    render();
+    return;
+  }
+
+  Uni.Storage->makeDir("/unigeek");
+  Uni.Storage->makeDir("/unigeek/wifi");
+  Uni.Storage->makeDir("/unigeek/wifi/remote");
+  Uni.Storage->makeDir("/unigeek/wifi/remote/webdav");
+  Uni.Storage->makeDir(DOWNLOAD_DIR);
+
+  String local = String(DOWNLOAD_DIR) + "/" +
+                 _safeLocalName(_baseName(_remotePaths[index]));
+  _startProgress(false, _remoteNames[index], _remoteSizes[index], 1);
+  bool ok = _getFile(_remotePaths[index], local, _remoteSizes[index]);
+  _finishProgress(ok,
+      ok ? "" : (_lastError.length() ? _lastError.c_str() : "Download failed"));
+}
+
+void WebDavClientScreen::_holdRemote(uint8_t index) {
+  if (index >= _remoteCount || !_remoteIsDir[index]) return;
+
+  if (_remoteMode == REMOTE_UPLOAD_DEST) {
+    if (_remoteNames[index] == "..") return;
+    _chooseUploadDestination(_remotePaths[index]);
+    return;
+  }
+
+  if (_remoteNames[index] == "..") return;
+  if (!_confirm("Download directory?")) {
+    render();
+    return;
+  }
+
+  Uni.Storage->makeDir("/unigeek");
+  Uni.Storage->makeDir("/unigeek/wifi");
+  Uni.Storage->makeDir("/unigeek/wifi/remote");
+  Uni.Storage->makeDir("/unigeek/wifi/remote/webdav");
+  Uni.Storage->makeDir(DOWNLOAD_DIR);
+
+  _startProgress(false, _remoteNames[index]);
+  uint64_t bytes = 0;
+  uint32_t files = 0;
+  bool ok = _scanRemote(_remotePaths[index], bytes, files, 0);
+  if (ok) {
+    _progressTotal = bytes;
+    _progressFilesTotal = files;
+    String local = String(DOWNLOAD_DIR) + "/" +
+                   _safeLocalName(_baseName(_remotePaths[index]));
+    ok = _downloadTree(_remotePaths[index], local, 0);
+  }
+  _finishProgress(ok,
+      ok ? "" : (_lastError.length() ? _lastError.c_str()
+                                     : "Directory download failed"));
+}
+
+void WebDavClientScreen::_chooseUploadDestination(const String& path) {
+  if (!_confirm(_uploadIsDir ? "Upload directory?" : "Upload file?")) {
+    _state = STATE_LOCAL_BROWSER;
+    render();
+    return;
+  }
+
+  String dir = _normalizeRemote(path, true);
+  if (!_ensureCollection(dir)) {
+    ShowStatusAction::show(
+        _lastError.length() ? _lastError.c_str() : "Remote directory failed",
+        1500);
+    _state = STATE_LOCAL_BROWSER;
+    render();
+    return;
+  }
+
+  if (_uploadIsDir) {
+    _startProgress(true, _uploadName);
+    uint64_t bytes = 0;
+    uint32_t files = 0;
+    bool ok = _scanLocal(_uploadLocalPath, bytes, files, 0);
+    if (ok) {
+      _progressTotal = bytes;
+      _progressFilesTotal = files;
+      ok = _uploadTree(_uploadLocalPath, _joinRemote(dir, _uploadName) + "/", 0);
+    }
+    _finishProgress(ok,
+        ok ? "" : (_lastError.length() ? _lastError.c_str()
+                                       : "Directory upload failed"));
+  } else {
+    fs::File f = Uni.Storage->open(_uploadLocalPath.c_str(), "r");
+    uint64_t size = f ? (uint64_t)f.size() : 0;
+    if (f) f.close();
+
+    _startProgress(true, _uploadName, size, 1);
+    bool ok = _putFile(_uploadLocalPath, _joinRemote(dir, _uploadName), size);
+    _finishProgress(ok,
+        ok ? "" : (_lastError.length() ? _lastError.c_str() : "Upload failed"));
+  }
+}
+
+bool WebDavClientScreen::_confirm(const char* title) {
+  static constexpr InputSelectAction::Option opts[] = {
+    {"Yes", "yes"},
+    {"No", "no"},
+  };
+  Uni.Lcd.setTextFont(1);
+  const char* result = InputSelectAction::popup(title, opts, 2, "yes");
+  return result && !strcmp(result, "yes");
+}
+
+bool WebDavClientScreen::_propfind(const String& path,
+                                   RemoteEntry* out,
+                                   uint8_t& count) {
+  count = 0;
+  _lastError = "";
+  _lastHttpCode = 0;
+
+  const String url = _urlFor(_normalizeRemote(path, true));
+  const bool secure = url.startsWith("https://");
+
+  WiFiClient plain;
+  WiFiClientSecure tls;
+  if (secure) tls.setInsecure();
+
+  WiFiClient& client = secure
+      ? static_cast<WiFiClient&>(tls)
+      : static_cast<WiFiClient&>(plain);
+
+  HTTPClient http;
+  if (!http.begin(client, url)) {
+    _setHttpError(0, "HTTP setup");
+    return false;
+  }
+
+  http.setTimeout(12000);
+  if (_username.length())
+    http.setAuthorization(_username.c_str(), _password.c_str());
+
+  http.addHeader("Depth", "1");
+  http.addHeader("Content-Type", "application/xml; charset=utf-8");
+  http.addHeader("Accept", "application/xml, text/xml");
+
+  const String body =
+      "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+      "<d:propfind xmlns:d=\"DAV:\"><d:prop>"
+      "<d:resourcetype/><d:getcontentlength/><d:displayname/>"
+      "</d:prop></d:propfind>";
+
+  int code = http.sendRequest("PROPFIND", body);
+  _lastHttpCode = code;
+
+  if (code != 207 && code != 200) {
+    http.end();
+    _setHttpError(code, "PROPFIND");
+    return false;
+  }
+
+  String xml;
+  if (!_davReadBodyLimited(http, xml, MAX_PROPFIND_BYTES)) {
+    http.end();
+    _lastError = "WebDAV response too large";
+    return false;
+  }
+  http.end();
+
+  // A null output pointer means the caller only wants to verify that this is
+  // a readable WebDAV collection (used by Connect and MKCOL verification).
+  if (!out) {
+    _lastError = "";
+    return true;
+  }
+
+  String current = _normalizeRemote(path, true);
+  int pos = 0;
+  String block;
+
+  while (_davNextElementBlock(xml, "response", pos, block)) {
+    String href = _extractTag(block, "href");
+    if (!href.length()) continue;
+
+    String relative;
+    if (!_hrefToRelative(_xmlDecode(href), relative)) continue;
+
+    String resourceType = _extractTag(block, "resourcetype");
+    bool isDir = _davHasElement(resourceType, "collection");
+    relative = _normalizeRemote(relative, isDir);
+
+    if (_normalizeRemote(relative, true) == current) continue;
+
+    String actualName = _baseName(relative);
+    actualName = _urlDecode(actualName);
+
+    String displayName = _xmlDecode(_extractTag(block, "displayname"));
+    displayName = _urlDecode(displayName);
+
+    String name = actualName.length() ? actualName : displayName;
+    if (!name.length() || name == "." || name == "..") continue;
+
+    if (count >= MAX_REMOTE_ENTRIES) {
+      _lastError = "Remote directory has too many entries";
+      return false;
+    }
+
+    String sizeText = _extractTag(block, "getcontentlength");
+    sizeText.trim();
+
+    out[count].name = name;
+    out[count].path = relative;
+    out[count].isDir = isDir;
+    out[count].size = sizeText.length()
+        ? strtoull(sizeText.c_str(), nullptr, 10) : 0;
+    count++;
+  }
+
+  for (uint8_t i = 1; i < count; ++i) {
+    RemoteEntry key = out[i];
+    int j = i - 1;
+    while (j >= 0) {
+      bool move = false;
+      if (out[j].isDir != key.isDir)
+        move = !out[j].isDir && key.isDir;
+      else
+        move = strcasecmp(out[j].name.c_str(), key.name.c_str()) > 0;
+
+      if (!move) break;
+      out[j + 1] = out[j];
+      --j;
+    }
+    out[j + 1] = key;
+  }
+
+  _lastError = "";
+  return true;
+}
+
+bool WebDavClientScreen::_mkcol(const String& path) {
+  String url = _urlFor(_normalizeRemote(path, true));
+  bool secure = url.startsWith("https://");
+
+  WiFiClient plain;
+  WiFiClientSecure tls;
+  if (secure) tls.setInsecure();
+
+  WiFiClient& client = secure
+      ? static_cast<WiFiClient&>(tls)
+      : static_cast<WiFiClient&>(plain);
+
+  HTTPClient http;
+  if (!http.begin(client, url)) {
+    _setHttpError(0, "HTTP setup");
+    return false;
+  }
+
+  http.setTimeout(12000);
+  if (_username.length())
+    http.setAuthorization(_username.c_str(), _password.c_str());
+
+  int code = http.sendRequest("MKCOL");
+  http.end();
+  _lastHttpCode = code;
+
+  if (code == 201 || code == 204) {
+    _lastError = "";
+    return true;
+  }
+
+  // 405 commonly means the collection already exists, but it can also mean
+  // MKCOL is disabled. Verify with PROPFIND instead of blindly accepting it.
+  if (code == 405) {
+    uint8_t count = 0;
+    if (_propfind(path, nullptr, count)) {
+      _lastError = "";
+      return true;
+    }
+    return false;
+  }
+
+  _setHttpError(code, "MKCOL");
+  return false;
+}
+
+bool WebDavClientScreen::_ensureCollection(const String& path) {
+  String clean = _normalizeRemote(path, true);
+  if (!clean.length()) return true;
+
+  String current;
+  int pos = 0;
+  while (pos < (int)clean.length()) {
+    int slash = clean.indexOf('/', pos);
+    if (slash < 0) break;
+    String part = clean.substring(pos, slash);
+    pos = slash + 1;
+    if (!part.length()) continue;
+    current += part + "/";
+    if (!_mkcol(current)) return false;
+  }
+  return true;
+}
+
+bool WebDavClientScreen::_getFile(const String& remotePath,
+                                  const String& localPath,
+                                  uint64_t size) {
+  if (_pollCancel()) return false;
+
+  fs::File out = Uni.Storage->open(localPath.c_str(), "w");
+  if (!out) {
+    _lastError = "Local file open failed";
+    return false;
+  }
+
+  String url = _urlFor(remotePath);
+  bool secure = url.startsWith("https://");
+  WiFiClient plain;
+  WiFiClientSecure tls;
+  if (secure) tls.setInsecure();
+
+  WiFiClient& client = secure
+      ? static_cast<WiFiClient&>(tls)
+      : static_cast<WiFiClient&>(plain);
+
+  HTTPClient http;
+  if (!http.begin(client, url)) {
+    out.close();
+    Uni.Storage->deleteFile(localPath.c_str());
+    _setHttpError(0, "HTTP setup");
+    return false;
+  }
+
+  http.setTimeout(12000);
+  if (_username.length())
+    http.setAuthorization(_username.c_str(), _password.c_str());
+
+  int code = http.GET();
+  _lastHttpCode = code;
+  if (!_davOk(code)) {
+    http.end();
+    out.close();
+    Uni.Storage->deleteFile(localPath.c_str());
+    _setHttpError(code, "GET");
+    return false;
+  }
+
+  int remaining = http.getSize();
+  if (remaining > 0 && _progressTotal == 0)
+    _progressTotal = (uint64_t)remaining;
+
+  WiFiClient* stream = http.getStreamPtr();
+  if (!stream) {
+    http.end();
+    out.close();
+    Uni.Storage->deleteFile(localPath.c_str());
+    _lastError = "HTTP stream unavailable";
+    return false;
+  }
+
+  uint8_t buf[4096];
+  uint64_t gotTotal = 0;
+  uint32_t lastData = millis();
+  bool ok = true;
+
+  while (!_pollCancel() &&
+         (http.connected() || stream->available()) &&
+         (remaining > 0 || remaining == -1)) {
+    int avail = stream->available();
+    if (avail > 0) {
+      int n = stream->read(buf, min<int>(avail, sizeof(buf)));
+      if (n <= 0) {
+        ok = false;
+        break;
+      }
+
+      if (out.write(buf, n) != (size_t)n) {
+        _lastError = "SD write failed";
+        ok = false;
+        break;
+      }
+
+      gotTotal += (uint64_t)n;
+      _progressDone += (uint64_t)n;
+      lastData = millis();
+      if (remaining > 0) remaining -= n;
+      _updateProgress();
+    } else {
+      if (remaining == 0) break;
+      if (millis() - lastData > 12000) {
+        _lastError = "Download timed out";
+        ok = false;
+        break;
+      }
+      delay(2);
+    }
+  }
+
+  if (remaining > 0) ok = false;
+
+  http.end();
+  out.close();
+
+  if (_cancelTransfer) {
+    Uni.Storage->deleteFile(localPath.c_str());
+    _lastError = "Cancelled";
+    return false;
+  }
+
+  if (!ok || (size && gotTotal != size)) {
+    Uni.Storage->deleteFile(localPath.c_str());
+    if (!_lastError.length()) _lastError = "Incomplete download";
+    return false;
+  }
+
+  _progressFilesDone++;
+  _lastError = "";
+  return true;
+}
+
+bool WebDavClientScreen::_putFile(const String& localPath,
+                                  const String& remotePath,
+                                  uint64_t size) {
+  if (_cancelTransfer) return false;
+
+  fs::File in = Uni.Storage->open(localPath.c_str(), "r");
+  if (!in) return false;
+
+  String url = _urlFor(remotePath);
+  bool secure = url.startsWith("https://");
+  WiFiClient plain;
+  WiFiClientSecure tls;
+  if (secure) tls.setInsecure();
+  WiFiClient& client = secure
+      ? static_cast<WiFiClient&>(tls)
+      : static_cast<WiFiClient&>(plain);
+
+  HTTPClient http;
+  if (!http.begin(client, url)) {
+    in.close();
+    return false;
+  }
+  http.setTimeout(15000);
+  if (_username.length()) http.setAuthorization(_username.c_str(), _password.c_str());
+  http.addHeader("Content-Type", "application/octet-stream");
+
+  int code = http.sendRequest("PUT", &in, size);
+  http.end();
+  in.close();
+  _lastHttpCode = code;
+
+  if (!_davOk(code)) {
+    _setHttpError(code, "PUT");
+    return false;
+  }
+  if (_cancelTransfer) {
+    _lastError = "Cancelled";
+    return false;
+  }
+  _progressDone += size;
+  _progressFilesDone++;
+  _updateProgress();
+  return true;
+}
+
+bool WebDavClientScreen::_scanRemote(const String& path,
+                                     uint64_t& bytes,
+                                     uint32_t& files,
+                                     int depth) {
+  if (depth > 12 || _pollCancel()) return false;
+
+  RemoteEntry* temp = new (std::nothrow) RemoteEntry[MAX_REMOTE_ENTRIES];
+  if (!temp) {
+    _lastError = "Not enough memory";
+    return false;
+  }
+
+  uint8_t count = 0;
+  if (!_propfind(path, temp, count)) {
+    delete[] temp;
+    return false;
+  }
+
+  for (uint8_t i = 0; i < count; ++i) {
+    if (_pollCancel()) {
+      delete[] temp;
+      return false;
+    }
+
+    if (temp[i].isDir) {
+      String child = temp[i].path;
+      if (!_scanRemote(child, bytes, files, depth + 1)) {
+        delete[] temp;
+        return false;
+      }
+    } else {
+      bytes += temp[i].size;
+      files++;
+    }
+  }
+
+  delete[] temp;
+  return !_cancelTransfer;
+}
+
+bool WebDavClientScreen::_downloadTree(const String& remote,
+                                       const String& local,
+                                       int depth) {
+  if (depth > 12 || _pollCancel()) return false;
+  Uni.Storage->makeDir(local.c_str());
+
+  RemoteEntry* temp = new (std::nothrow) RemoteEntry[MAX_REMOTE_ENTRIES];
+  if (!temp) {
+    _lastError = "Not enough memory";
+    return false;
+  }
+
+  uint8_t count = 0;
+  if (!_propfind(remote, temp, count)) {
+    delete[] temp;
+    return false;
+  }
+
+  for (uint8_t i = 0; i < count; ++i) {
+    if (_pollCancel()) {
+      delete[] temp;
+      return false;
+    }
+
+    String localChild = local + "/" + _safeLocalName(temp[i].name);
+    _progressName = temp[i].name;
+
+    if (temp[i].isDir) {
+      String childRemote = temp[i].path;
+      if (!_downloadTree(childRemote, localChild, depth + 1)) {
+        delete[] temp;
+        return false;
+      }
+    } else {
+      String childRemote = temp[i].path;
+      uint64_t childSize = temp[i].size;
+      if (!_getFile(childRemote, localChild, childSize)) {
+        delete[] temp;
+        return false;
+      }
+    }
+  }
+
+  delete[] temp;
+  return !_cancelTransfer;
+}
+
+bool WebDavClientScreen::_scanLocal(const String& path,
+                                    uint64_t& bytes,
+                                    uint32_t& files,
+                                    int depth) {
+  if (depth > 12 || _pollCancel()) return false;
+
+  fs::File dir = Uni.Storage->open(path.c_str(), "r");
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    return false;
+  }
+
+  fs::File child = dir.openNextFile();
+  while (child && !_pollCancel()) {
+    String name = _baseName(String(child.name()));
+    String childPath = path;
+    if (!childPath.endsWith("/")) childPath += "/";
+    childPath += name;
+
+    if (child.isDirectory()) {
+      child.close();
+      if (!_scanLocal(childPath, bytes, files, depth + 1)) {
+        dir.close();
+        return false;
+      }
+    } else {
+      bytes += child.size();
+      files++;
+      child.close();
+    }
+    child = dir.openNextFile();
+  }
+
+  if (child) child.close();
+  dir.close();
+  return !_cancelTransfer;
+}
+
+bool WebDavClientScreen::_uploadTree(const String& local,
+                                     const String& remote,
+                                     int depth) {
+  if (depth > 12 || _pollCancel()) return false;
+  if (!_ensureCollection(remote)) return false;
+
+  fs::File dir = Uni.Storage->open(local.c_str(), "r");
+  if (!dir || !dir.isDirectory()) {
+    if (dir) dir.close();
+    return false;
+  }
+
+  fs::File child = dir.openNextFile();
+  while (child && !_pollCancel()) {
+    String name = _baseName(String(child.name()));
+    String localChild = local;
+    if (!localChild.endsWith("/")) localChild += "/";
+    localChild += name;
+    _progressName = name;
+
+    if (child.isDirectory()) {
+      child.close();
+      if (!_uploadTree(localChild, _joinRemote(remote, name) + "/", depth + 1)) {
+        dir.close();
+        return false;
+      }
+    } else {
+      uint64_t size = child.size();
+      child.close();
+      if (!_putFile(localChild, _joinRemote(remote, name), size)) {
+        dir.close();
+        return false;
+      }
+    }
+    child = dir.openNextFile();
+  }
+
+  if (child) child.close();
+  dir.close();
+  return !_cancelTransfer;
+}
+
+String WebDavClientScreen::_urlFor(const String& relative) const {
+  String path = relative;
+  while (path.startsWith("/")) path.remove(0, 1);
+  return _baseUrl + _urlEncodePath(path);
+}
+
+String WebDavClientScreen::_normalizeBase(String value) const {
+  value.trim();
+  if (!value.endsWith("/")) value += "/";
+  return value;
+}
+
+String WebDavClientScreen::_normalizeRemote(String value, bool dir) const {
+  value.trim();
+  while (value.startsWith("/")) value.remove(0, 1);
+  while (value.indexOf("//") >= 0) value.replace("//", "/");
+  if (value == ".") value = "";
+  if (dir && value.length() && !value.endsWith("/")) value += "/";
+  return value;
+}
+
+String WebDavClientScreen::_parentRemote(const String& value) const {
+  String clean = _normalizeRemote(value, true);
+  if (!clean.length()) return "";
+  clean.remove(clean.length() - 1);
+  int slash = clean.lastIndexOf('/');
+  return slash < 0 ? "" : clean.substring(0, slash + 1);
+}
+
+String WebDavClientScreen::_joinRemote(const String& dir,
+                                       const String& name) const {
+  return _normalizeRemote(dir, true) + name;
+}
+
+String WebDavClientScreen::_baseName(const String& value) const {
+  String clean = value;
+  while (clean.length() && clean.endsWith("/"))
+    clean.remove(clean.length() - 1);
+  int slash = clean.lastIndexOf('/');
+  return slash >= 0 ? clean.substring(slash + 1) : clean;
+}
+
+String WebDavClientScreen::_safeLocalName(String value) const {
+  value = _urlDecode(value);
+  value.trim();
+
+  for (int i = 0; i < (int)value.length(); ++i) {
+    unsigned char c = (unsigned char)value[i];
+    if (c < 0x20 || value[i] == '/' || value[i] == '\\')
+      value.setCharAt(i, '_');
+  }
+
+  if (!value.length() || value == "." || value == "..") value = "file";
+  return value;
+}
+
+String WebDavClientScreen::_urlEncodePath(const String& value) const {
+  static const char HEX_DIGITS[] = "0123456789ABCDEF";
+  String out;
+  out.reserve(value.length() + 8);
+
+  for (int i = 0; i < (int)value.length(); ++i) {
+    uint8_t c = (uint8_t)value[i];
+    bool safe =
+        (c >= 'a' && c <= 'z') ||
+        (c >= 'A' && c <= 'Z') ||
+        (c >= '0' && c <= '9') ||
+        c == '-' || c == '_' || c == '.' || c == '~' || c == '/';
+
+    if (safe) {
+      out += (char)c;
+    } else {
+      out += '%';
+      out += HEX_DIGITS[(c >> 4) & 0x0F];
+      out += HEX_DIGITS[c & 0x0F];
+    }
+  }
+  return out;
+}
+
+bool WebDavClientScreen::_hrefToRelative(String href, String& relative) const {
+  relative = "";
+  href.trim();
+
+  int query = href.indexOf('?');
+  if (query >= 0) href = href.substring(0, query);
+  int fragment = href.indexOf('#');
+  if (fragment >= 0) href = href.substring(0, fragment);
+
+  int scheme = href.indexOf("://");
+  if (scheme >= 0) {
+    int slash = href.indexOf('/', scheme + 3);
+    href = slash >= 0 ? href.substring(slash) : "/";
+  }
+
+  String base = _baseUrl;
+  int baseScheme = base.indexOf("://");
+  if (baseScheme >= 0) {
+    int slash = base.indexOf('/', baseScheme + 3);
+    base = slash >= 0 ? base.substring(slash) : "/";
+  }
+
+  href = _urlDecode(href);
+  base = _urlDecode(base);
+
+  String baseNoSlash = base;
+  while (baseNoSlash.length() > 1 && baseNoSlash.endsWith("/"))
+    baseNoSlash.remove(baseNoSlash.length() - 1);
+
+  if (href == baseNoSlash || href == base) {
+    relative = "";
+    return true;
+  }
+
+  if (!href.startsWith(base)) return false;
+
+  relative = href.substring(base.length());
+  while (relative.startsWith("/")) relative.remove(0, 1);
+
+  if (relative == ".." || relative.startsWith("../") ||
+      relative.indexOf("/../") >= 0)
+    return false;
+
+  return true;
+}
+
+String WebDavClientScreen::_extractTag(const String& block,
+                                       const char* localName) const {
+  int pos = 0;
+
+  while (pos < (int)block.length()) {
+    int lt = block.indexOf('<', pos);
+    if (lt < 0) break;
+
+    int nameStart = lt + 1;
+    if (nameStart >= (int)block.length()) break;
+
+    char first = block[nameStart];
+    if (first == '/' || first == '?' || first == '!') {
+      pos = nameStart + 1;
+      continue;
+    }
+
+    int nameEnd = nameStart;
+    while (nameEnd < (int)block.length()) {
+      char c = block[nameEnd];
+      if (c == '>' || c == '/' || c == ' ' || c == '\t' ||
+          c == '\r' || c == '\n')
+        break;
+      nameEnd++;
+    }
+
+    if (nameEnd <= nameStart) {
+      pos = nameStart + 1;
+      continue;
+    }
+
+    String qname = block.substring(nameStart, nameEnd);
+    if (!_davTagLocalEquals(qname, localName)) {
+      pos = nameEnd;
+      continue;
+    }
+
+    int openEnd = block.indexOf('>', nameEnd);
+    if (openEnd < 0) break;
+
+    String closeTag = "</" + qname + ">";
+    int close = block.indexOf(closeTag, openEnd + 1);
+    if (close < 0) break;
+
+    return block.substring(openEnd + 1, close);
+  }
+
+  return "";
+}
+
+String WebDavClientScreen::_xmlDecode(String value) const {
+  value.replace("&quot;", "\"");
+  value.replace("&apos;", "'");
+  value.replace("&gt;", ">");
+  value.replace("&lt;", "<");
+  value.replace("&amp;", "&");
+  value.trim();
+  return value;
+}
+
+String WebDavClientScreen::_urlDecode(String value) const {
+  String out;
+  for (int i = 0; i < (int)value.length(); ++i) {
+    if (value[i] == '%' && i + 2 < (int)value.length()) {
+      char hex[3] = {value[i + 1], value[i + 2], 0};
+      char* end = nullptr;
+      long v = strtol(hex, &end, 16);
+      if (end && *end == 0) {
+        out += (char)v;
+        i += 2;
+        continue;
+      }
+    }
+    out += value[i];
+  }
+  return out;
+}
+
+
+bool WebDavClientScreen::_pollCancel() {
+  if (_cancelTransfer) return true;
+
+  if (_state == STATE_TRANSFER &&
+      Uni.Nav->wasPressed() &&
+      Uni.Nav->readDirection() == INavigation::DIR_BACK) {
+    _cancelTransfer = true;
+  }
+  return _cancelTransfer;
+}
+
+const char* WebDavClientScreen::_httpStatusText(int code) const {
+  switch (code) {
+    case 400: return "Bad request";
+    case 401: return "Authentication failed";
+    case 403: return "Permission denied";
+    case 404: return "Remote path not found";
+    case 405: return "WebDAV method not allowed";
+    case 409: return "Remote parent missing";
+    case 412: return "Precondition failed";
+    case 423: return "Remote resource locked";
+    case 507: return "Remote storage full";
+    default:  return nullptr;
+  }
+}
+
+void WebDavClientScreen::_setHttpError(int code, const char* context) {
+  _lastHttpCode = code;
+  const char* known = _httpStatusText(code);
+
+  if (known) {
+    _lastError = known;
+  } else if (code < 0) {
+    _lastError = "HTTP transport error";
+  } else if (code == 0) {
+    _lastError = context && *context ? String(context) + " failed"
+                                    : "HTTP setup failed";
+  } else {
+    _lastError = context && *context ? String(context) + " failed (" +
+                                       String(code) + ")"
+                                    : "HTTP error " + String(code);
+  }
+}
+
+void WebDavClientScreen::_startProgress(bool upload,
+                                        const String& name,
+                                        uint64_t bytes,
+                                        uint32_t files) {
+  _transferIsUpload = upload;
+  _cancelTransfer = false;
+  _progressDone = 0;
+  _progressTotal = bytes;
+  _progressFilesDone = 0;
+  _progressFilesTotal = files;
+  _progressName = name;
+  _state = STATE_TRANSFER;
+  ProgressView::init();
+  ProgressView::progress(name.c_str(), 0);
+}
+
+void WebDavClientScreen::_updateProgress() {
+  uint8_t pct = _progressTotal
+      ? (uint8_t)min<uint64_t>(100, (_progressDone * 100) / _progressTotal)
+      : 0;
+
+  String msg = _progressName;
+  if (_progressFilesTotal > 1)
+    msg += "\n" + String(_progressFilesDone) + "/" +
+           String(_progressFilesTotal) + " files";
+
+  ProgressView::progress(msg.c_str(), pct);
+}
+
+void WebDavClientScreen::_finishProgress(bool ok, const char* error) {
+  ProgressView::finish();
+  _state = _transferIsUpload ? STATE_LOCAL_BROWSER : STATE_REMOTE_BROWSER;
+  render();
+
+  if (_cancelTransfer) {
+    ShowStatusAction::show(
+        _transferIsUpload ? "Upload cancelled" : "Download cancelled", 1300);
+  } else if (ok) {
+    ShowStatusAction::show(
+        _transferIsUpload ? "Upload complete" : "Download complete", 1400);
+  } else {
+    ShowStatusAction::show(error && *error ? error : "Transfer failed", 1600);
+  }
+  render();
+}
+
+void WebDavClientScreen::_renderRemoteBrowser() {
+  ListScreen::onRender();
+}
+
+void WebDavClientScreen::_renderLocalBrowser() {
+  ListScreen::onRender();
+}

--- a/firmware/src/screens/wifi/network/remote/WebDavClientScreen.h
+++ b/firmware/src/screens/wifi/network/remote/WebDavClientScreen.h
@@ -1,0 +1,149 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+#include "ui/views/BrowseFileView.h"
+
+class WebDavClientScreen : public ListScreen
+{
+public:
+  const char* title() override;
+  bool inhibitPowerOff() override { return _state == STATE_TRANSFER; }
+
+  void onInit() override;
+  void onUpdate() override;
+  void onRender() override;
+  void onItemSelected(uint8_t index) override;
+  void onBack() override;
+
+private:
+  enum State : uint8_t {
+    STATE_CONFIG,
+    STATE_ACTION,
+    STATE_REMOTE_BROWSER,
+    STATE_LOCAL_BROWSER,
+    STATE_TRANSFER
+  };
+
+  enum RemoteMode : uint8_t {
+    REMOTE_DOWNLOAD,
+    REMOTE_UPLOAD_DEST
+  };
+
+  struct RemoteEntry {
+    String name;
+    String path;
+    bool isDir = false;
+    uint64_t size = 0;
+  };
+
+  static constexpr uint8_t MAX_REMOTE_ENTRIES = 80;
+  static constexpr uint32_t HOLD_MS = 900;
+  static constexpr size_t MAX_PROPFIND_BYTES = 65536;
+  static constexpr const char* DOWNLOAD_DIR =
+      "/unigeek/wifi/remote/webdav/downloads";
+
+  State _state = STATE_CONFIG;
+  RemoteMode _remoteMode = REMOTE_DOWNLOAD;
+
+  String _baseUrl;
+  String _username;
+  String _password;
+
+  char _urlLabel[48] = {};
+  char _userLabel[32] = {};
+  char _passwordLabel[16] = "-";
+
+  ListItem _configItems[4];
+  ListItem _actionItems[2] = {
+    {"Download", nullptr},
+    {"Upload", nullptr},
+  };
+
+  BrowseFileView _localBrowser;
+  String _uploadLocalPath;
+  String _uploadName;
+  bool _uploadIsDir = false;
+
+  RemoteEntry _entries[MAX_REMOTE_ENTRIES];
+  String _remoteNames[MAX_REMOTE_ENTRIES + 2];
+  String _remoteSubs[MAX_REMOTE_ENTRIES + 2];
+  String _remotePaths[MAX_REMOTE_ENTRIES + 2];
+  bool _remoteIsDir[MAX_REMOTE_ENTRIES + 2] = {};
+  uint64_t _remoteSizes[MAX_REMOTE_ENTRIES + 2] = {};
+  ListItem _remoteItems[MAX_REMOTE_ENTRIES + 2];
+  uint8_t _entryCount = 0;
+  uint8_t _remoteCount = 0;
+  String _remotePath;
+  bool _holdHandled = false;
+
+  bool _cancelTransfer = false;
+  bool _transferIsUpload = false;
+  uint64_t _progressDone = 0;
+  uint64_t _progressTotal = 0;
+  uint32_t _progressFilesDone = 0;
+  uint32_t _progressFilesTotal = 0;
+  String _progressName;
+  int _lastHttpCode = 0;
+  String _lastError;
+
+  void _updateLabels();
+  void _rebuildConfig();
+  void _showActions();
+
+  void _configUrl();
+  void _configUsername();
+  void _configPassword();
+  void _connect();
+
+  void _beginDownload();
+  void _beginUpload();
+
+  void _loadLocalDir(const String& path);
+  void _selectLocal(uint8_t index);
+  void _holdLocal(uint8_t index);
+  void _chooseUploadSource(const String& path, const String& name, bool isDir);
+  void _chooseUploadDestinationMode();
+
+  bool _loadRemote(const String& path);
+  void _buildRemoteItems();
+  void _selectRemote(uint8_t index);
+  void _holdRemote(uint8_t index);
+  void _chooseUploadDestination(const String& path);
+
+  bool _confirm(const char* title);
+  bool _pollCancel();
+  void _setHttpError(int code, const char* context);
+  const char* _httpStatusText(int code) const;
+
+  bool _propfind(const String& path, RemoteEntry* out, uint8_t& count);
+  bool _mkcol(const String& path);
+  bool _ensureCollection(const String& path);
+  bool _getFile(const String& remotePath, const String& localPath, uint64_t size);
+  bool _putFile(const String& localPath, const String& remotePath, uint64_t size);
+
+  bool _scanRemote(const String& path, uint64_t& bytes, uint32_t& files, int depth);
+  bool _downloadTree(const String& remote, const String& local, int depth);
+  bool _scanLocal(const String& path, uint64_t& bytes, uint32_t& files, int depth);
+  bool _uploadTree(const String& local, const String& remote, int depth);
+
+  String _urlFor(const String& relative) const;
+  String _normalizeBase(String value) const;
+  String _normalizeRemote(String value, bool dir = false) const;
+  String _parentRemote(const String& value) const;
+  String _joinRemote(const String& dir, const String& name) const;
+  String _baseName(const String& value) const;
+  String _safeLocalName(String value) const;
+  String _urlEncodePath(const String& value) const;
+  bool _hrefToRelative(String href, String& relative) const;
+  String _extractTag(const String& block, const char* localName) const;
+  String _xmlDecode(String value) const;
+  String _urlDecode(String value) const;
+
+  void _startProgress(bool upload, const String& name,
+                      uint64_t bytes = 0, uint32_t files = 0);
+  void _updateProgress();
+  void _finishProgress(bool ok, const char* error);
+
+  void _renderRemoteBrowser();
+  void _renderLocalBrowser();
+};

--- a/firmware/src/ui/actions/InputNumberAction.h
+++ b/firmware/src/ui/actions/InputNumberAction.h
@@ -74,7 +74,7 @@ private:
 
   void _buildSets() {
     // 3 cols × 5 rows = 15 items
-    // rows 0-2: 1-9  row 3: dummy 0 dummy  row 4: CNCL DEL SAVE
+    // rows 0-2: 1-9  row 3: dummy 0 dummy  row 4: BKSP SAVE EXIT
     static constexpr const char* d[] = { "1","2","3","4","5","6","7","8","9" };
     _setCount = 0;
     for (int i = 0; i < 9; i++)
@@ -82,9 +82,9 @@ private:
     _sets[_setCount++] = { "",     false, DigitSet::ACT_DEL    };  // dummy
     _sets[_setCount++] = { "0",    false, DigitSet::ACT_DEL    };
     _sets[_setCount++] = { "",     false, DigitSet::ACT_DEL    };  // dummy
-    _sets[_setCount++] = { "CNCL", true,  DigitSet::ACT_CANCEL };
-    _sets[_setCount++] = { "DEL",  true,  DigitSet::ACT_DEL    };
+    _sets[_setCount++] = { "BKSP", true,  DigitSet::ACT_DEL    };
     _sets[_setCount++] = { "SAVE", true,  DigitSet::ACT_SAVE   };
+    _sets[_setCount++] = { "EXIT", true,  DigitSet::ACT_CANCEL };
   }
 
   bool _validate() {
@@ -324,7 +324,7 @@ private:
       sp.setTextColor(TFT_WHITE, theme);
     } else {
       sp.drawRoundRect(1, 1, cW - 2, cH - 2, 3, 0x2104);
-      sp.setTextColor(s.isAction ? TFT_CYAN : TFT_LIGHTGREY, TFT_BLACK);
+      sp.setTextColor(s.isAction ? TFT_WHITE : TFT_LIGHTGREY, TFT_BLACK);
     }
     sp.drawString(s.label, cW / 2, cH / 2);
     sp.pushSprite(col * cW, hdr + row * cH);

--- a/firmware/src/ui/actions/InputTextAction.h
+++ b/firmware/src/ui/actions/InputTextAction.h
@@ -11,7 +11,7 @@
 class InputTextAction
 {
 public:
-  enum Mode : uint8_t { INPUT_TEXT = 0, INPUT_IP_ADDRESS = 1, INPUT_HEX = 2 };
+  enum Mode : uint8_t { INPUT_TEXT = 0, INPUT_IP_ADDRESS = 1, INPUT_HEX = 2, INPUT_PHONE =3 };
 
   static String popup(const char* title, const String& defaultValue = "", Mode mode = INPUT_TEXT) {
     InputTextAction action(title, defaultValue, mode);
@@ -30,7 +30,13 @@ private:
     SP_CAPS,
     SP_SYMBOL,
     SP_CANCEL,
-    SP_COUNT
+    SP_COUNT,
+    SP_SPACE
+  };
+
+  enum TextPage : uint8_t {
+    PAGE_ABC = 0,
+    PAGE_SYM
   };
 
   enum SpecialNum {
@@ -40,9 +46,10 @@ private:
     SPN_COUNT
   };
 
-  static constexpr int      MAX_SETS   = 20;
+  static constexpr int      MAX_SETS   = 60;
   static constexpr uint32_t COMMIT_MS  = 1000;
   static constexpr uint32_t BLINK_MS   = 500;
+  static constexpr uint32_t LONG_PRESS_MS = 600;
   static constexpr int      PAD        = 4;
 
   // keyboard mode overlay
@@ -64,6 +71,8 @@ private:
   String      _pendingChar;
 
   CharSet     _sets[MAX_SETS];
+  char        _keyChars[30][3]  = {};
+  char        _keyLabels[30][2] = {};
   int         _setCount    = 0;
   int         _scrollPos   = 0;
 
@@ -73,8 +82,10 @@ private:
   Mode        _mode        = INPUT_TEXT;
   bool        _capsLock    = false;
   bool        _symbolMode  = false;
+  TextPage    _page        = PAGE_ABC;
   bool        _done        = false;
   bool        _cancelled   = false;
+  bool        _longPressHandled = false;
 
   bool        _cursorVisible  = true;
   uint32_t    _lastBlinkTime  = 0;
@@ -102,40 +113,88 @@ private:
       _sets[_setCount++] = { " ",     " ",    false, SP_SAVE   };
       _sets[_setCount++] = { nullptr, "DEL",  true,  SP_DELETE };
       _sets[_setCount++] = { nullptr, "SAVE", true,  SP_SAVE   };
+
     } else if (_mode == INPUT_IP_ADDRESS) {
-      // rows 0-1: 0-9  row 2: CNCL · DEL SAVE
-      static constexpr const char* ipDigits[] = {
-        "0","1","2","3","4","5","6","7","8","9",
+      // Match the Phone keyboard geometry:
+      // rows 0-1: 1-9,0  row 2: . + spacers  row 3: spacers + BKSP SAVE EXIT
+      static constexpr const char* ipChars[] = {
+        "1","2","3","4","5",
+        "6","7","8","9","0",
+        ".",
       };
-      for (int i = 0; i < 10; i++)
-        _sets[_setCount++] = { ipDigits[i], ipDigits[i], false, SP_SAVE };
-      _sets[_setCount++] = { nullptr, "CNCL", true,  SP_CANCEL };
-      _sets[_setCount++] = { ".",     ".",    false, SP_SAVE   };
-      _sets[_setCount++] = { nullptr, "DEL",  true,  SP_DELETE };
-      _sets[_setCount++] = { nullptr, "",     false, SP_SAVE   };  // spacer
-      _sets[_setCount++] = { nullptr, "SAVE", true,  SP_SAVE   };
-    } else {
-      static constexpr const char* charLabels[] = {
-        " 0",    ",.1",   "abc2",  "def3",  "ghi4",
-        "jkl5",  "mno6",  "pqrs7", "tuv8",  "wxyz9",
-      };
-      static constexpr const char* symbolLabels[] = {
-        " ",     ",.'- ", "*/\\@", "+-=_",  ":;?",
-        "!$#",   "\"&%|", "()[]",  "<>{}",  "^~`",
+      for (int i = 0; i < 11; i++)
+        _sets[_setCount++] = { ipChars[i], ipChars[i], false, SP_SAVE };
+
+      // Pad to 17 cells so the action keys occupy the same final-row
+      // positions as INPUT_PHONE.
+      while (_setCount < 17)
+        _sets[_setCount++] = { nullptr, "", false, SP_SAVE };
+
+      _sets[_setCount++] = { nullptr, "BKSP", true, SP_DELETE };
+      _sets[_setCount++] = { nullptr, "SAVE", true, SP_SAVE };
+      _sets[_setCount++] = { nullptr, "EXIT", true, SP_CANCEL };
+
+    } else if (_mode == INPUT_PHONE) {
+      static constexpr const char* phoneChars[] = {
+        "1","2","3","4","5",
+        "6","7","8","9","0",
+        "+","-",".","*","#",
+        "(",")",
       };
 
-      const char* const* sets = _symbolMode ? symbolLabels : charLabels;
-      for (int i = 0; i < 10; i++) {
-        _sets[_setCount++] = { sets[i], sets[i], false, SP_SAVE };
+      for (int i = 0; i < 17; i++)
+        _sets[_setCount++] = { phoneChars[i], phoneChars[i], false, SP_SAVE };
+
+      _sets[_setCount++] = { nullptr, "BKSP", true, SP_DELETE };
+      _sets[_setCount++] = { nullptr, "SAVE", true, SP_SAVE };
+      _sets[_setCount++] = { nullptr, "EXIT", true, SP_CANCEL };
+
+    } else {
+      // Compact 6x5 grid optimized for small displays.
+      // Two ASCII pages: ABC <-> SYM.
+      struct KeyPair {
+        char normal;
+        char shifted;
+      };
+
+      static constexpr KeyPair alphaKeys[30] = {
+        {'a','A'}, {'b','B'}, {'c','C'}, {'d','D'}, {'e','E'}, {'f','F'},
+        {'g','G'}, {'h','H'}, {'i','I'}, {'j','J'}, {'k','K'}, {'l','L'},
+        {'m','M'}, {'n','N'}, {'o','O'}, {'p','P'}, {'q','Q'}, {'r','R'},
+        {'s','S'}, {'t','T'}, {'u','U'}, {'v','V'}, {'w','W'}, {'x','X'},
+        {'y','Y'}, {'z','Z'}, {'.',':'}, {',',';'}, {'-','_'}, {'/','?'},
+      };
+
+      static constexpr KeyPair symbolKeys[21] = {
+        {'1','!'}, {'2','@'}, {'3','#'}, {'4','$'}, {'5','%'}, {'6','^'},
+        {'7','&'}, {'8','*'}, {'9','+'}, {'0','='}, {'\'','"'}, {'\\','|'},
+        {'(', '('}, {')', ')'}, {'[', '['}, {']', ']'}, {'{', '{'}, {'}', '}'},
+        {'<', '<'}, {'>', '>'}, {'`','~'},
+      };
+
+      const KeyPair* keys = (_page == PAGE_SYM) ? symbolKeys : alphaKeys;
+      const int keyCount = (_page == PAGE_SYM) ? 21 : 30;
+
+      for (int i = 0; i < 30; i++) {
+        if (i < keyCount) {
+          _keyChars[i][0] = keys[i].normal;
+          _keyChars[i][1] = keys[i].shifted;
+          _keyChars[i][2] = '\0';
+          _keyLabels[i][0] = keys[i].normal;
+          _keyLabels[i][1] = '\0';
+          _sets[_setCount++] = { _keyChars[i], _keyLabels[i], false, SP_SAVE };
+        } else {
+          _sets[_setCount++] = { nullptr, "", false, SP_SAVE };
+        }
       }
 
-      static constexpr const char* specialLabels[SP_COUNT] = {
-        "CNCL", "DEL", "CAPS", "SYM", "SAVE"
+      static constexpr const char* specialLabels[6] = {
+        "123", "CAPS", "SPACE", "BKSP", "SAVE", "EXIT"
       };
-      static constexpr Special specialMap[SP_COUNT] = {
-        SP_CANCEL, SP_DELETE, SP_CAPS, SP_SYMBOL, SP_SAVE
+      static constexpr Special specialMap[6] = {
+        SP_SYMBOL, SP_CAPS, SP_SPACE, SP_DELETE, SP_SAVE, SP_CANCEL
       };
-      for (int i = 0; i < SP_COUNT; i++) {
+      for (int i = 0; i < 6; i++) {
         _sets[_setCount++] = { nullptr, specialLabels[i], true, specialMap[i] };
       }
     }
@@ -173,10 +232,35 @@ private:
 
   // ── grid scroll mode ────────────────────────────────────────────────────────
 
-  int _gridCols()  const { return 5; }
-  int _gridRows()  const { return (_setCount + _gridCols() - 1) / _gridCols(); }
-  int _gridCellW() const { return Uni.Lcd.width() / _gridCols(); }
-  int _gridCellH() const { return (Uni.Lcd.height() - HDR_H) / _gridRows(); }
+  int _gridCols() const { return _mode == INPUT_TEXT ? 6 : 5; }
+
+  int _charCount() const {
+    return _mode == INPUT_TEXT ? 30 : _setCount;
+  }
+
+  int _charRows() const {
+    return (_charCount() + _gridCols() - 1) / _gridCols();
+  }
+
+  int _actionCount() const {
+    return _mode == INPUT_TEXT ? 6 : 0;
+  }
+
+  int _gridRows() const {
+    return _charRows() + (_actionCount() > 0 ? 1 : 0);
+  }
+
+  int _gridCellW() const {
+    return Uni.Lcd.width() / _gridCols();
+  }
+
+  int _gridCellH() const {
+    return (Uni.Lcd.height() - HDR_H) / _gridRows();
+  }
+
+  int _actionCellW() const {
+    return _actionCount() > 0 ? Uni.Lcd.width() / _actionCount() : Uni.Lcd.width();
+  }
 
   String _runScroll() {
     _lastBlinkTime = millis();
@@ -187,6 +271,39 @@ private:
       Uni.update();
       UartFM.poll(); // read remote input so nav works in this dialog
       if (Mirror.dirty()) Mirror.pump(); // flush only when this overlay redrew
+
+      // Fire character Shift as soon as Select crosses the long-press threshold.
+      // Do not wait for release. Special/action keys keep their normal release
+      // behaviour so holding CAPS/SAVE/etc. cannot trigger them accidentally.
+      if (Uni.Nav->isPressed() &&
+          Uni.Nav->currentDirection() == INavigation::DIR_PRESS) {
+        if (!_longPressHandled &&
+            Uni.Nav->heldDuration() >= LONG_PRESS_MS &&
+            _scrollPos < _setCount &&
+            !_sets[_scrollPos].isSpecial &&
+            _sets[_scrollPos].chars != nullptr) {
+          bool pc = _capsLock, ps = _symbolMode;
+          TextPage pp = _page;
+
+          _handleSelect(true);
+          _longPressHandled = true;
+
+          // The shifted character has already been emitted. Drop the future
+          // release event so it cannot also insert the normal character.
+          Uni.Nav->suppressCurrentPress();
+
+          if (!_done && !_cancelled) {
+            if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
+            else _drawGridCell(_scrollPos);
+            _cursorVisible = true;
+            _lastBlinkTime = millis();
+            _drawGridInput();
+          }
+        }
+      } else {
+        // Ready for the next physical Select press.
+        _longPressHandled = false;
+      }
 
       if (_tapCount > 0 && millis() - _lastTapTime >= COMMIT_MS) {
         _commitTap();
@@ -207,7 +324,18 @@ private:
         int16_t tx = Uni.Nav->lastTouchX();
         int16_t ty = Uni.Nav->lastTouchY();
         if (tx >= 0 && ty >= HDR_H) {
-          int idx = (int)(ty - HDR_H) / _gridCellH() * _gridCols() + (int)tx / _gridCellW();
+          int relY = ty - HDR_H;
+          int row = relY / _gridCellH();
+          int idx = -1;
+
+          if (_mode == INPUT_TEXT && row >= _charRows()) {
+            int action = tx / _actionCellW();
+            if (action >= 6) action = 5;
+            idx = 30 + action;
+          } else {
+            idx = row * _gridCols() + tx / _gridCellW();
+          }
+
           if (idx >= 0 && idx < _setCount) {
             const CharSet& hit = _sets[idx];
             if (!hit.isSpecial && hit.chars == nullptr) { delay(10); continue; }
@@ -217,9 +345,10 @@ private:
               _scrollPos = idx;
             }
             bool pc = _capsLock, ps = _symbolMode;
-            _handleSelect();
+            TextPage pp = _page;
+            _handleSelect(false);
             if (!_done && !_cancelled) {
-              if (pc != _capsLock || ps != _symbolMode) _drawFullGrid();
+              if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
               else { _drawGridCell(prev); _drawGridCell(_scrollPos); }
               _cursorVisible = true; _lastBlinkTime = millis();
               _drawGridInput();
@@ -231,47 +360,98 @@ private:
 #endif
 
       const bool nav4 = Uni.Nav->is4Way();
-      if (nav4 && dir == INavigation::DIR_UP) {
+
+      if (_mode == INPUT_TEXT && nav4 &&
+          (dir == INavigation::DIR_UP || dir == INavigation::DIR_DOWN)) {
+        _commitTap();
+
+        if (_scrollPos < 30) {
+          int col = _scrollPos % _gridCols();
+          int row = _scrollPos / _gridCols();
+
+          if (dir == INavigation::DIR_UP) {
+            if (row == 0) {
+              // Jump to the closest action button in the bottom row.
+              int a = (col * 6) / _gridCols();
+              if (a >= 6) a = 5;
+              _scrollPos = 30 + a;
+            } else {
+              _scrollPos -= _gridCols();
+            }
+          } else {
+            if (row == _charRows() - 1) {
+              int a = (col * 6) / _gridCols();
+              if (a >= 6) a = 5;
+              _scrollPos = 30 + a;
+            } else {
+              _scrollPos += _gridCols();
+            }
+          }
+        } else {
+          // From the action row, UP/DOWN returns to the bottom character row.
+          int a = _scrollPos - 30;
+          int col = (a * _gridCols()) / 6;
+          if (col >= _gridCols()) col = _gridCols() - 1;
+          _scrollPos = (_charRows() - 1) * _gridCols() + col;
+        }
+
+        // SYM has intentionally blank tail cells.
+        if (_scrollPos < 30 && _sets[_scrollPos].chars == nullptr) {
+          int col = _scrollPos % _gridCols();
+          _scrollPos = 30 + min(col, 5);
+        }
+
+      } else if (nav4 && dir == INavigation::DIR_UP) {
         _commitTap();
         do { _scrollPos = (_scrollPos - _gridCols() + _setCount) % _setCount; }
         while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+
       } else if (nav4 && dir == INavigation::DIR_DOWN) {
         _commitTap();
         do { _scrollPos = (_scrollPos + _gridCols()) % _setCount; }
         while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+
       } else if (dir == INavigation::DIR_LEFT || dir == INavigation::DIR_UP) {
         _commitTap();
-        do { _scrollPos = (_scrollPos - 1 + _setCount) % _setCount; }
-        while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+        do {
+          _scrollPos = (_scrollPos - 1 + _setCount) % _setCount;
+        } while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+
       } else if (dir == INavigation::DIR_RIGHT || dir == INavigation::DIR_DOWN) {
         _commitTap();
-        do { _scrollPos = (_scrollPos + 1) % _setCount; }
-        while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+        do {
+          _scrollPos = (_scrollPos + 1) % _setCount;
+        } while (!_sets[_scrollPos].isSpecial && _sets[_scrollPos].chars == nullptr);
+
       } else if (dir == INavigation::DIR_PRESS) {
         bool pc = _capsLock, ps = _symbolMode;
-        _handleSelect();
+        TextPage pp = _page;
+        _handleSelect(false);
         if (!_done && !_cancelled) {
-          if (pc != _capsLock || ps != _symbolMode) _drawFullGrid();
+          if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
           else _drawGridCell(prev);
           _cursorVisible = true; _lastBlinkTime = millis();
           _drawGridInput();
         }
         delay(10); continue;
       } else if (dir == INavigation::DIR_BACK) {
-        // Mirror DEL: drop a pending multi-tap first, then chip away at the
-        // committed input, and only cancel once everything is empty.
-        if (_pendingChar.length() > 0) {
-          _pendingChar = "";
-          _tapCount    = 0;
-          _lastTapTime = 0;
-          _cursorVisible = true; _lastBlinkTime = millis();
+        if (_mode == INPUT_TEXT) {
+          // Physical Back toggles ABC <-> 123 on the standard keyboard.
+          // Other keyboard modes intentionally ignore Back.
+          _commitTap();
+
+          _page = (_page == PAGE_ABC) ? PAGE_SYM : PAGE_ABC;
+          _symbolMode = (_page == PAGE_SYM);
+          _buildSets();
+
+          // Back always opens the new page at its first character:
+          // ABC -> 'a', 123 -> '1'.
+          _scrollPos = 0;
+
+          _drawFullGrid();
+          _cursorVisible = true;
+          _lastBlinkTime = millis();
           _drawGridInput();
-        } else if (_input.length() > 0) {
-          _input.remove(_input.length() - 1);
-          _cursorVisible = true; _lastBlinkTime = millis();
-          _drawGridInput();
-        } else {
-          _cancelled = true;
         }
       }
 
@@ -286,13 +466,17 @@ private:
     return _cancelled ? "" : _input;
   }
 
-  void _handleSelect() {
+  void _handleSelect(bool shifted = false) {
     const CharSet& s = _sets[_scrollPos];
 
     if (s.isSpecial) {
       _commitTap();
+
       switch (s.special) {
-        case SP_SAVE:   _done = true;                   break;
+        case SP_SAVE:
+          _done = true;
+          break;
+
         case SP_DELETE:
           if (_pendingChar.length() > 0) {
             _pendingChar = "";
@@ -302,49 +486,116 @@ private:
             _input.remove(_input.length() - 1);
           }
           break;
-        case SP_CAPS:   _capsLock = !_capsLock;         break;
-        case SP_SYMBOL:
-          _symbolMode  = !_symbolMode;
-          _buildSets();
-          _scrollPos   = 0;
-          _tapCount    = 0;
-          _pendingChar = "";
+
+        case SP_CAPS:
+          _capsLock = !_capsLock;
           break;
-        case SP_CANCEL: _cancelled = true;              break;
-        default: break;
+
+        case SP_SYMBOL:
+          if (_mode == INPUT_TEXT && _scrollPos == 30) {
+            _page = (_page == PAGE_ABC) ? PAGE_SYM : PAGE_ABC;
+            _symbolMode = (_page == PAGE_SYM);
+            _buildSets();
+            _scrollPos = 30;
+          }
+          break;
+
+        case SP_SPACE:
+          _input += ' ';
+          break;
+
+        case SP_CANCEL:
+          _cancelled = true;
+          break;
+
+        default:
+          break;
       }
+
     } else {
       const char* chars = s.chars;
       if (!chars || chars[0] == '\0') return;
-      int  len = strlen(chars);
-      if (len == 1) {
+
+      if (_mode == INPUT_TEXT) {
+        // Short press inserts chars[0]; long press inserts chars[1].
+        // CAPS remains persistent for alphabetic keys. Holding Select
+        // temporarily inverts CAPS for letters, like a momentary Shift.
         char c = chars[0];
-        if (_capsLock && isalpha(c)) c = toupper(c);
-        _input      += c;
+
+        if (isalpha(chars[0])) {
+          bool upper = _capsLock ^ shifted;
+          c = upper ? toupper(chars[0]) : tolower(chars[0]);
+        } else if (shifted && chars[1] != '\0') {
+          c = chars[1];
+        }
+
+        _input += c;
         _pendingChar = "";
-        _tapCount    = 0;
+        _tapCount = 0;
         _lastTapTime = 0;
+
       } else {
-        char c = chars[_tapCount % len];
-        if (_capsLock && isalpha(c)) c = toupper(c);
-        _pendingChar = String(c);
-        _tapCount++;
-        _lastTapTime = millis();
+        int len = strlen(chars);
+
+        if (len == 1) {
+          char c = chars[0];
+          if (_capsLock && isalpha(c)) c = toupper(c);
+
+          _input += c;
+          _pendingChar = "";
+          _tapCount = 0;
+          _lastTapTime = 0;
+
+        } else {
+          char c = chars[_tapCount % len];
+          if (_capsLock && isalpha(c)) c = toupper(c);
+
+          _pendingChar = String(c);
+          _tapCount++;
+          _lastTapTime = millis();
+        }
       }
     }
   }
 
   void _drawFullGrid() {
     auto& lcd = Uni.Lcd;
+    uint16_t theme = Config.getThemeColor();
+
     lcd.fillScreen(TFT_BLACK);
     lcd.setTextSize(1);
     lcd.setTextDatum(TL_DATUM);
-    lcd.setTextColor(TFT_YELLOW, TFT_BLACK);
+
+    // Match the rest of UniGeek: black canvas + current primary/theme colour
+    // for the active screen accent.
+    lcd.setTextColor(theme, TFT_BLACK);
     lcd.drawString(_title, PAD, PAD);
-    int ix = PAD + lcd.textWidth(_title) + PAD;
-    if (_capsLock)   { lcd.setTextColor(TFT_GREEN, TFT_BLACK); lcd.drawString("CAPS", ix, PAD); ix += lcd.textWidth("CAPS") + PAD; }
-    if (_symbolMode) { lcd.setTextColor(TFT_CYAN,  TFT_BLACK); lcd.drawString("SYM",  ix, PAD); }
+
+    // Active keyboard-mode indicators live in the upper-right corner.
+    // Keep the title area uncluttered; when both are active, show "CAPS 123".
+    lcd.setTextColor(TFT_LIGHTGREY, TFT_BLACK);
+    lcd.setTextDatum(TR_DATUM);
+    String modeLabel;
+    if (_capsLock) modeLabel = "CAPS";
+    if (_page == PAGE_SYM) {
+      if (modeLabel.length() > 0) modeLabel += " ";
+      modeLabel += "123";
+    }
+    if (modeLabel.length() > 0) {
+      lcd.drawString(modeLabel.c_str(), lcd.width() - PAD, PAD);
+    }
+    lcd.setTextDatum(TL_DATUM);
+
+    // Thin theme separator, echoing the normal UniGeek screen chrome.
+    lcd.drawFastHLine(PAD, PAD + 10, lcd.width() - PAD * 2, theme);
+
     _drawGridInput();
+
+    if (_mode == INPUT_TEXT) {
+      int footerY = HDR_H + _charRows() * _gridCellH();
+      lcd.drawFastHLine(PAD, footerY, lcd.width() - PAD * 2, TFT_DARKGREY);
+    }
+
     for (int i = 0; i < _setCount; i++) _drawGridCell(i);
   }
 
@@ -354,7 +605,7 @@ private:
     Sprite sp(&lcd);
     sp.createSprite(iW, INP_H);
     sp.fillSprite(TFT_BLACK);
-    sp.drawRoundRect(0, 0, iW, INP_H, 2, TFT_DARKGREY);
+    sp.drawRoundRect(0, 0, iW, INP_H, 2, Config.getThemeColor());
     sp.setTextColor(TFT_WHITE, TFT_BLACK);
     sp.setTextDatum(TL_DATUM);
     String display = _input + _pendingChar;
@@ -369,8 +620,21 @@ private:
     if (idx < 0 || idx >= _setCount) return;
     auto&    lcd   = Uni.Lcd;
     uint16_t theme = Config.getThemeColor();
-    int cW  = _gridCellW(), cH = _gridCellH();
-    int col = idx % _gridCols(), row = idx / _gridCols();
+    int cH = _gridCellH();
+    int cW;
+    int col;
+    int row;
+
+    if (_mode == INPUT_TEXT && idx >= 30) {
+      cW = _actionCellW();
+      col = idx - 30;
+      row = _charRows();
+    } else {
+      cW = _gridCellW();
+      col = idx % _gridCols();
+      row = idx / _gridCols();
+    }
+
     bool sel = (idx == _scrollPos);
     const CharSet& s = _sets[idx];
 
@@ -386,18 +650,56 @@ private:
     Sprite sp(&lcd);
     sp.createSprite(cW, cH);
     sp.fillSprite(TFT_BLACK);
+
+    // Character cells have plenty of horizontal room in the 6-column layout.
+    // Draw them at 2x for legibility; keep footer/action labels at 1x so
+    // SAVE/CAPS/SPACE/DEL/EXIT continue to fit comfortably.
+    // Use UniGeek's standard built-in UI font/size for maximum consistency
+    // and compatibility across display backends.
+    sp.setTextFont(1);
     sp.setTextSize(1);
     sp.setTextDatum(MC_DATUM);
+
     if (sel) {
-      sp.fillRoundRect(1, 1, cW - 2, cH - 2, 3, theme);
+      sp.fillRoundRect(2, 2, cW - 4, cH - 4, 3, theme);
       sp.setTextColor(TFT_WHITE, theme);
     } else {
-      sp.drawRoundRect(1, 1, cW - 2, cH - 2, 3, 0x2104);
-      sp.setTextColor(s.isSpecial ? TFT_CYAN : TFT_LIGHTGREY, TFT_BLACK);
+      sp.drawRoundRect(2, 2, cW - 4, cH - 4, 3, TFT_DARKGREY);
+      sp.setTextColor(s.isSpecial ? TFT_WHITE : TFT_LIGHTGREY, TFT_BLACK);
     }
-    String lbl = String(s.label);
-    if (!s.isSpecial && _capsLock && _mode == INPUT_TEXT) lbl.toUpperCase();
+
+    String lbl;
+    bool drawShiftHint = false;
+    char shiftHint = '\0';
+    if (!s.isSpecial && _mode == INPUT_TEXT && s.chars) {
+      char shown = s.chars[0];
+
+      if (isalpha(s.chars[0])) {
+        // CAPS changes the primary character; long Select temporarily inverts it.
+        shown = _capsLock ? toupper(s.chars[0]) : tolower(s.chars[0]);
+        shiftHint = _capsLock ? tolower(s.chars[0]) : toupper(s.chars[0]);
+        drawShiftHint = true;
+      } else if (s.chars[1] != '\0' && s.chars[1] != s.chars[0]) {
+        shiftHint = s.chars[1];
+        drawShiftHint = true;
+      }
+
+      lbl = String(shown);
+    } else if (_mode == INPUT_TEXT && idx == 30) {
+      lbl = (_page == PAGE_ABC) ? "123" : "ABC";
+    } else {
+      lbl = String(s.label);
+    }
+
     sp.drawString(lbl.c_str(), cW / 2, cH / 2);
+
+    if (drawShiftHint) {
+      sp.setTextDatum(TR_DATUM);
+      sp.setTextSize(1);
+      sp.setTextColor(sel ? TFT_WHITE : TFT_DARKGREY, sel ? theme : TFT_BLACK);
+      char hint[2] = { shiftHint, '\0' };
+      sp.drawString(hint, cW - 5, 3);
+    }
     sp.pushSprite(col * cW, HDR_H + row * cH);
     sp.deleteSprite();
   }

--- a/firmware/src/ui/actions/InputTextAction.h
+++ b/firmware/src/ui/actions/InputTextAction.h
@@ -31,7 +31,8 @@ private:
     SP_SYMBOL,
     SP_CANCEL,
     SP_COUNT,
-    SP_SPACE
+    SP_SPACE,
+    SP_TEXT
   };
 
   enum TextPage : uint8_t {
@@ -125,11 +126,14 @@ private:
       for (int i = 0; i < 11; i++)
         _sets[_setCount++] = { ipChars[i], ipChars[i], false, SP_SAVE };
 
-      // Pad to 17 cells so the action keys occupy the same final-row
-      // positions as INPUT_PHONE.
-      while (_setCount < 17)
+      // Keep the Phone keyboard geometry, but use the bottom-left cell as a
+      // one-way escape to the normal text keyboard for DNS hostnames.
+      // Layout of the final row: ABC | spacer | BKSP | SAVE | EXIT.
+      while (_setCount < 15)
         _sets[_setCount++] = { nullptr, "", false, SP_SAVE };
 
+      _sets[_setCount++] = { nullptr, "ABC",  true, SP_TEXT };
+      _sets[_setCount++] = { nullptr, "",     false, SP_SAVE };
       _sets[_setCount++] = { nullptr, "BKSP", true, SP_DELETE };
       _sets[_setCount++] = { nullptr, "SAVE", true, SP_SAVE };
       _sets[_setCount++] = { nullptr, "EXIT", true, SP_CANCEL };
@@ -284,6 +288,7 @@ private:
             _sets[_scrollPos].chars != nullptr) {
           bool pc = _capsLock, ps = _symbolMode;
           TextPage pp = _page;
+          Mode pm = _mode;
 
           _handleSelect(true);
           _longPressHandled = true;
@@ -293,7 +298,8 @@ private:
           Uni.Nav->suppressCurrentPress();
 
           if (!_done && !_cancelled) {
-            if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
+            if (pc != _capsLock || ps != _symbolMode || pp != _page || pm != _mode)
+              _drawFullGrid();
             else _drawGridCell(_scrollPos);
             _cursorVisible = true;
             _lastBlinkTime = millis();
@@ -346,9 +352,11 @@ private:
             }
             bool pc = _capsLock, ps = _symbolMode;
             TextPage pp = _page;
+            Mode pm = _mode;
             _handleSelect(false);
             if (!_done && !_cancelled) {
-              if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
+              if (pc != _capsLock || ps != _symbolMode || pp != _page || pm != _mode)
+                _drawFullGrid();
               else { _drawGridCell(prev); _drawGridCell(_scrollPos); }
               _cursorVisible = true; _lastBlinkTime = millis();
               _drawGridInput();
@@ -426,9 +434,11 @@ private:
       } else if (dir == INavigation::DIR_PRESS) {
         bool pc = _capsLock, ps = _symbolMode;
         TextPage pp = _page;
+        Mode pm = _mode;
         _handleSelect(false);
         if (!_done && !_cancelled) {
-          if (pc != _capsLock || ps != _symbolMode || pp != _page) _drawFullGrid();
+          if (pc != _capsLock || ps != _symbolMode || pp != _page || pm != _mode)
+            _drawFullGrid();
           else _drawGridCell(prev);
           _cursorVisible = true; _lastBlinkTime = millis();
           _drawGridInput();
@@ -502,6 +512,24 @@ private:
 
         case SP_SPACE:
           _input += ' ';
+          break;
+
+        case SP_TEXT:
+          // INPUT_IP_ADDRESS prioritizes fast IPv4 entry. ABC is a one-way
+          // switch for hostnames: discard the IP prefill/current IP text and
+          // continue in the normal text keyboard until SAVE/EXIT.
+          if (_mode == INPUT_IP_ADDRESS) {
+            _input = "";
+            _pendingChar = "";
+            _tapCount = 0;
+            _lastTapTime = 0;
+            _mode = INPUT_TEXT;
+            _page = PAGE_ABC;
+            _symbolMode = false;
+            _capsLock = false;
+            _buildSets();
+            _scrollPos = 0;
+          }
           break;
 
         case SP_CANCEL:

--- a/firmware/src/ui/views/TerminalCommandLine.h
+++ b/firmware/src/ui/views/TerminalCommandLine.h
@@ -28,8 +28,6 @@ public:
     uint8_t modifiers = keyboard->modifiers();
     char c = keyboard->getKey();
 
-    if (c == '\x1b') return ACTION_EXIT;
-
     // The Cardputer family uses Fn + ; . , / as the four arrow keys.
     if (modifiers & IKeyboard::MOD_FN) {
       if (c == ';') return ACTION_SCROLL_UP;
@@ -43,7 +41,7 @@ public:
         _text.remove(_text.length() - 1);
         return ACTION_CHANGED;
       }
-      return ACTION_NONE;
+      return ACTION_EXIT;
     }
 
     if (c == '\n' || c == '\r') return ACTION_SUBMIT;
@@ -66,7 +64,7 @@ public:
 
     String line;
     if (remoteClosed) {
-      line = keyboardDevice ? "ESC: Exit" : "BACK: Exit";
+      line = "BACK: Exit";
     } else if (keyboardDevice) {
       line = "> " + _text + "_";
     } else {

--- a/firmware/src/ui/views/TerminalCommandLine.h
+++ b/firmware/src/ui/views/TerminalCommandLine.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "core/Device.h"
+#include "core/IKeyboard.h"
+
+class TerminalCommandLine
+{
+public:
+  enum Action : uint8_t {
+    ACTION_NONE,
+    ACTION_CHANGED,
+    ACTION_SUBMIT,
+    ACTION_EXIT,
+    ACTION_SCROLL_UP,
+    ACTION_SCROLL_DOWN,
+    ACTION_SCROLL_LEFT,
+    ACTION_SCROLL_RIGHT,
+  };
+
+  static constexpr int MAX_LEN = 256;
+
+  const String& text() const { return _text; }
+  void clear() { _text = ""; }
+
+  Action consume(IKeyboard* keyboard) {
+    if (!keyboard || !keyboard->available()) return ACTION_NONE;
+
+    uint8_t modifiers = keyboard->modifiers();
+    char c = keyboard->getKey();
+
+    if (c == '\x1b') return ACTION_EXIT;
+
+    // The Cardputer family uses Fn + ; . , / as the four arrow keys.
+    if (modifiers & IKeyboard::MOD_FN) {
+      if (c == ';') return ACTION_SCROLL_UP;
+      if (c == '.') return ACTION_SCROLL_DOWN;
+      if (c == ',') return ACTION_SCROLL_LEFT;
+      if (c == '/') return ACTION_SCROLL_RIGHT;
+    }
+
+    if (c == '\b' || c == 0x7f) {
+      if (_text.length() > 0) {
+        _text.remove(_text.length() - 1);
+        return ACTION_CHANGED;
+      }
+      return ACTION_NONE;
+    }
+
+    if (c == '\n' || c == '\r') return ACTION_SUBMIT;
+
+    if (c >= 0x20 && c <= 0x7e && (int)_text.length() < MAX_LEN) {
+      _text += c;
+      return ACTION_CHANGED;
+    }
+
+    return ACTION_NONE;
+  }
+
+  void render(int x, int y, int w, int h, bool remoteClosed, bool keyboardDevice) {
+    auto& lcd = Uni.Lcd;
+    lcd.fillRect(x, y, w, h, TFT_BLACK);
+    lcd.setTextFont(1);
+    lcd.setTextSize(1);
+    lcd.setTextDatum(TL_DATUM);
+    lcd.setTextColor(remoteClosed ? TFT_DARKGREY : TFT_WHITE, TFT_BLACK);
+
+    String line;
+    if (remoteClosed) {
+      line = keyboardDevice ? "ESC: Exit" : "BACK: Exit";
+    } else if (keyboardDevice) {
+      line = "> " + _text + "_";
+    } else {
+      line = "> PRESS: Type";
+    }
+
+    int maxChars = max(4, (w - 8) / 6);
+    if ((int)line.length() > maxChars) {
+      if (!remoteClosed && keyboardDevice && maxChars > 3) {
+        int keep = maxChars - 3;
+        line = ">.." + line.substring(line.length() - keep);
+      } else {
+        line = line.substring(0, maxChars);
+      }
+    }
+
+    lcd.drawString(line.c_str(), x + 4, y + max(0, (h - 8) / 2));
+  }
+
+private:
+  String _text;
+};

--- a/firmware/src/ui/views/TextScrollView.h
+++ b/firmware/src/ui/views/TextScrollView.h
@@ -5,8 +5,8 @@
 #include "core/ConfigManager.h"
 
 // Word-wrapped, scrollable text region. Pure view — owner screen calls
-// setContent(), then render(x,y,w,h) on draw and onNav(dir) on input.
-// Up/Down scroll one line, Left/Right page.
+// setContent()/updateContent(), then render(x,y,w,h) on draw and onNav(dir)
+// on input. Up/Down scroll one line, Left/Right page.
 class TextScrollView
 {
 public:
@@ -14,10 +14,48 @@ public:
   {
     _content = content;
     _scrollOffset = 0;
+    _scrollToBottomPending = false;
+    _discardedRows = 0;
     _wrapped = false;  // re-wrap on next render — body width may have changed
   }
 
-  void resetScroll() { _scrollOffset = 0; }
+  // Replace content without necessarily resetting the user's scroll position.
+  // followBottom=true is intended for live logs/terminals that should keep
+  // following new content while the user is already at the bottom.
+  void updateContent(const String& content, bool followBottom = false)
+  {
+    if (content == _content) {
+      if (followBottom) _scrollToBottomPending = true;
+      return;
+    }
+
+    _content = content;
+    _wrapped = false;
+    _scrollToBottomPending = followBottom;
+  }
+
+  void resetScroll()
+  {
+    _scrollOffset = 0;
+    _scrollToBottomPending = false;
+  }
+
+  void scrollToBottom()
+  {
+    if (!_wrapped) {
+      _scrollToBottomPending = true;
+      return;
+    }
+
+    _scrollOffset = _maxOffset();
+    _scrollToBottomPending = false;
+    if (_w > 0 && _h > 0) _draw();
+  }
+
+  bool isAtBottom() const
+  {
+    return _scrollOffset >= _maxOffset();
+  }
 
   void render(int x, int y, int w, int h)
   {
@@ -28,9 +66,8 @@ public:
 
   bool onNav(INavigation::Direction dir)
   {
-    int visible = (_h > 0) ? _h / kLineH : 1;
-    if (visible < 1) visible = 1;
-    int maxOffset = (_lineCount > visible) ? _lineCount - visible : 0;
+    int visible = _visibleLines();
+    int maxOffset = _maxOffset();
 
     if (dir == INavigation::DIR_UP && _scrollOffset > 0) {
       _scrollOffset--;
@@ -59,7 +96,7 @@ public:
 private:
   static constexpr int kLineH    = 11;
   static constexpr int kScrollW  = 3;
-  static constexpr int kMaxLines = 80;
+  static constexpr int kMaxLines = 160;
 
   String _content;
   String _lines[kMaxLines];
@@ -67,39 +104,72 @@ private:
   int    _scrollOffset = 0;
   int    _x = 0, _y = 0, _w = 0, _h = 0;
   bool   _wrapped      = false;
+  bool   _scrollToBottomPending = false;
+  int    _discardedRows = 0;
+  int    _wrapDiscarded = 0;
+
+  int _visibleLines() const
+  {
+    int visible = (_h > 0) ? _h / kLineH : 1;
+    return max(1, visible);
+  }
+
+  int _maxOffset() const
+  {
+    int visible = _visibleLines();
+    return (_lineCount > visible) ? _lineCount - visible : 0;
+  }
+
+  void _pushWrappedLine(const String& line)
+  {
+    if (_lineCount < kMaxLines) {
+      _lines[_lineCount++] = line;
+      return;
+    }
+
+    // Keep the newest rows. _wrapText() later compensates the scroll offset
+    // by the number of newly discarded rows so browsing stays stable.
+    for (int i = 1; i < kMaxLines; i++) _lines[i - 1] = _lines[i];
+    _lines[kMaxLines - 1] = line;
+    _wrapDiscarded++;
+  }
 
   void _wrapText()
   {
+    int oldDiscarded = _discardedRows;
+    _wrapDiscarded = 0;
     _lineCount = 0;
     int maxChars = (_w - kScrollW - 8) / 6;
     if (maxChars < 8) maxChars = 8;
 
     int pos = 0;
     int len = (int)_content.length();
-    while (pos <= len && _lineCount < kMaxLines) {
+    while (pos <= len) {
       int nl = _content.indexOf('\n', pos);
       int segEnd = (nl < 0) ? len : nl;
 
       if (pos == segEnd) {
-        _lines[_lineCount++] = "";
+        _pushWrappedLine("");
       } else {
-        while (pos < segEnd && _lineCount < kMaxLines) {
+        while (pos < segEnd) {
           int remain = segEnd - pos;
           if (remain <= maxChars) {
-            _lines[_lineCount++] = _content.substring(pos, segEnd);
+            _pushWrappedLine(_content.substring(pos, segEnd));
             pos = segEnd;
             break;
           }
+
           int wrapAt = pos + maxChars;
           int lastSpace = -1;
           for (int i = wrapAt; i > pos; i--) {
             if (_content[i] == ' ') { lastSpace = i; break; }
           }
+
           if (lastSpace > pos) {
-            _lines[_lineCount++] = _content.substring(pos, lastSpace);
+            _pushWrappedLine(_content.substring(pos, lastSpace));
             pos = lastSpace + 1;
           } else {
-            _lines[_lineCount++] = _content.substring(pos, wrapAt);
+            _pushWrappedLine(_content.substring(pos, wrapAt));
             pos = wrapAt;
           }
         }
@@ -108,14 +178,26 @@ private:
       if (nl < 0) break;
       pos = nl + 1;
     }
+
     _wrapped = true;
+
+    int maxOffset = _maxOffset();
+    if (_scrollToBottomPending) {
+      _scrollOffset = maxOffset;
+      _scrollToBottomPending = false;
+    } else {
+      int newlyDiscarded = _wrapDiscarded - oldDiscarded;
+      if (newlyDiscarded > 0)
+        _scrollOffset = max(0, _scrollOffset - newlyDiscarded);
+      if (_scrollOffset > maxOffset) _scrollOffset = maxOffset;
+    }
+    _discardedRows = _wrapDiscarded;
   }
 
   void _draw()
   {
     auto& lcd = Uni.Lcd;
-    int visible = _h / kLineH;
-    if (visible < 1) visible = 1;
+    int visible = _visibleLines();
     int textColW = _w - kScrollW;
 
     int rendered = 0;
@@ -147,8 +229,8 @@ private:
       if (sbH > _h) sbH = _h;
       int maxOffset = _lineCount - visible;
       int sbY = (_h - sbH) * _scrollOffset / max(1, maxOffset);
-      if (sbY < 0) sbY = 0;
-      if (sbY > _h - sbH) sbY = _h - sbH;
+      if (sbY < 0)              sbY = 0;
+      if (sbY > _h - sbH)       sbY = _h - sbH;
       lcd.fillRect(sbX, _y + sbY, kScrollW, sbH, Config.getThemeColor());
     }
   }

--- a/firmware/src/ui/views/TextScrollView.h
+++ b/firmware/src/ui/views/TextScrollView.h
@@ -10,6 +10,18 @@
 class TextScrollView
 {
 public:
+  enum WrapMode : uint8_t {
+    WRAP_WORD,
+    WRAP_CHARACTER,
+  };
+
+  void setWrapMode(WrapMode mode)
+  {
+    if (_wrapMode == mode) return;
+    _wrapMode = mode;
+    _wrapped = false;
+  }
+
   void setContent(const String& content)
   {
     _content = content;
@@ -104,6 +116,7 @@ private:
   int    _scrollOffset = 0;
   int    _x = 0, _y = 0, _w = 0, _h = 0;
   bool   _wrapped      = false;
+  WrapMode _wrapMode    = WRAP_WORD;
   bool   _scrollToBottomPending = false;
   int    _discardedRows = 0;
   int    _wrapDiscarded = 0;
@@ -160,6 +173,17 @@ private:
           }
 
           int wrapAt = pos + maxChars;
+
+          // Terminal/transcript mode must preserve every character position:
+          // wrapping at whitespace would consume the separator and distort
+          // column-oriented output such as `ls`. Other users retain the
+          // existing word-wrap behavior by default.
+          if (_wrapMode == WRAP_CHARACTER) {
+            _pushWrappedLine(_content.substring(pos, wrapAt));
+            pos = wrapAt;
+            continue;
+          }
+
           int lastSpace = -1;
           for (int i = wrapAt; i > pos; i--) {
             if (_content[i] == ' ') { lastSpace = i; break; }

--- a/platformio.ini
+++ b/platformio.ini
@@ -67,6 +67,7 @@ lib_deps =
 	nrf24/RF24@^1.4.11
 	adafruit/Adafruit PN532
 	adafruit/Adafruit BusIO
+	LibSSH-ESP32
 
 extra_scripts =
 	pre:scripts/patch.py


### PR DESCRIPTION
## Summary

This PR introduces and consolidates the Remote Access feature set, adding
interactive TCP, Telnet, SSH, FTP, and SFTP clients under a common menu and
storage layout.

## Remote Access menu

The Remote Access menu now provides:

- TCP Client
- Telnet Client
- SSH Client
- FTP Client
- SFTP Client

## TCP Client

- Add configurable host and port
- Add interactive TCP connection
- Support sending text/data to the remote endpoint
- Display received data in the client UI
- Keep connection handling integrated with the Remote Access navigation flow

## Telnet Client

- Add configurable host and port
- Add interactive Telnet terminal
- Implement basic Telnet option negotiation
- Support command input
- Handle remote output with ANSI/terminal parsing
- Support scrolling through terminal output

## SSH Client

- Add interactive SSH terminal
- Support password authentication
- Support private-key authentication
- Add key-file picker
- Add host-key fingerprint confirmation before authentication
- Add command input and terminal output handling
- Preserve session state while using the client
- Store SSH keys under:  /unigeek/wifi/remote/ssh

## FTP Client

- Add persistent FTP sessions
- Support configurable host, port, username and password
- Use binary transfer mode
- Support passive FTP transfers
- Add remote directory browser
- Prefer MLSD directory listings with LIST fallback
- Include hidden files/dotfiles
- Support file downloads
- Support recursive directory downloads
- Support file uploads
- Support recursive directory uploads
- Add transfer confirmation and progress display
- Support remote upload destination selection with:
  - Downloads
  - Browse
- Store downloads under: /unigeek/wifi/remote/ftp/downloads

## SFTP Client

- Add SFTP support on top of the SSH connection
- Support password and private-key authentication
- Reuse SSH host-key confirmation
- Add remote directory browser
- Support file downloads
- Support recursive directory downloads
- Support file uploads
- Support recursive directory uploads
- Keep the SFTP session alive while switching between Download and Upload
- Add transfer confirmation and progress display
- Support remote upload destination selection with:
  - Downloads
  - Browse
- Store downloads under: /unigeek/wifi/remote/sftp/downloads

## Storage layout

Remote-access files are grouped under:

    /unigeek/wifi/remote/
    ├── ssh/
    ├── ftp/
    │   └── downloads/
    └── sftp/
        └── downloads/

## Memory usage

The screen-mirroring implementation was changed to use region streaming
instead of allocating a full per-frame framebuffer/canvas.

This significantly reduces memory pressure, avoids large PSRAM allocations on
larger displays, and allows the same approach to work on boards without PSRAM.

The mirroring-related memory is only used while the feature is active, so when
screen mirroring is disabled it does not keep a large framebuffer allocated.

Remote serial services also remain disabled by default to avoid unnecessary
runtime memory usage.

## Notes

The clients share consistent Remote Access navigation and UI conventions where
possible.

FTP and SFTP use the same general Download / Upload interaction model, while
TCP, Telnet and SSH provide interactive remote-session interfaces appropriate
to their protocols.