### PR TITLE
Fix T-Embed CC1101 battery percentage reading

### DIFF
--- a/firmware/boards/t_embed_cc1101/core/Power.h
+++ b/firmware/boards/t_embed_cc1101/core/Power.h
@@ -11,7 +11,7 @@
 
 // ─── BQ27220 Fuel Gauge ───────────────────────────────────
 #define BQ27220_ADDR        0x55
-#define BQ27220_REG_SOC     0x1C
+#define BQ27220_REG_SOC     0x2C
 
 // ─── BQ25896 Charger ─────────────────────────────────────
 #define BQ25896_ADDR        0x6B


### PR DESCRIPTION
## Summary

Fixes battery percentage reporting on the T-Embed CC1101.

The BQ27220 StateOfCharge register was incorrectly set to `0x1C`. This PR updates it to the correct `0x2C` register.

## Changes

- Fix BQ27220 SOC register address (`0x1C` → `0x2C`)
- Restore correct battery percentage reporting on T-Embed CC1101

## Scope

T-Embed CC1101 only. No changes to the common UI or other boards.