### PR TITLE
Reorganize WiFi and Bluetooth menus and fix BLE HID cleanup

### DIFF
--- a/firmware/src/screens/ble/BLEAnalysisDetectionMenuScreen.cpp
+++ b/firmware/src/screens/ble/BLEAnalysisDetectionMenuScreen.cpp
@@ -1,0 +1,22 @@
+#include "BLEAnalysisDetectionMenuScreen.h"
+#include "core/ScreenManager.h"
+#include "screens/ble/BLEAnalyzerScreen.h"
+#include "screens/ble/BLEDetectorScreen.h"
+
+void BLEAnalysisDetectionMenuScreen::onInit()
+{
+  setItems(_items);
+}
+
+void BLEAnalysisDetectionMenuScreen::onItemSelected(uint8_t index)
+{
+  switch (index) {
+    case 0: Screen.push(new BLEAnalyzerScreen()); break;
+    case 1: Screen.push(new BLEDetectorScreen()); break;
+  }
+}
+
+void BLEAnalysisDetectionMenuScreen::onBack()
+{
+  Screen.goBack();
+}

--- a/firmware/src/screens/ble/BLEAnalysisDetectionMenuScreen.h
+++ b/firmware/src/screens/ble/BLEAnalysisDetectionMenuScreen.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+
+class BLEAnalysisDetectionMenuScreen : public ListScreen {
+public:
+  const char* title() override { return "Analysis & Detection"; }
+
+  void onInit() override;
+  void onItemSelected(uint8_t index) override;
+  void onBack() override;
+
+private:
+  ListItem _items[2] = {
+    {"BLE Analyzer"},
+    {"BLE Detector"},
+  };
+};

--- a/firmware/src/screens/ble/BLEAttacksMenuScreen.cpp
+++ b/firmware/src/screens/ble/BLEAttacksMenuScreen.cpp
@@ -1,0 +1,22 @@
+#include "BLEAttacksMenuScreen.h"
+#include "core/ScreenManager.h"
+#include "screens/ble/BLESpamScreen.h"
+#include "screens/ble/WhisperPairScreen.h"
+
+void BLEAttacksMenuScreen::onInit()
+{
+  setItems(_items);
+}
+
+void BLEAttacksMenuScreen::onItemSelected(uint8_t index)
+{
+  switch (index) {
+    case 0: Screen.push(new BLESpamScreen()); break;
+    case 1: Screen.push(new WhisperPairScreen()); break;
+  }
+}
+
+void BLEAttacksMenuScreen::onBack()
+{
+  Screen.goBack();
+}

--- a/firmware/src/screens/ble/BLEAttacksMenuScreen.h
+++ b/firmware/src/screens/ble/BLEAttacksMenuScreen.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+
+class BLEAttacksMenuScreen : public ListScreen {
+public:
+  const char* title() override { return "Attacks"; }
+
+  void onInit() override;
+  void onItemSelected(uint8_t index) override;
+  void onBack() override;
+
+private:
+  ListItem _items[2] = {
+    {"BLE Spam"},
+    {"WhisperPair"},
+  };
+};

--- a/firmware/src/screens/ble/BLEExtensionsMenuScreen.cpp
+++ b/firmware/src/screens/ble/BLEExtensionsMenuScreen.cpp
@@ -1,0 +1,22 @@
+#include "BLEExtensionsMenuScreen.h"
+#include "core/ScreenManager.h"
+#include "screens/ble/chameleon/ChameleonMenuScreen.h"
+#include "screens/ble/ClaudeBuddyScreen.h"
+
+void BLEExtensionsMenuScreen::onInit()
+{
+  setItems(_items);
+}
+
+void BLEExtensionsMenuScreen::onItemSelected(uint8_t index)
+{
+  switch (index) {
+    case 0: Screen.push(new ChameleonMenuScreen()); break;
+    case 1: Screen.push(new ClaudeBuddyScreen()); break;
+  }
+}
+
+void BLEExtensionsMenuScreen::onBack()
+{
+  Screen.goBack();
+}

--- a/firmware/src/screens/ble/BLEExtensionsMenuScreen.h
+++ b/firmware/src/screens/ble/BLEExtensionsMenuScreen.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+
+class BLEExtensionsMenuScreen : public ListScreen {
+public:
+  const char* title() override { return "Extensions"; }
+
+  void onInit() override;
+  void onItemSelected(uint8_t index) override;
+  void onBack() override;
+
+private:
+  ListItem _items[2] = {
+    {"Chameleon Ultra"},
+    {"Claude Buddy"},
+  };
+};

--- a/firmware/src/screens/ble/BLEMenuScreen.cpp
+++ b/firmware/src/screens/ble/BLEMenuScreen.cpp
@@ -2,32 +2,26 @@
 #include "core/Device.h"
 #include "core/ScreenManager.h"
 #include "screens/MainMenuScreen.h"
-#include "screens/ble/BLEAnalyzerScreen.h"
-#include "screens/ble/BLESpamScreen.h"
-#include "screens/ble/BLEDetectorScreen.h"
-#include "screens/ble/WhisperPairScreen.h"
-#include "screens/ble/chameleon/ChameleonMenuScreen.h"
-#include "screens/ble/ClaudeBuddyScreen.h"
+#include "screens/ble/BLEAnalysisDetectionMenuScreen.h"
+#include "screens/ble/BLEAttacksMenuScreen.h"
+#include "screens/ble/BLEExtensionsMenuScreen.h"
 #include "core/ScreenMirror.h"
 #include "utils/uart/BleFileManager.h"
 #include "utils/uart/UartFileManager.h"
 
 void BLEMenuScreen::onInit()
 {
-  _items[6].sublabel = BleFM.isActive() ? "ON" : "OFF";
+  _items[3].sublabel = BleFM.isActive() ? "On" : "Off";
   setItems(_items);
 }
 
 void BLEMenuScreen::onItemSelected(uint8_t index)
 {
   switch (index) {
-    case 0: Screen.push(new BLEAnalyzerScreen());   break;
-    case 1: Screen.push(new BLESpamScreen());       break;
-    case 2: Screen.push(new BLEDetectorScreen());   break;
-    case 3: Screen.push(new WhisperPairScreen());   break;
-    case 4: Screen.push(new ChameleonMenuScreen()); break;
-    case 5: Screen.push(new ClaudeBuddyScreen());   break;
-    case 6: _toggleRemoteDevice();                  break;
+    case 0: Screen.push(new BLEAnalysisDetectionMenuScreen()); break;
+    case 1: Screen.push(new BLEAttacksMenuScreen());           break;
+    case 2: Screen.push(new BLEExtensionsMenuScreen());        break;
+    case 3: _toggleRemoteDevice();                             break;
   }
 }
 
@@ -45,7 +39,7 @@ void BLEMenuScreen::_toggleRemoteDevice()
     Mirror.setEnabled(true);
     BleFM.begin();
   }
-  _items[6].sublabel = BleFM.isActive() ? "ON" : "OFF";
+  _items[3].sublabel = BleFM.isActive() ? "On" : "Off";
   render();
 }
 

--- a/firmware/src/screens/ble/BLEMenuScreen.h
+++ b/firmware/src/screens/ble/BLEMenuScreen.h
@@ -13,13 +13,10 @@ public:
 private:
   void _toggleRemoteDevice();
 
-  ListItem _items[7] = {
-    {"BLE Analyzer"},
-    {"BLE Spam"},
-    {"BLE Detector"},
-    {"WhisperPair"},
-    {"Chameleon Ultra"},
-    {"Claude Buddy"},
-    {"Remote Device"},
+  ListItem _items[4] = {
+    {"Analysis & Detection"},
+    {"Attacks"},
+    {"Extensions"},
+    {"BLE Remote"},
   };
 };

--- a/firmware/src/screens/hid/KeyboardMenuScreen.cpp
+++ b/firmware/src/screens/hid/KeyboardMenuScreen.cpp
@@ -17,7 +17,7 @@
 
 void KeyboardMenuScreen::onInit()
 {
-  _items[USB_REMOTE_IDX].sublabel = UartFM.isActive() ? "ON" : "OFF";
+  _items[USB_REMOTE_IDX].sublabel = UartFM.isActive() ? "On" : "Off";
   setItems(_items);
 }
 
@@ -68,7 +68,7 @@ void KeyboardMenuScreen::_toggleUsbRemote()
     Mirror.setEnabled(true);
     UartFM.begin(true, true);
   }
-  _items[USB_REMOTE_IDX].sublabel = UartFM.isActive() ? "ON" : "OFF";
+  _items[USB_REMOTE_IDX].sublabel = UartFM.isActive() ? "On" : "Off";
   render();
 }
 

--- a/firmware/src/screens/hid/KeyboardMenuScreen.h
+++ b/firmware/src/screens/hid/KeyboardMenuScreen.h
@@ -17,22 +17,22 @@ private:
 
 #ifdef DEVICE_HAS_WEBAUTHN
   ListItem _items[5] = {
-    {"USB MouseKeyboard"},
-    {"BLE MouseKeyboard"},
+    {"USB HID"},
+    {"BLE HID"},
     {"USB Web Authn"},
     {"USB Mass Storage"},
     {"USB Remote"},
   };
 #elif defined(DEVICE_HAS_USB_HID)
   ListItem _items[4] = {
-    {"USB MouseKeyboard"},
-    {"BLE MouseKeyboard"},
+    {"USB HID"},
+    {"BLE HID"},
     {"USB Mass Storage"},
     {"USB Remote"},
   };
 #else
   ListItem _items[2] = {
-    {"BLE MouseKeyboard"},
+    {"BLE HID"},
     {"USB Remote"},
   };
 #endif

--- a/firmware/src/screens/hid/KeyboardScreen.h
+++ b/firmware/src/screens/hid/KeyboardScreen.h
@@ -12,7 +12,9 @@ public:
   explicit KeyboardScreen(int mode);
   ~KeyboardScreen() override;
 
-  const char* title()            override { return "USB HID"; "BLE HID"; }
+  const char* title() override {
+  return _mode == MODE_USB ? "USB HID" : "BLE HID";
+  }
   bool inhibitPowerOff()         override { return true; }
 
   void onInit()                  override;

--- a/firmware/src/screens/hid/KeyboardScreen.h
+++ b/firmware/src/screens/hid/KeyboardScreen.h
@@ -12,7 +12,7 @@ public:
   explicit KeyboardScreen(int mode);
   ~KeyboardScreen() override;
 
-  const char* title()            override { return "HID"; }
+  const char* title()            override { return "USB HID"; "BLE HID"; }
   bool inhibitPowerOff()         override { return true; }
 
   void onInit()                  override;

--- a/firmware/src/screens/utility/UtilityMenuScreen.cpp
+++ b/firmware/src/screens/utility/UtilityMenuScreen.cpp
@@ -8,6 +8,7 @@
 #include "screens/utility/AchievementScreen.h"
 #include "screens/utility/TotpScreen.h"
 #include "screens/utility/UartTerminalScreen.h"
+#include "screens/wifi/WifiESPNowChatScreen.h"
 #include "screens/utility/PomodoroScreen.h"
 #include "screens/utility/RandomLinePickerScreen.h"
 #include "screens/wifi/network/WikipediaScreen.h"
@@ -36,9 +37,10 @@ void UtilityMenuScreen::onItemSelected(uint8_t index) {
     case 5: Screen.push(new AchievementScreen());      break;
     case 6: Screen.push(new TotpScreen());             break;
     case 7: Screen.push(new UartTerminalScreen());     break;
-    case 8: Screen.push(new PomodoroScreen());         break;
-    case 9: Screen.push(new RandomLinePickerScreen()); break;
-    case 10: Screen.push(new WikipediaScreen(true));   break;
+    case 8: Screen.push(new WifiESPNowChatScreen());   break;
+    case 9: Screen.push(new PomodoroScreen());         break;
+    case 10: Screen.push(new RandomLinePickerScreen()); break;
+    case 11: Screen.push(new WikipediaScreen(true));   break;
   }
 #else
   switch (index) {
@@ -49,9 +51,10 @@ void UtilityMenuScreen::onItemSelected(uint8_t index) {
     case 4: Screen.push(new AchievementScreen());      break;
     case 5: Screen.push(new TotpScreen());             break;
     case 6: Screen.push(new UartTerminalScreen());     break;
-    case 7: Screen.push(new PomodoroScreen());         break;
-    case 8: Screen.push(new RandomLinePickerScreen()); break;
-    case 9: Screen.push(new WikipediaScreen(true));    break;
+    case 7: Screen.push(new WifiESPNowChatScreen());   break;
+    case 8: Screen.push(new PomodoroScreen());         break;
+    case 9: Screen.push(new RandomLinePickerScreen()); break;
+    case 10: Screen.push(new WikipediaScreen(true));   break;
   }
 #endif
 }

--- a/firmware/src/screens/utility/UtilityMenuScreen.h
+++ b/firmware/src/screens/utility/UtilityMenuScreen.h
@@ -14,7 +14,7 @@ public:
 
 private:
 #ifdef DEVICE_HAS_WEBAUTHN
-  ListItem _items[11] = {
+  ListItem _items[12] = {
     {"I2C Detector"},
     {"QR Code"},
     {"Barcode"},
@@ -23,12 +23,13 @@ private:
     {"Achievements"},
     {"TOTP Auth"},
     {"UART Terminal"},
+    {"ESPNOW Chat"},
     {"Pomodoro"},
     {"Random Line Picker"},
     {"Wikipedia"},
   };
 #else
-  ListItem _items[10] = {
+  ListItem _items[11] = {
     {"I2C Detector"},
     {"QR Code"},
     {"Barcode"},
@@ -36,6 +37,7 @@ private:
     {"Achievements"},
     {"TOTP Auth"},
     {"UART Terminal"},
+    {"ESPNOW Chat"},
     {"Pomodoro"},
     {"Random Line Picker"},
     {"Wikipedia"},

--- a/firmware/src/screens/wifi/WifiAPScreen.cpp
+++ b/firmware/src/screens/wifi/WifiAPScreen.cpp
@@ -8,45 +8,17 @@
 #include "ui/actions/ShowStatusAction.h"
 #include "ui/actions/ShowQRCodeAction.h"
 #include "ui/components/QRCodeRenderer.h"
-#include "ui/actions/InputSelectAction.h"
-#include "utils/StorageUtil.h"
 #include <WiFi.h>
-
-// Static callback bridge for visit logging
-static WifiAPScreen* _activeInstance = nullptr;
-
-static void _onVisit(const char* clientIP, const char* domain)
-{
-  if (_activeInstance) {
-    char buf[60];
-    snprintf(buf, sizeof(buf), "%s > %s", clientIP, domain);
-    _activeInstance->logVisit(buf);
-  }
-}
-
-static void _onPost(const char* clientIP, const char* domain, const char* data)
-{
-  (void)clientIP;
-  (void)data;
-  if (_activeInstance) {
-    char buf[60];
-    snprintf(buf, sizeof(buf), "[+] POST %s", domain);
-    _activeInstance->logPost(buf);
-  }
-}
 
 // ── Lifecycle ──────────────────────────────────────────────────────────────
 
 void WifiAPScreen::onInit()
 {
-  _activeInstance = this;
   _showMenu();
 }
 
 void WifiAPScreen::onUpdate()
 {
-  _dnsSpoofServer.update();
-
   if (_state == STATE_LOG && millis() - _lastDraw > 500) {
     render();
     _lastDraw = millis();
@@ -150,61 +122,11 @@ void WifiAPScreen::onItemSelected(uint8_t index)
     }
     case 2: { // Hidden toggle
       _hidden = !_hidden;
-      _menuItems[2].sublabel = _hidden ? "Yes" : "No";
+      _menuItems[2].sublabel = _hidden ? "On" : "Off";
       render();
       break;
     }
-    case 3: { // DNS Spoof toggle
-      if (!_dnsSpoofEnabled) {
-        if (!Uni.Storage || !Uni.Storage->exists(DnsSpoofServer::CONFIG_PATH)) {
-          ShowStatusAction::show("dns_config not found", 1500);
-          render();
-          break;
-        }
-      }
-      _dnsSpoofEnabled = !_dnsSpoofEnabled;
-      _menuItems[3].sublabel = _dnsSpoofEnabled ? "Yes" : "No";
-      render();
-      break;
-    }
-    case 4: { // Captive Portal toggle
-      if (!_captiveEnabled) {
-        // List portal folders
-        static constexpr const char* PORTALS_DIR = "/unigeek/web/portals";
-        if (!Uni.Storage || !Uni.Storage->exists(PORTALS_DIR)) {
-          ShowStatusAction::show("No portals found", 1500);
-          render();
-          break;
-        }
-        // BrowseFileView in DIRECTORY mode — sorts folders alphabetically.
-        uint8_t n = _browser.load(this, PORTALS_DIR, BrowseFileView::Mode::DIRECTORY);
-        if (n == 0) {
-          ShowStatusAction::show("No portal folders found", 1500);
-          render();
-          break;
-        }
-        static constexpr uint8_t kMaxOpts = 10;
-        uint8_t optCount = (n < kMaxOpts) ? n : kMaxOpts;
-        InputSelectAction::Option opts[kMaxOpts];
-        for (uint8_t i = 0; i < optCount; i++) {
-          opts[i] = { _browser.entry(i).name.c_str(), _browser.entry(i).name.c_str() };
-        }
-        const char* selected = InputSelectAction::popup("Captive Portal", opts, optCount);
-        render();
-        if (!selected) break;
-        _captivePath = String(PORTALS_DIR) + "/" + selected;
-        _captiveEnabled = true;
-        _captiveSub = selected;
-      } else {
-        _captiveEnabled = false;
-        _captivePath = "";
-        _captiveSub = "No";
-      }
-      _menuItems[4].sublabel = _captiveEnabled ? _captiveSub.c_str() : "No";
-      render();
-      break;
-    }
-    case 5: { // File Manager toggle
+    case 3: { // File Manager toggle
       if (!_fileManagerEnabled) {
         String indexPath = String(SharedWebServer::FM_PATH) + "/index.htm";
         if (!Uni.Storage || !Uni.Storage->exists(indexPath.c_str())) {
@@ -214,11 +136,11 @@ void WifiAPScreen::onItemSelected(uint8_t index)
         }
       }
       _fileManagerEnabled = !_fileManagerEnabled;
-      _menuItems[5].sublabel = _fileManagerEnabled ? "Yes" : "No";
+      _menuItems[3].sublabel = _fileManagerEnabled ? "On" : "Off";
       render();
       break;
     }
-    case 6: { // Start
+    case 4: { // Start
       _startAP();
       break;
     }
@@ -231,7 +153,6 @@ void WifiAPScreen::onBack()
     _stopAP();
     return;
   }
-  _activeInstance = nullptr;
   Screen.goBack();
 }
 
@@ -242,26 +163,17 @@ void WifiAPScreen::_showMenu()
   _state       = STATE_MENU;
   _ssidSub     = Config.get(APP_CONFIG_WIFI_AP_SSID, APP_CONFIG_WIFI_AP_SSID_DEFAULT);
   String pwd   = Config.get(APP_CONFIG_WIFI_AP_PASSWORD, APP_CONFIG_WIFI_AP_PASSWORD_DEFAULT);
-  _passwordSub = pwd.isEmpty() ? "None" : pwd;
-  _captiveSub = _captiveEnabled ? _captivePath.substring(_captivePath.lastIndexOf('/') + 1) : "No";
-  _menuItems[0] = {"SSID",            _ssidSub.c_str()};
-  _menuItems[1] = {"Password",        _passwordSub.c_str()};
-  _menuItems[2] = {"Hidden",          _hidden ? "Yes" : "No"};
-  _menuItems[3] = {"DNS Spoof",       _dnsSpoofEnabled ? "Yes" : "No"};
-  _menuItems[4] = {"Captive Portal",  _captiveSub.c_str()};
-  _menuItems[5] = {"File Manager",    _fileManagerEnabled ? "Yes" : "No"};
-  _menuItems[6] = {"Start"};
-  setItems(_menuItems, 7);
+  _passwordSub = pwd.isEmpty() ? "-" : pwd;
+  _menuItems[0] = {"SSID",         _ssidSub.isEmpty() ? "-" : _ssidSub.c_str()};
+  _menuItems[1] = {"Password",     _passwordSub.c_str()};
+  _menuItems[2] = {"Hidden",       _hidden ? "On" : "Off"};
+  _menuItems[3] = {"File Manager", _fileManagerEnabled ? "On" : "Off"};
+  _menuItems[4] = {"Start"};
+  setItems(_menuItems, 5);
 }
 
 void WifiAPScreen::_startAP()
 {
-  if ((_dnsSpoofEnabled || _captiveEnabled) && !StorageUtil::hasSpace()) {
-    ShowStatusAction::show("Storage full! (<20KB free)");
-    render();
-    return;
-  }
-
   String ssid = Config.get(APP_CONFIG_WIFI_AP_SSID, APP_CONFIG_WIFI_AP_SSID_DEFAULT);
   String pwd  = Config.get(APP_CONFIG_WIFI_AP_PASSWORD, APP_CONFIG_WIFI_AP_PASSWORD_DEFAULT);
 
@@ -272,20 +184,6 @@ void WifiAPScreen::_startAP()
     IPAddress(255, 255, 255, 0)
   );
   WiFi.softAP(ssid.c_str(), pwd.c_str(), 1, _hidden);
-
-  // Start DNS Spoof if enabled (also needed for captive portal)
-  if (_dnsSpoofEnabled || _captiveEnabled) {
-    _dnsSpoofServer.setVisitCallback(_onVisit);
-    _dnsSpoofServer.setPostCallback(_onPost);
-    _dnsSpoofServer.setCaptiveIntercept(_captiveEnabled);
-    if (_captiveEnabled) {
-      _dnsSpoofServer.setCaptivePortalPath(_captivePath.c_str());
-    }
-    if (!_dnsSpoofServer.begin(WiFi.softAPIP())) {
-      _dnsSpoofEnabled = false;
-      _captiveEnabled = false;
-    }
-  }
 
   // Start File Manager if enabled
   if (_fileManagerEnabled) {
@@ -302,16 +200,11 @@ void WifiAPScreen::_startAP()
 
 void WifiAPScreen::_stopAP()
 {
-  if (_dnsSpoofEnabled || _captiveEnabled) {
-    _dnsSpoofServer.end();
-  }
   if (_fileManagerEnabled) {
     Uni.Server.disableFileManager();
   }
   WiFi.softAPdisconnect(true);
   WiFi.mode(WIFI_MODE_STA);
-  _dnsSpoofEnabled = false;
-  _captiveEnabled = false;
   _fileManagerEnabled = false;
   _log.clear();
   _lastDraw    = 0;
@@ -346,26 +239,6 @@ void WifiAPScreen::_showLog()
   snprintf(apLabel, sizeof(apLabel), "[*] AP: %s", ssid.c_str());
   _log.addLine(apLabel);
 
-  if (_dnsSpoofEnabled) {
-    _log.addLine("[*] DNS Spoof started");
-    for (int i = 0; i < _dnsSpoofServer.recordCount(); i++) {
-      char buf[60];
-      const char* path = _dnsSpoofServer.records()[i].path;
-      const char* lastSlash = strrchr(path, '/');
-      const char* pathName = lastSlash ? lastSlash + 1 : path;
-      snprintf(buf, sizeof(buf), "  %s > %s",
-               _dnsSpoofServer.records()[i].domain, pathName);
-      _log.addLine(buf);
-    }
-  }
-
-  if (_captiveEnabled) {
-    char capBuf[60];
-    const char* lastSlash = strrchr(_captivePath.c_str(), '/');
-    snprintf(capBuf, sizeof(capBuf), "[*] Captive: %s", lastSlash ? lastSlash + 1 : _captivePath.c_str());
-    _log.addLine(capBuf);
-  }
-
   if (_fileManagerEnabled) {
     char fmBuf[60];
     snprintf(fmBuf, sizeof(fmBuf), "[*] FM: unigeek.local / %s:8000",
@@ -384,18 +257,6 @@ void WifiAPScreen::_showLog()
 
 // ── Log ────────────────────────────────────────────────────────────────────
 
-void WifiAPScreen::logVisit(const char* msg)
-{
-  int nv = Achievement.inc("wifi_ap_client_visit");
-  if (nv == 1) Achievement.unlock("wifi_ap_client_visit");
-  _log.addLine(msg);
-}
-
-void WifiAPScreen::logPost(const char* msg)
-{
-  _log.addLine(msg, TFT_GREEN);
-}
-
 void WifiAPScreen::_drawLog()
 {
   auto* self = this;
@@ -404,13 +265,7 @@ void WifiAPScreen::_drawLog()
       auto* s = static_cast<WifiAPScreen*>(ud);
       sp.setTextColor(TFT_GREEN, TFT_BLACK);
       sp.setTextDatum(TL_DATUM);
-      char label[30];
-      if (s->_dnsSpoofEnabled) {
-        snprintf(label, sizeof(label), "DNS: %d", s->_dnsSpoofServer.recordCount());
-      } else {
-        snprintf(label, sizeof(label), "AP");
-      }
-      sp.drawString(label, 2, barY);
+      sp.drawString("AP", 2, barY);
       sp.setTextDatum(TR_DATUM);
       sp.drawString(WiFi.softAPIP().toString(), w - 2, barY);
     }, self);

--- a/firmware/src/screens/wifi/WifiAPScreen.h
+++ b/firmware/src/screens/wifi/WifiAPScreen.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "ui/templates/ListScreen.h"
-#include "ui/views/BrowseFileView.h"
 #include "ui/views/LogView.h"
-#include "utils/network/DnsSpoofServer.h"
 
 class WifiAPScreen : public ListScreen {
 public:
@@ -16,28 +14,16 @@ public:
   void onItemSelected(uint8_t index) override;
   void onBack() override;
 
-  void logVisit(const char* msg);
-  void logPost(const char* msg);
-
 private:
   enum State { STATE_MENU, STATE_LOG, STATE_QR };
   State _state  = STATE_MENU;
   bool  _hidden = false;
-  bool  _dnsSpoofEnabled = false;
-  bool  _captiveEnabled = false;
   bool  _fileManagerEnabled = false;
 
   String _ssidSub;
   String _passwordSub;
-  String _rogueSub;
-  String _captiveSub;
-  String _fmSub;
-  String _captivePath;
 
-  ListItem _menuItems[7];
-
-  BrowseFileView _browser;     // captive-portal folder picker
-  DnsSpoofServer _dnsSpoofServer;
+  ListItem _menuItems[5];
 
   // Log view
   LogView _log;

--- a/firmware/src/screens/wifi/WifiAnalysisDetectionMenuScreen.cpp
+++ b/firmware/src/screens/wifi/WifiAnalysisDetectionMenuScreen.cpp
@@ -1,0 +1,24 @@
+#include "WifiAnalysisDetectionMenuScreen.h"
+#include "core/ScreenManager.h"
+#include "WifiAnalyzerScreen.h"
+#include "WifiWatchdogScreen.h"
+#include "karma/WifiKarmaDetectorScreen.h"
+
+void WifiAnalysisDetectionMenuScreen::onInit() {
+  setItems(_items);
+}
+
+void WifiAnalysisDetectionMenuScreen::onItemSelected(uint8_t index) {
+  switch (index) {
+    case 0: Screen.push(new WifiAnalyzerScreen()); break;
+    case 1: Screen.push(new WifiWatchdogScreen()); break;
+    case 2: Screen.push(new WifiWatchdogScreen(WifiWatchdogScreen::InitialView::Deauth)); break;
+    case 3: Screen.push(new WifiWatchdogScreen(WifiWatchdogScreen::InitialView::Flood)); break;
+    case 4: Screen.push(new WifiWatchdogScreen(WifiWatchdogScreen::InitialView::EvilTwin)); break;
+    case 5: Screen.push(new WifiKarmaDetectorScreen()); break;
+  }
+}
+
+void WifiAnalysisDetectionMenuScreen::onBack() {
+  Screen.goBack();
+}

--- a/firmware/src/screens/wifi/WifiAnalysisDetectionMenuScreen.h
+++ b/firmware/src/screens/wifi/WifiAnalysisDetectionMenuScreen.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+
+class WifiAnalysisDetectionMenuScreen : public ListScreen
+{
+public:
+  const char* title() override { return "Analysis & Detection"; }
+
+  void onInit() override;
+  void onItemSelected(uint8_t index) override;
+  void onBack() override;
+
+private:
+  ListItem _items[6] = {
+    {"WiFi Analyzer"},
+    {"WiFi Watchdog"},
+    {"Deauth/Disassoc Detector"},
+    {"Beacon Flood Detector"},
+    {"Evil Twin Detector"},
+    {"Karma Detector"},
+  };
+};

--- a/firmware/src/screens/wifi/WifiAttacksMenuScreen.cpp
+++ b/firmware/src/screens/wifi/WifiAttacksMenuScreen.cpp
@@ -1,6 +1,6 @@
 #include "WifiAttacksMenuScreen.h"
 #include "core/ScreenManager.h"
-#include "WifiAPScreen.h"
+#include "WifiRogueAPScreen.h"
 #include "WifiEvilTwinScreen.h"
 #include "karma/WifiKarmaMenuScreen.h"
 #include "WifiDeautherScreen.h"
@@ -14,7 +14,7 @@ void WifiAttacksMenuScreen::onInit() {
 
 void WifiAttacksMenuScreen::onItemSelected(uint8_t index) {
   switch (index) {
-    case 0: Screen.push(new WifiAPScreen()); break;
+    case 0: Screen.push(new WifiRogueAPScreen()); break;
     case 1: Screen.push(new WifiEvilTwinScreen()); break;
     case 2: Screen.push(new WifiKarmaMenuScreen()); break;
     case 3: Screen.push(new WifiDeautherScreen()); break;

--- a/firmware/src/screens/wifi/WifiAttacksMenuScreen.cpp
+++ b/firmware/src/screens/wifi/WifiAttacksMenuScreen.cpp
@@ -1,0 +1,29 @@
+#include "WifiAttacksMenuScreen.h"
+#include "core/ScreenManager.h"
+#include "WifiAPScreen.h"
+#include "WifiEvilTwinScreen.h"
+#include "karma/WifiKarmaMenuScreen.h"
+#include "WifiDeautherScreen.h"
+#include "WifiBeaconAttackScreen.h"
+#include "WifiCiwZeroclickScreen.h"
+#include "WifiEapolBruteForceScreen.h"
+
+void WifiAttacksMenuScreen::onInit() {
+  setItems(_items);
+}
+
+void WifiAttacksMenuScreen::onItemSelected(uint8_t index) {
+  switch (index) {
+    case 0: Screen.push(new WifiAPScreen()); break;
+    case 1: Screen.push(new WifiEvilTwinScreen()); break;
+    case 2: Screen.push(new WifiKarmaMenuScreen()); break;
+    case 3: Screen.push(new WifiDeautherScreen()); break;
+    case 4: Screen.push(new WifiBeaconAttackScreen()); break;
+    case 5: Screen.push(new WifiCiwZeroclickScreen()); break;
+    case 6: Screen.push(new WifiEapolBruteForceScreen()); break;
+  }
+}
+
+void WifiAttacksMenuScreen::onBack() {
+  Screen.goBack();
+}

--- a/firmware/src/screens/wifi/WifiAttacksMenuScreen.h
+++ b/firmware/src/screens/wifi/WifiAttacksMenuScreen.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+
+class WifiAttacksMenuScreen : public ListScreen
+{
+public:
+  const char* title() override { return "Attacks"; }
+
+  void onInit() override;
+  void onItemSelected(uint8_t index) override;
+  void onBack() override;
+
+private:
+  ListItem _items[7] = {
+    {"Rogue Access Point"},
+    {"Evil Twin"},
+    {"Karma Attack"},
+    {"Deauth Attack"},
+    {"Beacon Attack"},
+    {"CIW Zeroclick"},
+    {"EAPOL Brute Force"},
+  };
+};

--- a/firmware/src/screens/wifi/WifiEvilTwinScreen.cpp
+++ b/firmware/src/screens/wifi/WifiEvilTwinScreen.cpp
@@ -106,22 +106,7 @@ void WifiEvilTwinScreen::onItemSelected(uint8_t index)
         setItems(_browser.items(), n);
         break;
       }
-      case 4: { // File Manager toggle
-        if (!_fmEnabled) {
-          String indexPath = String(SharedWebServer::FM_PATH) + "/index.htm";
-          if (!Uni.Storage || !Uni.Storage->exists(indexPath.c_str())) {
-            ShowStatusAction::show("Web files not installed", 1500);
-            render();
-            break;
-          }
-        }
-        _fmEnabled = !_fmEnabled;
-        _fmSub = _fmEnabled ? "On" : "Off";
-        _menuItems[4].sublabel = _fmSub.c_str();
-        render();
-        break;
-      }
-      case 5: _startAttack();   break;
+      case 4: _startAttack();   break;
     }
   } else if (_state == STATE_SELECT_PORTAL && index < _browser.count()) {
     _portal.setPortalFolder(_browser.entry(index).name);
@@ -203,15 +188,13 @@ void WifiEvilTwinScreen::_showMenu()
   _deauthSub   = _deauth ? "On" : "Off";
   _checkPwdSub = _checkPwd ? "On" : "Off";
   _portalSub   = _portal.portalFolder().isEmpty() ? "-" : _portal.portalFolder();
-  _fmSub       = _fmEnabled ? "On" : "Off";
 
   _menuItems[0] = {"Network",        _networkSub.c_str()};
   _menuItems[1] = {"Deauth",         _deauthSub.c_str()};
   _menuItems[2] = {"Check Password", _checkPwdSub.c_str()};
   _menuItems[3] = {"Portal",         _portalSub.c_str()};
-  _menuItems[4] = {"File Manager",   _fmSub.c_str()};
-  _menuItems[5] = {"Start"};
-  setItems(_menuItems, 6);
+  _menuItems[4] = {"Start"};
+  setItems(_menuItems, 5);
 }
 
 // ── WiFi Scan ───────────────────────────────────────────────────────────────
@@ -316,14 +299,6 @@ void WifiEvilTwinScreen::_startAttack()
 
   _log.addLine("AP started");
 
-  // Start file manager if enabled
-  if (_fmEnabled) {
-    if (!Uni.Server.enableFileManager()) {
-      _fmEnabled = false;
-      _log.addLine("[!] File Manager failed", TFT_RED);
-    }
-  }
-
   // Start captive portal server
   AsyncWebServer* server = _portal.start(apIP);
 
@@ -402,9 +377,6 @@ void WifiEvilTwinScreen::_startAttack()
 
 void WifiEvilTwinScreen::_stopAttack()
 {
-  if (_fmEnabled) {
-    Uni.Server.disableFileManager();
-  }
   _portal.reset();
   if (_attacker) {
     delete _attacker;

--- a/firmware/src/screens/wifi/WifiMenuScreen.cpp
+++ b/firmware/src/screens/wifi/WifiMenuScreen.cpp
@@ -9,7 +9,6 @@
 #include "WifiAnalysisDetectionMenuScreen.h"
 #include "WifiSniffersMenuScreen.h"
 #include "WifiAttacksMenuScreen.h"
-#include "WifiESPNowChatScreen.h"
 
 void WifiMenuScreen::onInit() {
   setItems(_items);
@@ -22,7 +21,6 @@ void WifiMenuScreen::onItemSelected(uint8_t index) {
     case 2: Screen.push(new WifiAnalysisDetectionMenuScreen()); break;
     case 3: Screen.push(new WifiSniffersMenuScreen());          break;
     case 4: Screen.push(new WifiAttacksMenuScreen());           break;
-    case 5: Screen.push(new WifiESPNowChatScreen());            break;
   }
 }
 

--- a/firmware/src/screens/wifi/WifiMenuScreen.cpp
+++ b/firmware/src/screens/wifi/WifiMenuScreen.cpp
@@ -4,20 +4,12 @@
 
 #include "WifiMenuScreen.h"
 #include "core/ScreenManager.h"
-#include "screens/MainMenuScreen.h"
 #include "network/NetworkMenuScreen.h"
 #include "WifiAPScreen.h"
-#include "WifiAnalyzerScreen.h"
-#include "WifiPacketMonitorScreen.h"
-#include "WifiDeautherScreen.h"
-#include "WifiWatchdogScreen.h"
-#include "WifiBeaconAttackScreen.h"
+#include "WifiAnalysisDetectionMenuScreen.h"
+#include "WifiSniffersMenuScreen.h"
+#include "WifiAttacksMenuScreen.h"
 #include "WifiESPNowChatScreen.h"
-#include "WifiEapolCaptureScreen.h"
-#include "WifiCiwZeroclickScreen.h"
-#include "WifiEapolBruteForceScreen.h"
-#include "WifiEvilTwinScreen.h"
-#include "karma/WifiKarmaMenuScreen.h"
 
 void WifiMenuScreen::onInit() {
   setItems(_items);
@@ -25,19 +17,12 @@ void WifiMenuScreen::onInit() {
 
 void WifiMenuScreen::onItemSelected(uint8_t index) {
   switch (index) {
-    case 0:  Screen.push(new NetworkMenuScreen());        break;
-    case 1:  Screen.push(new WifiAPScreen());             break;
-    case 2:  Screen.push(new WifiEvilTwinScreen());        break;
-    case 3:  Screen.push(new WifiKarmaMenuScreen());       break;
-    case 4:  Screen.push(new WifiAnalyzerScreen());        break;
-    case 5:  Screen.push(new WifiPacketMonitorScreen());   break;
-    case 6:  Screen.push(new WifiDeautherScreen());        break;
-    case 7:  Screen.push(new WifiWatchdogScreen());        break;
-    case 8:  Screen.push(new WifiBeaconAttackScreen());    break;
-    case 9:  Screen.push(new WifiCiwZeroclickScreen());    break;
-    case 10: Screen.push(new WifiESPNowChatScreen());      break;
-    case 11: Screen.push(new WifiEapolCaptureScreen());    break;
-    case 12: Screen.push(new WifiEapolBruteForceScreen()); break;
+    case 0: Screen.push(new WifiAPScreen());                    break;
+    case 1: Screen.push(new NetworkMenuScreen());               break;
+    case 2: Screen.push(new WifiAnalysisDetectionMenuScreen()); break;
+    case 3: Screen.push(new WifiSniffersMenuScreen());          break;
+    case 4: Screen.push(new WifiAttacksMenuScreen());           break;
+    case 5: Screen.push(new WifiESPNowChatScreen());            break;
   }
 }
 

--- a/firmware/src/screens/wifi/WifiMenuScreen.h
+++ b/firmware/src/screens/wifi/WifiMenuScreen.h
@@ -16,12 +16,11 @@ public:
   void onBack() override;
 
 private:
-  ListItem _items[6] = {
+  ListItem _items[5] = {
     {"Access Point"},
     {"Network"},
     {"Analysis & Detection"},
     {"Sniffers"},
     {"Attacks"},
-    {"ESPNOW Chat"},
   };
 };

--- a/firmware/src/screens/wifi/WifiMenuScreen.h
+++ b/firmware/src/screens/wifi/WifiMenuScreen.h
@@ -16,19 +16,12 @@ public:
   void onBack() override;
 
 private:
-  ListItem _items[13] = {
-    {"Network"},
+  ListItem _items[6] = {
     {"Access Point"},
-    {"Evil Twin"},
-    {"Karma Attack"},
-    {"WiFi Analyzer"},
-    {"Packet Monitor"},
-    {"WiFi Deauther"},
-    {"WiFi Watchdog"},
-    {"Beacon Attack"},
-    {"CIW Zeroclick"},
+    {"Network"},
+    {"Analysis & Detection"},
+    {"Sniffers"},
+    {"Attacks"},
     {"ESPNOW Chat"},
-    {"EAPOL Capture"},
-    {"EAPOL Brute Force"},
   };
 };

--- a/firmware/src/screens/wifi/WifiRogueAPScreen.cpp
+++ b/firmware/src/screens/wifi/WifiRogueAPScreen.cpp
@@ -1,0 +1,233 @@
+#include "WifiRogueAPScreen.h"
+#include "core/Device.h"
+#include "core/ScreenManager.h"
+#include "core/AchievementManager.h"
+#include "ui/actions/InputTextAction.h"
+#include "ui/actions/InputSelectAction.h"
+#include "ui/actions/ShowStatusAction.h"
+#include "utils/StorageUtil.h"
+#include <WiFi.h>
+
+static WifiRogueAPScreen* _activeRogueInstance = nullptr;
+
+static void _onRogueVisit(const char* clientIP, const char* domain) {
+  if (_activeRogueInstance) {
+    char buf[60];
+    snprintf(buf, sizeof(buf), "%s > %s", clientIP, domain);
+    _activeRogueInstance->logVisit(buf);
+  }
+}
+
+static void _onRoguePost(const char* clientIP, const char* domain, const char* data) {
+  (void)clientIP; (void)data;
+  if (_activeRogueInstance) {
+    char buf[60];
+    snprintf(buf, sizeof(buf), "[+] POST %s", domain);
+    _activeRogueInstance->logPost(buf);
+  }
+}
+
+void WifiRogueAPScreen::onInit() {
+  _activeRogueInstance = this;
+  _ssid = "";
+  _showMenu();
+}
+
+void WifiRogueAPScreen::onUpdate() {
+  _dnsSpoofServer.update();
+  if (_state == STATE_LOG && millis() - _lastDraw > 500) {
+    render();
+    _lastDraw = millis();
+  }
+  if (_state == STATE_MENU) {
+    ListScreen::onUpdate();
+  } else if (Uni.Nav->wasPressed()) {
+    auto dir = Uni.Nav->readDirection();
+    if (dir == INavigation::DIR_BACK || dir == INavigation::DIR_PRESS) _stopAP();
+  }
+}
+
+void WifiRogueAPScreen::onRender() {
+  if (_state == STATE_LOG) { _drawLog(); return; }
+  ListScreen::onRender();
+}
+
+void WifiRogueAPScreen::onItemSelected(uint8_t index) {
+  if (_state != STATE_MENU) return;
+  switch (index) {
+    case 0: {
+      String ssid = InputTextAction::popup("SSID", _ssid);
+      render();
+      if (InputTextAction::wasCancelled()) { render(); return; }
+      if (ssid.isEmpty()) {
+        ShowStatusAction::show("SSID is required", 1500);
+        render();
+        return;
+      }
+      if (ssid.length() > 32) {
+        ShowStatusAction::show("SSID too long (max 32)", 1500);
+        render();
+        return;
+      }
+      _ssid = ssid;
+      _showMenu();
+      break;
+    }
+    case 1: {
+      if (!_dnsSpoofEnabled && (!Uni.Storage || !Uni.Storage->exists(DnsSpoofServer::CONFIG_PATH))) {
+        ShowStatusAction::show("dns_config not found", 1500);
+        render();
+        break;
+      }
+      _dnsSpoofEnabled = !_dnsSpoofEnabled;
+      _menuItems[1].sublabel = _dnsSpoofEnabled ? "On" : "Off";
+      render();
+      break;
+    }
+    case 2: {
+      if (!_captiveEnabled) {
+        static constexpr const char* PORTALS_DIR = "/unigeek/web/portals";
+        if (!Uni.Storage || !Uni.Storage->exists(PORTALS_DIR)) {
+          ShowStatusAction::show("No portals found", 1500);
+          render();
+          break;
+        }
+        uint8_t n = _browser.load(this, PORTALS_DIR, BrowseFileView::Mode::DIRECTORY);
+        if (n == 0) {
+          ShowStatusAction::show("No portal folders found", 1500);
+          render();
+          break;
+        }
+        static constexpr uint8_t kMaxOpts = 10;
+        uint8_t optCount = (n < kMaxOpts) ? n : kMaxOpts;
+        InputSelectAction::Option opts[kMaxOpts];
+        for (uint8_t i = 0; i < optCount; i++)
+          opts[i] = {_browser.entry(i).name.c_str(), _browser.entry(i).name.c_str()};
+        const char* selected = InputSelectAction::popup("Captive Portal", opts, optCount);
+        render();
+        if (!selected) break;
+        _captivePath = String(PORTALS_DIR) + "/" + selected;
+        _captiveEnabled = true;
+        _captiveSub = selected;
+      } else {
+        _captiveEnabled = false;
+        _captivePath = "";
+        _captiveSub = "-";
+      }
+      _menuItems[2].sublabel = _captiveEnabled ? _captiveSub.c_str() : "-";
+      render();
+      break;
+    }
+    case 3: _startAP(); break;
+  }
+}
+
+void WifiRogueAPScreen::onBack() {
+  if (_state == STATE_LOG) { _stopAP(); return; }
+  _activeRogueInstance = nullptr;
+  Screen.goBack();
+}
+
+void WifiRogueAPScreen::_showMenu() {
+  _state = STATE_MENU;
+  _menuItems[0] = {"SSID", _ssid.isEmpty() ? "-" : _ssid.c_str()};
+  _menuItems[1] = {"DNS Spoof", _dnsSpoofEnabled ? "On" : "Off"};
+  _menuItems[2] = {"Captive Portal", _captiveEnabled ? _captiveSub.c_str() : "-"};
+  _menuItems[3] = {"Start"};
+  setItems(_menuItems, 4);
+}
+
+void WifiRogueAPScreen::_startAP() {
+  if (_ssid.isEmpty()) {
+    ShowStatusAction::show("SSID is required", 1500);
+    render();
+    return;
+  }
+  if ((_dnsSpoofEnabled || _captiveEnabled) && !StorageUtil::hasSpace()) {
+    ShowStatusAction::show("Storage full! (<20KB free)");
+    render();
+    return;
+  }
+  WiFi.mode(WIFI_MODE_AP);
+  WiFi.softAPConfig(IPAddress(10,0,0,1), IPAddress(10,0,0,1), IPAddress(255,255,255,0));
+  WiFi.softAP(_ssid.c_str());
+
+  if (_dnsSpoofEnabled || _captiveEnabled) {
+    _dnsSpoofServer.setVisitCallback(_onRogueVisit);
+    _dnsSpoofServer.setPostCallback(_onRoguePost);
+    _dnsSpoofServer.setCaptiveIntercept(_captiveEnabled);
+    if (_captiveEnabled) _dnsSpoofServer.setCaptivePortalPath(_captivePath.c_str());
+    if (!_dnsSpoofServer.begin(WiFi.softAPIP())) {
+      _dnsSpoofEnabled = false;
+      _captiveEnabled = false;
+    }
+  }
+  int n = Achievement.inc("wifi_ap_started");
+  if (n == 1) Achievement.unlock("wifi_ap_started");
+  _showLog();
+}
+
+void WifiRogueAPScreen::_stopAP() {
+  if (_dnsSpoofEnabled || _captiveEnabled) _dnsSpoofServer.end();
+  WiFi.softAPdisconnect(true);
+  WiFi.mode(WIFI_MODE_STA);
+  _dnsSpoofEnabled = false;
+  _captiveEnabled = false;
+  _captivePath = "";
+  _captiveSub = "-";
+  _log.clear();
+  _lastDraw = 0;
+  ShowStatusAction::show("AP Stopped", 1500);
+  _showMenu();
+}
+
+void WifiRogueAPScreen::_showLog() {
+  _state = STATE_LOG;
+  _log.clear();
+  char apLabel[60];
+  snprintf(apLabel, sizeof(apLabel), "[*] AP: %s", _ssid.c_str());
+  _log.addLine(apLabel);
+  if (_dnsSpoofEnabled) {
+    _log.addLine("[*] DNS Spoof started");
+    for (int i = 0; i < _dnsSpoofServer.recordCount(); i++) {
+      char buf[60];
+      const char* path = _dnsSpoofServer.records()[i].path;
+      const char* lastSlash = strrchr(path, '/');
+      snprintf(buf, sizeof(buf), "  %s > %s", _dnsSpoofServer.records()[i].domain, lastSlash ? lastSlash + 1 : path);
+      _log.addLine(buf);
+    }
+  }
+  if (_captiveEnabled) {
+    char buf[60];
+    const char* lastSlash = strrchr(_captivePath.c_str(), '/');
+    snprintf(buf, sizeof(buf), "[*] Captive: %s", lastSlash ? lastSlash + 1 : _captivePath.c_str());
+    _log.addLine(buf);
+  }
+  _log.addLine("");
+  _log.addLine("Waiting for clients...");
+  _drawLog();
+}
+
+void WifiRogueAPScreen::logVisit(const char* msg) {
+  int nv = Achievement.inc("wifi_ap_client_visit");
+  if (nv == 1) Achievement.unlock("wifi_ap_client_visit");
+  _log.addLine(msg);
+}
+
+void WifiRogueAPScreen::logPost(const char* msg) { _log.addLine(msg, TFT_GREEN); }
+
+void WifiRogueAPScreen::_drawLog() {
+  auto* self = this;
+  _log.draw(Uni.Lcd, bodyX(), bodyY(), bodyW(), bodyH(),
+    [](Sprite& sp, int barY, int w, void* ud) {
+      auto* s = static_cast<WifiRogueAPScreen*>(ud);
+      sp.setTextColor(TFT_GREEN, TFT_BLACK);
+      sp.setTextDatum(TL_DATUM);
+      if (s->_dnsSpoofEnabled)
+        sp.drawString((String("DNS: ") + s->_dnsSpoofServer.recordCount()).c_str(), 2, barY);
+      else
+        sp.drawString("AP", 2, barY);
+      sp.setTextDatum(TR_DATUM);
+      sp.drawString(WiFi.softAPIP().toString(), w - 2, barY);
+    }, self);
+}

--- a/firmware/src/screens/wifi/WifiRogueAPScreen.cpp
+++ b/firmware/src/screens/wifi/WifiRogueAPScreen.cpp
@@ -103,7 +103,7 @@ void WifiRogueAPScreen::onItemSelected(uint8_t index) {
         InputSelectAction::Option opts[kMaxOpts];
         for (uint8_t i = 0; i < optCount; i++)
           opts[i] = {_browser.entry(i).name.c_str(), _browser.entry(i).name.c_str()};
-        const char* selected = InputSelectAction::popup("Captive Portal", opts, optCount);
+        const char* selected = InputSelectAction::popup("Portal", opts, optCount);
         render();
         if (!selected) break;
         _captivePath = String(PORTALS_DIR) + "/" + selected;
@@ -132,7 +132,7 @@ void WifiRogueAPScreen::_showMenu() {
   _state = STATE_MENU;
   _menuItems[0] = {"SSID", _ssid.isEmpty() ? "-" : _ssid.c_str()};
   _menuItems[1] = {"DNS Spoof", _dnsSpoofEnabled ? "On" : "Off"};
-  _menuItems[2] = {"Captive Portal", _captiveEnabled ? _captiveSub.c_str() : "-"};
+  _menuItems[2] = {"Portal", _captiveEnabled ? _captiveSub.c_str() : "-"};
   _menuItems[3] = {"Start"};
   setItems(_menuItems, 4);
 }

--- a/firmware/src/screens/wifi/WifiRogueAPScreen.h
+++ b/firmware/src/screens/wifi/WifiRogueAPScreen.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+#include "ui/views/BrowseFileView.h"
+#include "ui/views/LogView.h"
+#include "utils/network/DnsSpoofServer.h"
+
+class WifiRogueAPScreen : public ListScreen {
+public:
+  const char* title() override { return "Rogue Access Point"; }
+  bool inhibitPowerOff() override { return _state != STATE_MENU; }
+
+  void onInit() override;
+  void onUpdate() override;
+  void onRender() override;
+  void onItemSelected(uint8_t index) override;
+  void onBack() override;
+  void logVisit(const char* msg);
+  void logPost(const char* msg);
+
+private:
+  enum State { STATE_MENU, STATE_LOG };
+  State _state = STATE_MENU;
+  String _ssid;
+  bool _dnsSpoofEnabled = false;
+  bool _captiveEnabled = false;
+  String _captiveSub = "Off";
+  String _captivePath;
+  ListItem _menuItems[4];
+  BrowseFileView _browser;
+  DnsSpoofServer _dnsSpoofServer;
+  LogView _log;
+  unsigned long _lastDraw = 0;
+
+  void _showMenu();
+  void _showLog();
+  void _startAP();
+  void _stopAP();
+  void _drawLog();
+};

--- a/firmware/src/screens/wifi/WifiSniffersMenuScreen.cpp
+++ b/firmware/src/screens/wifi/WifiSniffersMenuScreen.cpp
@@ -1,0 +1,21 @@
+#include "WifiSniffersMenuScreen.h"
+#include "core/ScreenManager.h"
+#include "WifiPacketMonitorScreen.h"
+#include "WifiWatchdogScreen.h"
+#include "WifiEapolCaptureScreen.h"
+
+void WifiSniffersMenuScreen::onInit() {
+  setItems(_items);
+}
+
+void WifiSniffersMenuScreen::onItemSelected(uint8_t index) {
+  switch (index) {
+    case 0: Screen.push(new WifiPacketMonitorScreen()); break;
+    case 1: Screen.push(new WifiWatchdogScreen(WifiWatchdogScreen::InitialView::Probes)); break;
+    case 2: Screen.push(new WifiEapolCaptureScreen()); break;
+  }
+}
+
+void WifiSniffersMenuScreen::onBack() {
+  Screen.goBack();
+}

--- a/firmware/src/screens/wifi/WifiSniffersMenuScreen.h
+++ b/firmware/src/screens/wifi/WifiSniffersMenuScreen.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "ui/templates/ListScreen.h"
+
+class WifiSniffersMenuScreen : public ListScreen
+{
+public:
+  const char* title() override { return "Sniffers"; }
+
+  void onInit() override;
+  void onItemSelected(uint8_t index) override;
+  void onBack() override;
+
+private:
+  ListItem _items[3] = {
+    {"Packet Monitor"},
+    {"Probe Requests"},
+    {"EAPOL Capture"},
+  };
+};

--- a/firmware/src/screens/wifi/WifiWatchdogScreen.cpp
+++ b/firmware/src/screens/wifi/WifiWatchdogScreen.cpp
@@ -1,4 +1,5 @@
 #include "WifiWatchdogScreen.h"
+#include "karma/WifiKarmaDetectorScreen.h"
 #include "core/Device.h"
 #include "core/ScreenManager.h"
 #include "core/AchievementManager.h"
@@ -84,6 +85,8 @@ void WifiWatchdogScreen::onInit()
   _beaconMap.clear();
   _twinMap.clear();
 
+  _karmaBaseline = Achievement.getInt("wifi_karma_attack_detected");
+
   WiFi.mode(WIFI_MODE_STA);
   esp_wifi_set_promiscuous(true);
   esp_wifi_set_promiscuous_rx_cb(&WifiWatchdogScreen::_promiscuousCb);
@@ -114,6 +117,22 @@ void WifiWatchdogScreen::_enterView(View view)
   _renderView();
 }
 
+void WifiWatchdogScreen::onRestore()
+{
+  WiFi.mode(WIFI_MODE_STA);
+  esp_wifi_set_promiscuous(true);
+  esp_wifi_set_promiscuous_rx_cb(&WifiWatchdogScreen::_promiscuousCb);
+
+  _view        = VIEW_OVERALL;
+  _prevGridSel = -1;
+  _holdCell    = -1;
+  for (int i = 0; i < 4; i++) _prevCounts[i] = -1;
+
+#ifdef DEVICE_HAS_TOUCH_NAV
+  Uni.Nav->setSuppressKeys(true);
+#endif
+}
+
 void WifiWatchdogScreen::onUpdate()
 {
   if (_view == VIEW_OVERALL) {
@@ -133,8 +152,14 @@ void WifiWatchdogScreen::onUpdate()
         const int col = gx / (gw / 2);
         const int row = ((int)ty - (int)bodyY()) / (bodyH() / 2);
         if (col >= 0 && col < 2 && row >= 0 && row < 2) {
-          static constexpr View kViewMap[] = {VIEW_DEAUTH, VIEW_PROBES, VIEW_FLOOD, VIEW_EVILTWIN};
-          _enterView(kViewMap[row * 2 + col]);
+          const int idx = row * 2 + col;
+          if (idx == 3) {
+            Uni.Nav->setSuppressKeys(false);
+            Screen.push(new WifiKarmaDetectorScreen());
+            return;
+          }
+          static constexpr View kViewMap[] = {VIEW_DEAUTH, VIEW_FLOOD, VIEW_EVILTWIN};
+          _enterView(kViewMap[idx]);
           return;
         }
       }
@@ -159,7 +184,11 @@ void WifiWatchdogScreen::onUpdate()
         _renderOverall();
         if (Uni.Speaker) Uni.Speaker->beep();
       } else if (dir == INavigation::DIR_PRESS) {
-        static constexpr View kViewMap[] = {VIEW_DEAUTH, VIEW_PROBES, VIEW_FLOOD, VIEW_EVILTWIN};
+        if (_gridSel == 3) {
+          Screen.push(new WifiKarmaDetectorScreen());
+          return;
+        }
+        static constexpr View kViewMap[] = {VIEW_DEAUTH, VIEW_FLOOD, VIEW_EVILTWIN};
         _enterView(kViewMap[_gridSel]);
         return;
       }
@@ -491,13 +520,14 @@ void WifiWatchdogScreen::_renderOverall()
 
   int counts[4];
   counts[0] = (int)_deauthMap.size();
-  counts[1] = (int)_probeMap.size();
-  counts[2] = 0;
+  counts[1] = 0;
   for (auto& kv : _beaconMap)
-    if (kv.second.ratePerSec >= FLOOD_THRESHOLD) counts[2]++;
-  counts[3] = 0;
+    if (kv.second.ratePerSec >= FLOOD_THRESHOLD) counts[1]++;
+  counts[2] = 0;
   for (auto& kv : _twinMap)
-    if ((int)kv.second.size() >= 2) counts[3]++;
+    if ((int)kv.second.size() >= 2) counts[2]++;
+  counts[3] = Achievement.getInt("wifi_karma_attack_detected") - _karmaBaseline;
+  if (counts[3] < 0) counts[3] = 0;
 
   const bool forceAll = (_prevGridSel < 0);
 
@@ -651,7 +681,7 @@ void WifiWatchdogScreen::_drawBackButton()
 void WifiWatchdogScreen::_drawGridCell(int idx, int count)
 {
   static constexpr const char* kNames[] = {
-    "Deauth", "Probes", "Beacon Flood", "Evil Twin"
+    "Deauth", "Beacon Flood", "Evil Twin", "Karma"
   };
 
 #ifdef DEVICE_HAS_TOUCH_NAV

--- a/firmware/src/screens/wifi/WifiWatchdogScreen.cpp
+++ b/firmware/src/screens/wifi/WifiWatchdogScreen.cpp
@@ -92,7 +92,26 @@ void WifiWatchdogScreen::onInit()
   Uni.Nav->setSuppressKeys(true);
 #endif
 
-  render();
+  if (_initialView != InitialView::None) {
+    static constexpr View kInitialViewMap[] = {
+      VIEW_DEAUTH, VIEW_PROBES, VIEW_FLOOD, VIEW_EVILTWIN
+    };
+    _enterView(kInitialViewMap[static_cast<int>(_initialView)]);
+  } else {
+    render();
+  }
+}
+
+void WifiWatchdogScreen::_enterView(View view)
+{
+#ifdef DEVICE_HAS_TOUCH_NAV
+  Uni.Nav->setSuppressKeys(false);
+#endif
+  _holdCell  = -1;
+  _view      = view;
+  _itemCount = 0;
+  _scroll.resetScroll();
+  _renderView();
 }
 
 void WifiWatchdogScreen::onUpdate()
@@ -115,12 +134,8 @@ void WifiWatchdogScreen::onUpdate()
         const int row = ((int)ty - (int)bodyY()) / (bodyH() / 2);
         if (col >= 0 && col < 2 && row >= 0 && row < 2) {
           static constexpr View kViewMap[] = {VIEW_DEAUTH, VIEW_PROBES, VIEW_FLOOD, VIEW_EVILTWIN};
-          Uni.Nav->setSuppressKeys(false);
-          _holdCell  = -1;
-          _view      = kViewMap[row * 2 + col];
-          _itemCount = 0;
-          _scroll.resetScroll();
-          _renderView();
+          _enterView(kViewMap[row * 2 + col]);
+          return;
         }
       }
 #else
@@ -145,10 +160,7 @@ void WifiWatchdogScreen::onUpdate()
         if (Uni.Speaker) Uni.Speaker->beep();
       } else if (dir == INavigation::DIR_PRESS) {
         static constexpr View kViewMap[] = {VIEW_DEAUTH, VIEW_PROBES, VIEW_FLOOD, VIEW_EVILTWIN};
-        _view      = kViewMap[_gridSel];
-        _itemCount = 0;
-        _scroll.resetScroll();
-        _renderView();
+        _enterView(kViewMap[_gridSel]);
         return;
       }
 #endif
@@ -195,6 +207,10 @@ void WifiWatchdogScreen::onUpdate()
     if (Uni.Nav->wasPressed()) {
       auto dir = Uni.Nav->readDirection();
       if (dir == INavigation::DIR_BACK || dir == INavigation::DIR_PRESS) {
+        if (_initialView != InitialView::None) {
+          onBack();
+          return;
+        }
         _view        = VIEW_OVERALL;
         _prevGridSel = -1;
 #ifdef DEVICE_HAS_TOUCH_NAV
@@ -233,14 +249,14 @@ void WifiWatchdogScreen::onRender()
   if (_itemCount > 0) {
     _scroll.render(bodyX(), bodyY(), bodyW(), bodyH());
   } else {
-    Sprite sp(&Uni.Lcd);
-    sp.createSprite(bodyW(), bodyH());
-    sp.fillSprite(TFT_BLACK);
-    sp.setTextDatum(MC_DATUM);
-    sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-    sp.drawString("Monitoring...", bodyW() / 2, bodyH() / 2);
-    sp.pushSprite(bodyX(), bodyY());
-    sp.deleteSprite();
+    Uni.Lcd.fillRect(bodyX(), bodyY(), bodyW(), bodyH(), TFT_BLACK);
+    Uni.Lcd.setTextDatum(MC_DATUM);
+    Uni.Lcd.setTextColor(TFT_DARKGREY, TFT_BLACK);
+    Uni.Lcd.drawString(
+      "Monitoring...",
+      bodyX() + bodyW() / 2,
+      bodyY() + bodyH() / 2
+    );
   }
 }
 

--- a/firmware/src/screens/wifi/WifiWatchdogScreen.h
+++ b/firmware/src/screens/wifi/WifiWatchdogScreen.h
@@ -30,6 +30,7 @@ public:
   ~WifiWatchdogScreen();
 
   void onInit() override;
+  void onRestore() override;
   void onUpdate() override;
   void onRender() override;
   void onBack();
@@ -153,6 +154,7 @@ private:
   int                 _prevGridSel      = -1;
   int                 _holdCell         = -1;
   int                 _prevCounts[4]    = {-1, -1, -1, -1};
+  int                 _karmaBaseline    = 0;
   ScrollListView      _scroll;
   ScrollListView::Row _rows[MAX_ROWS]          = {};
   char                _labels[MAX_ROWS][64]    = {};

--- a/firmware/src/screens/wifi/WifiWatchdogScreen.h
+++ b/firmware/src/screens/wifi/WifiWatchdogScreen.h
@@ -13,6 +13,17 @@
 class WifiWatchdogScreen : public BaseScreen
 {
 public:
+  enum class InitialView : int8_t {
+    None     = -1,
+    Deauth   = 0,
+    Probes   = 1,
+    Flood    = 2,
+    EvilTwin = 3
+  };
+
+  explicit WifiWatchdogScreen(InitialView initialView = InitialView::None)
+    : _initialView(initialView) {}
+
   const char* title() override;
   bool inhibitPowerOff() override { return true; }
 
@@ -133,6 +144,7 @@ private:
 
   static portMUX_TYPE    _ringLock;
 
+  InitialView         _initialView      = InitialView::None;
   View                _view             = VIEW_OVERALL;
   int                 _channel          = 1;
   unsigned long       _lastUpdate       = 0;
@@ -146,6 +158,7 @@ private:
   char                _labels[MAX_ROWS][64]    = {};
   char                _sublabels[MAX_ITEMS][64] = {};
 
+  void _enterView(View view);
   void _drainRings();
   void _updateRates();
   void _renderView();

--- a/firmware/src/screens/wifi/karma/WifiKarmaDetectorScreen.cpp
+++ b/firmware/src/screens/wifi/karma/WifiKarmaDetectorScreen.cpp
@@ -79,8 +79,8 @@ void WifiKarmaDetectorScreen::onRender()
   if (_state == STATE_SCANNING) {
     sp.setTextDatum(MC_DATUM);
     sp.setTextColor(TFT_DARKGREY, TFT_BLACK);
-    sp.drawString(_statusLine[0] ? _statusLine : "Starting...", bodyW() / 2, bodyH() / 2 - 8);
-    sp.drawString("No Karma Attacks Found", bodyW() / 2, bodyH() / 2 + 8);
+    sp.drawString("Monitoring...", bodyW() / 2, bodyH() / 2 - 8);
+    sp.drawString(_statusLine[0] ? _statusLine : "Starting...", bodyW() / 2, bodyH() / 2 + 8);
   } else {
     // Alert view
     const int cy = bodyH() / 2;

--- a/firmware/src/screens/wifi/karma/WifiKarmaMenuScreen.cpp
+++ b/firmware/src/screens/wifi/karma/WifiKarmaMenuScreen.cpp
@@ -3,7 +3,6 @@
 #include "WifiKarmaCaptiveScreen.h"
 #include "WifiKarmaEapolScreen.h"
 #include "WifiKarmaBroadcastScreen.h"
-#include "WifiKarmaDetectorScreen.h"
 #include "WifiKarmaSupportScreen.h"
 
 void WifiKarmaMenuScreen::onInit() {
@@ -15,8 +14,7 @@ void WifiKarmaMenuScreen::onItemSelected(uint8_t index) {
     case 0: Screen.push(new WifiKarmaCaptiveScreen());   break;
     case 1: Screen.push(new WifiKarmaEapolScreen());     break;
     case 2: Screen.push(new WifiKarmaBroadcastScreen()); break;
-    case 3: Screen.push(new WifiKarmaDetectorScreen());  break;
-    case 4: Screen.push(new WifiKarmaSupportScreen());   break;
+    case 3: Screen.push(new WifiKarmaSupportScreen());   break;
   }
 }
 

--- a/firmware/src/screens/wifi/karma/WifiKarmaMenuScreen.h
+++ b/firmware/src/screens/wifi/karma/WifiKarmaMenuScreen.h
@@ -14,11 +14,10 @@ public:
   void onBack() override;
 
 private:
-  ListItem _items[5] = {
+  ListItem _items[4] = {
     {"Captive Portal"},   // harvest credentials via evil portal
     {"EAPOL Handshake"},  // capture WPA handshake (+ optional support device)
     {"Active Karma"},     // probe-response + beaconing engine, modes & options
-    {"Detector"},         // defensive: spot a rogue Karma AP nearby
     {"Support Device"},   // companion role for the dual-device attack
   };
 };

--- a/firmware/src/utils/keyboard/BLEKeyboardUtil.cpp
+++ b/firmware/src/utils/keyboard/BLEKeyboardUtil.cpp
@@ -1,5 +1,4 @@
 #include "BLEKeyboardUtil.h"
-
 static constexpr uint8_t kKeyboardId = 0x01;
 static constexpr uint8_t kMouseId    = 0x02;
 static constexpr uint8_t kConsumerId = 0x03;
@@ -26,7 +25,7 @@ void BLEKeyboardUtil::begin()
     NimBLEDevice::setSecurityAuth(true, true, true);
 
     _server = NimBLEDevice::createServer();
-    _server->setCallbacks(this);
+    _server->setCallbacks(this, false);
 
     _hid = new NimBLEHIDDevice(_server);
     _inputKbd  = _hid->inputReport(kKeyboardId);


### PR DESCRIPTION
## Summary

This PR reorganizes the WiFi and Bluetooth menus to improve navigation and group related features more consistently. It also fixes a crash when leaving the BLE MouseKeyboard screen.

### WiFi

The WiFi menu is reorganized into:

* **Access Point**
* **Network**
* **Analysis & Detection**
* **Sniffers**
* **Attacks**

Main changes include:

* Separates the regular **Access Point** from **Rogue Access Point**.
* Moves detection tools into **Analysis & Detection**.
* Groups packet capture tools under **Sniffers**.
* Groups offensive WiFi tools under **Attacks**.
* Reorganizes **WiFi Watchdog**, including Karma detection.
* Keeps the existing **Network** structure intact.
* Moves **ESPNOW Chat** from WiFi to **Utility**.

### Bluetooth

The Bluetooth menu is reorganized into:

* **Analysis & Detection**

  * BLE Analyzer
  * BLE Detector
* **Attacks**

  * BLE Spam
  * WhisperPair
* **Extensions**

  * Chameleon Ultra
  * Claude Buddy
* **BLE Remote**

BLE Remote remains a direct toggle in the Bluetooth menu.

### Access Point separation

The regular **Access Point** screen is simplified to configuration appropriate for a normal AP:

* SSID
* Password
* Hidden
* File Manager
* Start

Attack-oriented functionality is moved to a dedicated **Rogue Access Point** screen:

* SSID
* DNS Spoof
* Captive Portal
* Start

### BLE MouseKeyboard crash fix

Fixes a crash/reboot that occurred when leaving the **BLE MouseKeyboard** screen.

The issue was caused by callback ownership in NimBLE. `BLEKeyboardUtil` registers itself as the `NimBLEServer` callback. With the default callback ownership behavior, the server attempted to delete that callback during `NimBLEDevice::deinit(true)`, while the same `BLEKeyboardUtil` instance was already being destroyed by `KeyboardScreen`.

The server callback is now explicitly registered as non-owning:

```cpp
_server->setCallbacks(this, false);
```

This keeps `KeyboardScreen` as the sole owner of the `BLEKeyboardUtil` instance and prevents the recursive/double deletion during BLE cleanup.

The HID menu also standardizes the **USB Remote** toggle labels to `On` / `Off`.

### Notes

This PR focuses on menu organization, separation of responsibilities between existing features, and the BLE HID cleanup fix.

It intentionally does **not** reorganize the physical source directory structure. File/folder restructuring can be handled separately to avoid unnecessary conflicts with other ongoing changes.
