### PR TITLE
Fix T-Embed SubGHz and encoder regressions

### DIFF
--- a/firmware/boards/t_embed_cc1101/config.ini
+++ b/firmware/boards/t_embed_cc1101/config.ini
@@ -8,9 +8,6 @@ build_flags =
 	-Ifirmware/boards/t_embed_cc1101
 	-O2
 	-DCORE_DEBUG_LEVEL=1
-	; FastLED reserves RMT TX channels from 0 up; keep it to one so
-	; RmtRf (SubGHz TX) can install on channel 1. See RmtRf.h.
-	-DFASTLED_RMT_MAX_CHANNELS=1
 	-DCONFIG_SPIRAM_SUPPORT=1
 
 lib_deps =

--- a/firmware/boards/t_embed_cc1101/core/Device.cpp
+++ b/firmware/boards/t_embed_cc1101/core/Device.cpp
@@ -18,7 +18,9 @@ static ExtSpiClass        sharedSpi(HSPI);
 static SpeakerEmbedCC1101 speaker;
 
 void Device::boardHook() {
-  ledRing.update();
+  // Disabled on T-Embed CC1101: FastLED conflicts with the RMT resources
+  // used by SubGHz RX/TX, causing rmt_driver_install() to fail.
+  //ledRing.update();
 
 #ifdef DEVICE_HAS_LIGHT_SLEEP
   // Global shortcut: hold the dedicated Back button for 3 seconds.
@@ -80,7 +82,9 @@ Device* Device::createInstance() {
   // Init I2C and shared SPI
   Wire.begin(GROVE_SDA, GROVE_SCL);
   sharedSpi.begin(SPI_SCK_PIN, SPI_MISO_PIN, SPI_MOSI_PIN, -1);
-  ledRing.begin();
+  // Disabled on T-Embed CC1101: FastLED conflicts with the RMT resources
+  // used by SubGHz RX/TX, causing rmt_driver_install() to fail.
+  //ledRing.begin();
 
   Device* dev = new Device(display, power, &navigation, nullptr, &sharedSpi, &speaker);
   dev->InI2C = &Wire;   // Wire already begun above on GROVE_SDA/GROVE_SCL (GPIO 8/18) —

--- a/firmware/boards/t_embed_cc1101/core/Navigation.h
+++ b/firmware/boards/t_embed_cc1101/core/Navigation.h
@@ -20,7 +20,7 @@ private:
   // and 3), so one click = DETENT_COUNTS. Carrying the remainder instead of
   // resetting means a half-detent dropped to contact bounce is recovered on the
   // next edge rather than costing the whole click ("rotate twice" symptom).
-  static constexpr int           DETENT_COUNTS   = 2;
+  static constexpr int           DETENT_COUNTS   = 1;
 
   RotaryEncoder* _encoder     = nullptr;
   int            _lastPos     = 0;

--- a/firmware/boards/t_embed_cc1101/pins_arduino.h
+++ b/firmware/boards/t_embed_cc1101/pins_arduino.h
@@ -94,7 +94,9 @@ static const uint8_t SCL = GROVE_SCL;
 #define DEVICE_HAS_VOLUME_CONTROL        // I2S amp supports setVolume()
 #define DEVICE_HAS_USB_HID               // ESP32-S3 native USB OTG
 #define DEVICE_HAS_WEBAUTHN              // FIDO2 / WebAuthn USB security key (CTAP2 + U2F)
-#define DEVICE_HAS_LED_RING              // WS2812B ring → LED Effect setting
+// Disabled on T-Embed CC1101: FastLED conflicts with the RMT resources
+// used by SubGHz RX/TX, causing rmt_driver_install() to fail.
+//#define DEVICE_HAS_LED_RING              // WS2812B ring → LED Effect setting
 #define DEVICE_HAS_LIGHT_SLEEP           // Light sleep with wake via dedicated back button
 #define DEVICE_HAS_DEEP_SLEEP            // Deep sleep with wake via dedicated back button
 #define DEVICE_HAS_POWER_OFF             // BQ25896 can power off the device


### PR DESCRIPTION
FastLED conflicts with the RMT resources used by SubGHz RX/TX. This PR contains a workaround: disable FastLED. While merging, there will be conflicts. The solution is to keep the following feature flags in pins_arduino.h:

// ─── Firmware Feature Flags ───────────────────────────────
#define DEVICE_HAS_SOUND                  // NS4168 I2S speaker
#define DEVICE_HAS_VOLUME_CONTROL         // I2S amp supports setVolume()
#define DEVICE_HAS_USB_HID                // ESP32-S3 native USB OTG
#define DEVICE_HAS_HID_VIRTUAL_KEYBOARD   // On-screen keyboard for HID relay
#define DEVICE_HAS_WEBAUTHN               // FIDO2 / WebAuthn USB security key (CTAP2 + U2F)

// Disabled on T-Embed CC1101: FastLED conflicts with the RMT resources
// used by SubGHz RX/TX, causing rmt_driver_install() to fail.
//#define DEVICE_HAS_LED_RING              // WS2812B ring → LED Effect setting

#define DEVICE_HAS_LIGHT_SLEEP            // Light sleep with wake via dedicated back button
#define DEVICE_HAS_DEEP_SLEEP             // Deep sleep with wake via dedicated back button
#define DEVICE_HAS_POWER_OFF              // BQ25896 can power off the device
#define DEVICE_HAS_CC1101_ANTENNA_SWITCH  // SW0/SW1 select the RF band filter path
#define DEVICE_HAS_PN532_POWER_CONTROL    // On-board PN532 RSTPDN can be used for hard power-down
#define DEVICE_PN532_REINIT_IN_I2C        // On-board PN532 probe requires restarting InI2C on this board
#define APP_MENU_POWER_OFF                // BQ25896 can power off the device